### PR TITLE
VEGA-1208 Use window.parent to escape iframe so cypress works

### DIFF
--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -16,12 +16,12 @@ GOVUKFrontend.Tabs.prototype.setup = () => {};
 GOVUKFrontend.initAll();
 MOJFrontend.initAll();
 
-if (window.self !== window.top) {
+if (window.self !== window.parent) {
   document.body.className += " app-!-embedded";
 
   const success = document.querySelector(".moj-banner--success");
   if (success) {
-    window.top.postMessage(
+    window.parent.postMessage(
       "form-done",
       `${window.location.protocol}//${window.location.host}`
     );
@@ -29,7 +29,7 @@ if (window.self !== window.top) {
 
   document.querySelectorAll("[data-app-iframe-cancel]").forEach((el) => {
     el.addEventListener("click", (event) => {
-      window.top.postMessage(
+      window.parent.postMessage(
         "form-cancel",
         `${window.location.protocol}//${window.location.host}`
       );

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -5,9 +5,6 @@ $moj-page-width: 1220px;
 @import "node_modules/govuk-frontend/govuk/all";
 @import "node_modules/@ministryofjustice/frontend/moj/all";
 
-.app-\!-embedded {
-  .moj-header,
-  .govuk-footer {
+.app-\!-embedded .app-\!-embedded-hide {
     display: none;
-  }
 }

--- a/web/template/layout/header.gohtml
+++ b/web/template/layout/header.gohtml
@@ -1,5 +1,5 @@
 {{ define "header" }}
-  <header class="moj-header" role="banner">
+  <header class="moj-header app-!-embedded-hide" role="banner">
     <div class="moj-header__container">
       <div class="moj-header__logo">
         <svg role="presentation" focusable="false" class="moj-header__logotype-crest" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" height="40" width="40">

--- a/web/template/layout/page.gohtml
+++ b/web/template/layout/page.gohtml
@@ -32,7 +32,7 @@
         </main>
       </div>
 
-      <footer class="govuk-footer" role="contentinfo"></footer>
+      <footer class="govuk-footer app-!-embedded-hide" role="contentinfo"></footer>
 
       <script src="{{ prefix "/javascript/all.js" }}"></script>
     </body>

--- a/web/template/warning.gohtml
+++ b/web/template/warning.gohtml
@@ -11,7 +11,7 @@
         {{ template "success-banner" "You have successfully created a warning." }}
       {{ end }}
       
-      <h1 class="govuk-heading-l">Create Warning</h1>
+      <h1 class="govuk-heading-l app-!-embedded-hide">Create Warning</h1>
 
       <form class="form" method="POST">
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>


### PR DESCRIPTION
Cypress runs tests in an iframe so `window.top` won't be the one we want to talk to