### PR TITLE
VEGA-1245 Add form to create an event

### DIFF
--- a/cypress/integration/create-event.spec.js
+++ b/cypress/integration/create-event.spec.js
@@ -1,0 +1,19 @@
+describe("Create an event", () => {
+  beforeEach(() => {
+    cy.setCookie("Other", "other");
+    cy.setCookie("XSRF-TOKEN", "abcde");
+    cy.setCookie("OPG-Bypass-Membrane", "1");
+    cy.visit("/create-event?id=800&entity=lpa");
+  });
+
+  it("creates an event", () => {
+    cy.contains("Create Event");
+    cy.contains("LPA 7000-0000-0000");
+    cy.get(".moj-banner").should("not.exist");
+    cy.get("#f-type").select("Application processing");
+    cy.get("#f-name").type("A title");
+    cy.get("#f-description").type("More words");
+    cy.get("button[type=submit]").click();
+    cy.get(".moj-banner").should("exist");
+  });
+});

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.6"
 
 services:
   app:
+    image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/sirius/sirius-lpa-frontend:latest
     build:
       context: ..
       dockerfile: ./docker/sirius-lpa-frontend/Dockerfile

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.1.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/server/event.go
+++ b/internal/server/event.go
@@ -1,0 +1,150 @@
+package server
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strconv"
+
+	"github.com/ministryofjustice/opg-go-common/template"
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"golang.org/x/sync/errgroup"
+)
+
+const Megabyte = 1024 * 1024
+
+type EventClient interface {
+	NoteTypes(ctx sirius.Context) ([]string, error)
+	CreateNote(ctx sirius.Context, entityID int, entityType, noteType, name, description string, file *sirius.NoteFile) error
+	Person(ctx sirius.Context, id int) (sirius.Person, error)
+	Case(ctx sirius.Context, id int) (sirius.Case, error)
+}
+
+type eventData struct {
+	XSRFToken string
+	NoteTypes []string
+	Entity    string
+	Success   bool
+	Errors    sirius.ValidationErrors
+
+	Type        string
+	Name        string
+	Description string
+}
+
+func Event(client EventClient, tmpl template.Template) Handler {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		entityID, err := strconv.Atoi(r.FormValue("id"))
+		if err != nil {
+			return err
+		}
+
+		entityType := r.FormValue("entity")
+		if entityType != "person" && entityType != "lpa" && entityType != "epa" {
+			return fmt.Errorf("entity must be one of 'person', 'lpa' or 'epa'")
+		}
+
+		ctx := getContext(r)
+		data := eventData{XSRFToken: ctx.XSRFToken}
+
+		group, groupCtx := errgroup.WithContext(ctx.Context)
+
+		group.Go(func() error {
+			noteTypes, err := client.NoteTypes(ctx.With(groupCtx))
+			if err != nil {
+				return err
+			}
+
+			data.NoteTypes = noteTypes
+			return nil
+		})
+
+		group.Go(func() error {
+			switch entityType {
+			case "person":
+				person, err := client.Person(ctx.With(groupCtx), entityID)
+				if err != nil {
+					return err
+				}
+				data.Entity = fmt.Sprintf("%s %s", person.Firstname, person.Surname)
+			case "lpa", "epa":
+				caseitem, err := client.Case(ctx.With(groupCtx), entityID)
+				if err != nil {
+					return err
+				}
+				data.Entity = fmt.Sprintf("%s %s", caseitem.CaseType, caseitem.UID)
+			}
+
+			return nil
+		})
+
+		if err := group.Wait(); err != nil {
+			return err
+		}
+
+		if r.Method == http.MethodPost {
+			if err := r.ParseMultipartForm(64 * Megabyte); err != nil {
+				return err
+			}
+
+			var (
+				noteType    = r.FormValue("type")
+				name        = r.FormValue("name")
+				description = r.FormValue("description")
+				file, err   = findNoteFile(r.MultipartForm, "file")
+			)
+			if err != nil {
+				return err
+			}
+
+			err = client.CreateNote(ctx, entityID, entityType, noteType, name, description, file)
+
+			if ve, ok := err.(sirius.ValidationError); ok {
+				w.WriteHeader(http.StatusBadRequest)
+				data.Errors = ve.Errors
+				data.Type = noteType
+				data.Name = name
+				data.Description = description
+			} else if err != nil {
+				return err
+			} else {
+				data.Success = true
+			}
+		}
+
+		return tmpl(w, data)
+	}
+}
+
+func findNoteFile(form *multipart.Form, key string) (*sirius.NoteFile, error) {
+	files := form.File["file"]
+	if len(files) != 1 {
+		return nil, nil
+	}
+
+	f, err := files[0].Open()
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var buf bytes.Buffer
+	enc := base64.NewEncoder(base64.StdEncoding, &buf)
+
+	if _, err := io.Copy(enc, f); err != nil {
+		return nil, err
+	}
+
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+
+	return &sirius.NoteFile{
+		Name:   files[0].Filename,
+		Type:   files[0].Header.Get("Content-Type"),
+		Source: buf.String(),
+	}, nil
+}

--- a/internal/server/event_test.go
+++ b/internal/server/event_test.go
@@ -17,7 +17,7 @@ type mockEventClient struct {
 	mock.Mock
 }
 
-func (m *mockEventClient) CreateNote(ctx sirius.Context, entityID int, entityType, noteType, name, description string, file *sirius.NoteFile) error {
+func (m *mockEventClient) CreateNote(ctx sirius.Context, entityID int, entityType sirius.EntityType, noteType, name, description string, file *sirius.NoteFile) error {
 	args := m.Called(ctx, entityID, entityType, noteType, name, description, file)
 	return args.Error(0)
 }
@@ -183,7 +183,7 @@ func TestPostEvent(t *testing.T) {
 		On("Person", mock.Anything, 123).
 		Return(sirius.Person{Firstname: "John", Surname: "Doe"}, nil)
 	client.
-		On("CreateNote", mock.Anything, 123, "person", "Application processing", "Something", "More words", (*sirius.NoteFile)(nil)).
+		On("CreateNote", mock.Anything, 123, sirius.EntityTypePerson, "Application processing", "Something", "More words", (*sirius.NoteFile)(nil)).
 		Return(nil)
 
 	template := &mockTemplate{}
@@ -222,7 +222,7 @@ func TestPostEventWithFile(t *testing.T) {
 		On("Person", mock.Anything, 123).
 		Return(sirius.Person{Firstname: "John", Surname: "Doe"}, nil)
 	client.
-		On("CreateNote", mock.Anything, 123, "person", "Application processing", "Something", "More words",
+		On("CreateNote", mock.Anything, 123, sirius.EntityTypePerson, "Application processing", "Something", "More words",
 			&sirius.NoteFile{Name: "test.txt", Type: "application/octet-stream", Source: "SGV5"}).
 		Return(nil)
 
@@ -290,7 +290,7 @@ func TestPostEventWhenCreateNoteFails(t *testing.T) {
 		On("Person", mock.Anything, 123).
 		Return(sirius.Person{Firstname: "John", Surname: "Doe"}, nil)
 	client.
-		On("CreateNote", mock.Anything, 123, "person", "Application processing", "Something", "More words", (*sirius.NoteFile)(nil)).
+		On("CreateNote", mock.Anything, 123, sirius.EntityTypePerson, "Application processing", "Something", "More words", (*sirius.NoteFile)(nil)).
 		Return(expectedError)
 
 	template := &mockTemplate{}
@@ -331,7 +331,7 @@ func TestPostEventWhenValidationError(t *testing.T) {
 		On("Person", mock.Anything, 123).
 		Return(sirius.Person{Firstname: "John", Surname: "Doe"}, nil)
 	client.
-		On("CreateNote", mock.Anything, 123, "person", "Application processing", "Something", "More words", (*sirius.NoteFile)(nil)).
+		On("CreateNote", mock.Anything, 123, sirius.EntityTypePerson, "Application processing", "Something", "More words", (*sirius.NoteFile)(nil)).
 		Return(sirius.ValidationError{Errors: expectedErrors})
 
 	template := &mockTemplate{}

--- a/internal/server/event_test.go
+++ b/internal/server/event_test.go
@@ -1,0 +1,366 @@
+package server
+
+import (
+	"bytes"
+	"errors"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockEventClient struct {
+	mock.Mock
+}
+
+func (m *mockEventClient) CreateNote(ctx sirius.Context, entityID int, entityType, noteType, name, description string, file *sirius.NoteFile) error {
+	args := m.Called(ctx, entityID, entityType, noteType, name, description, file)
+	return args.Error(0)
+}
+
+func (m *mockEventClient) NoteTypes(ctx sirius.Context) ([]string, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *mockEventClient) Person(ctx sirius.Context, id int) (sirius.Person, error) {
+	args := m.Called(ctx, id)
+	return args.Get(0).(sirius.Person), args.Error(1)
+}
+
+func (m *mockEventClient) Case(ctx sirius.Context, id int) (sirius.Case, error) {
+	args := m.Called(ctx, id)
+	return args.Get(0).(sirius.Case), args.Error(1)
+}
+
+func TestGetEvent(t *testing.T) {
+	testCases := map[string]struct {
+		url            string
+		clientSetup    func(*mockEventClient)
+		expectedEntity string
+	}{
+		"person": {
+			url: "/?id=123&entity=person",
+			clientSetup: func(client *mockEventClient) {
+				client.
+					On("Person", mock.Anything, 123).
+					Return(sirius.Person{Firstname: "John", Surname: "Doe"}, nil)
+			},
+			expectedEntity: "John Doe",
+		},
+		"lpa": {
+			url: "/?id=123&entity=lpa",
+			clientSetup: func(client *mockEventClient) {
+				client.
+					On("Case", mock.Anything, 123).
+					Return(sirius.Case{UID: "7000-0000-0001", CaseType: "LPA"}, nil)
+			},
+			expectedEntity: "LPA 7000-0000-0001",
+		},
+		"epa": {
+			url: "/?id=123&entity=epa",
+			clientSetup: func(client *mockEventClient) {
+				client.
+					On("Case", mock.Anything, 123).
+					Return(sirius.Case{UID: "7000-0000-0001", CaseType: "EPA"}, nil)
+			},
+			expectedEntity: "EPA 7000-0000-0001",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			client := &mockEventClient{}
+			client.
+				On("NoteTypes", mock.Anything).
+				Return([]string{"a", "b"}, nil)
+			tc.clientSetup(client)
+
+			template := &mockTemplate{}
+			template.
+				On("Func", mock.Anything, eventData{
+					NoteTypes: []string{"a", "b"},
+					Entity:    tc.expectedEntity,
+				}).
+				Return(nil)
+
+			r, _ := http.NewRequest(http.MethodGet, tc.url, nil)
+			w := httptest.NewRecorder()
+
+			err := Event(client, template.Func)(w, r)
+			resp := w.Result()
+
+			assert.Nil(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
+}
+
+func TestGetEventBadQueryString(t *testing.T) {
+	testCases := map[string]string{
+		"no-id":      "/?entity=person",
+		"no-entity":  "/?id=123",
+		"bad-entity": "/?id=123&entity=what",
+	}
+
+	for name, url := range testCases {
+		t.Run(name, func(t *testing.T) {
+			client := &mockEventClient{}
+			client.
+				On("NoteTypes", mock.Anything).
+				Return([]string{"a", "b"}, nil)
+
+			template := &mockTemplate{}
+			template.
+				On("Func", mock.Anything, eventData{
+					NoteTypes: []string{"a", "b"},
+				}).
+				Return(nil)
+
+			r, _ := http.NewRequest(http.MethodGet, url, nil)
+			w := httptest.NewRecorder()
+
+			err := Event(client, template.Func)(w, r)
+
+			assert.NotNil(t, err)
+		})
+	}
+}
+
+func TestGetEventWhenNoteTypeErrors(t *testing.T) {
+	expectedError := errors.New("hmm")
+
+	client := &mockEventClient{}
+	client.
+		On("NoteTypes", mock.Anything).
+		Return([]string{}, expectedError)
+	client.
+		On("Person", mock.Anything, 123).
+		Return(sirius.Person{Firstname: "John", Surname: "Doe"}, nil)
+
+	r, _ := http.NewRequest(http.MethodGet, "/?id=123&entity=person", nil)
+	w := httptest.NewRecorder()
+
+	err := Event(client, nil)(w, r)
+
+	assert.Equal(t, expectedError, err)
+}
+
+func TestGetEventWhenTemplateErrors(t *testing.T) {
+	expectedError := errors.New("hmm")
+
+	client := &mockEventClient{}
+	client.
+		On("NoteTypes", mock.Anything).
+		Return([]string{"a", "b"}, nil)
+	client.
+		On("Person", mock.Anything, 123).
+		Return(sirius.Person{Firstname: "John", Surname: "Doe"}, nil)
+
+	template := &mockTemplate{}
+	template.
+		On("Func", mock.Anything, mock.Anything).
+		Return(expectedError)
+
+	r, _ := http.NewRequest(http.MethodGet, "/?id=123&entity=person", nil)
+	w := httptest.NewRecorder()
+
+	err := Event(client, template.Func)(w, r)
+
+	assert.Equal(t, expectedError, err)
+}
+
+func TestPostEvent(t *testing.T) {
+	client := &mockEventClient{}
+	client.
+		On("NoteTypes", mock.Anything).
+		Return([]string{"a", "b"}, nil)
+	client.
+		On("Person", mock.Anything, 123).
+		Return(sirius.Person{Firstname: "John", Surname: "Doe"}, nil)
+	client.
+		On("CreateNote", mock.Anything, 123, "person", "Application processing", "Something", "More words", (*sirius.NoteFile)(nil)).
+		Return(nil)
+
+	template := &mockTemplate{}
+	template.
+		On("Func", mock.Anything, eventData{
+			Success:   true,
+			NoteTypes: []string{"a", "b"},
+			Entity:    "John Doe",
+		}).
+		Return(nil)
+
+	var buf bytes.Buffer
+	form := multipart.NewWriter(&buf)
+	_ = form.WriteField("type", "Application processing")
+	_ = form.WriteField("name", "Something")
+	_ = form.WriteField("description", "More words")
+	_ = form.Close()
+
+	r, _ := http.NewRequest(http.MethodPost, "/?id=123&entity=person", &buf)
+	r.Header.Add("Content-Type", form.FormDataContentType())
+	w := httptest.NewRecorder()
+
+	err := Event(client, template.Func)(w, r)
+	resp := w.Result()
+
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestPostEventWithFile(t *testing.T) {
+	client := &mockEventClient{}
+	client.
+		On("NoteTypes", mock.Anything).
+		Return([]string{"a", "b"}, nil)
+	client.
+		On("Person", mock.Anything, 123).
+		Return(sirius.Person{Firstname: "John", Surname: "Doe"}, nil)
+	client.
+		On("CreateNote", mock.Anything, 123, "person", "Application processing", "Something", "More words",
+			&sirius.NoteFile{Name: "test.txt", Type: "application/octet-stream", Source: "SGV5"}).
+		Return(nil)
+
+	template := &mockTemplate{}
+	template.
+		On("Func", mock.Anything, eventData{
+			Success:   true,
+			NoteTypes: []string{"a", "b"},
+			Entity:    "John Doe",
+		}).
+		Return(nil)
+
+	var buf bytes.Buffer
+	form := multipart.NewWriter(&buf)
+	_ = form.WriteField("type", "Application processing")
+	_ = form.WriteField("name", "Something")
+	_ = form.WriteField("description", "More words")
+	part, _ := form.CreateFormFile("file", "test.txt")
+	_, _ = part.Write([]byte("Hey"))
+	_ = form.Close()
+
+	r, _ := http.NewRequest(http.MethodPost, "/?id=123&entity=person", &buf)
+	r.Header.Add("Content-Type", form.FormDataContentType())
+	w := httptest.NewRecorder()
+
+	err := Event(client, template.Func)(w, r)
+	resp := w.Result()
+
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestPostEventWithBadForm(t *testing.T) {
+	client := &mockEventClient{}
+	client.
+		On("NoteTypes", mock.Anything).
+		Return([]string{"a", "b"}, nil)
+	client.
+		On("Person", mock.Anything, 123).
+		Return(sirius.Person{Firstname: "John", Surname: "Doe"}, nil)
+
+	var buf bytes.Buffer
+	form := multipart.NewWriter(&buf)
+	_ = form.WriteField("type", "Application processing")
+	_ = form.WriteField("name", "Something")
+	_ = form.WriteField("description", "More words")
+	_ = form.Close()
+
+	r, _ := http.NewRequest(http.MethodPost, "/?id=123&entity=person", &buf)
+	w := httptest.NewRecorder()
+
+	err := Event(client, nil)(w, r)
+
+	assert.NotNil(t, err)
+}
+
+func TestPostEventWhenCreateNoteFails(t *testing.T) {
+	expectedError := errors.New("hmm")
+
+	client := &mockEventClient{}
+	client.
+		On("NoteTypes", mock.Anything).
+		Return([]string{"a", "b"}, nil)
+	client.
+		On("Person", mock.Anything, 123).
+		Return(sirius.Person{Firstname: "John", Surname: "Doe"}, nil)
+	client.
+		On("CreateNote", mock.Anything, 123, "person", "Application processing", "Something", "More words", (*sirius.NoteFile)(nil)).
+		Return(expectedError)
+
+	template := &mockTemplate{}
+	template.
+		On("Func", mock.Anything, eventData{
+			Success:   true,
+			NoteTypes: []string{"a", "b"},
+			Entity:    "John Doe",
+		}).
+		Return(nil)
+
+	var buf bytes.Buffer
+	form := multipart.NewWriter(&buf)
+	_ = form.WriteField("type", "Application processing")
+	_ = form.WriteField("name", "Something")
+	_ = form.WriteField("description", "More words")
+	_ = form.Close()
+
+	r, _ := http.NewRequest(http.MethodPost, "/?id=123&entity=person", &buf)
+	r.Header.Add("Content-Type", form.FormDataContentType())
+	w := httptest.NewRecorder()
+
+	err := Event(client, template.Func)(w, r)
+
+	assert.Equal(t, expectedError, err)
+}
+
+func TestPostEventWhenValidationError(t *testing.T) {
+	expectedErrors := sirius.ValidationErrors{
+		"field": {"reason": "Description"},
+	}
+
+	client := &mockEventClient{}
+	client.
+		On("NoteTypes", mock.Anything).
+		Return([]string{"a", "b"}, nil)
+	client.
+		On("Person", mock.Anything, 123).
+		Return(sirius.Person{Firstname: "John", Surname: "Doe"}, nil)
+	client.
+		On("CreateNote", mock.Anything, 123, "person", "Application processing", "Something", "More words", (*sirius.NoteFile)(nil)).
+		Return(sirius.ValidationError{Errors: expectedErrors})
+
+	template := &mockTemplate{}
+	template.
+		On("Func", mock.Anything, eventData{
+			Success:     false,
+			NoteTypes:   []string{"a", "b"},
+			Errors:      expectedErrors,
+			Entity:      "John Doe",
+			Type:        "Application processing",
+			Name:        "Something",
+			Description: "More words",
+		}).
+		Return(nil)
+
+	var buf bytes.Buffer
+	form := multipart.NewWriter(&buf)
+	_ = form.WriteField("type", "Application processing")
+	_ = form.WriteField("name", "Something")
+	_ = form.WriteField("description", "More words")
+	_ = form.Close()
+
+	r, _ := http.NewRequest(http.MethodPost, "/?id=123&entity=person", &buf)
+	r.Header.Add("Content-Type", form.FormDataContentType())
+	w := httptest.NewRecorder()
+
+	err := Event(client, template.Func)(w, r)
+	resp := w.Result()
+
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,6 +37,7 @@ func getContext(r *http.Request) sirius.Context {
 }
 
 type Client interface {
+	EventClient
 	WarningClient
 }
 
@@ -48,6 +49,7 @@ func New(logger Logger, client Client, templates template.Templates, prefix, sir
 	mux.Handle("/", http.NotFoundHandler())
 	mux.HandleFunc("/health-check", func(w http.ResponseWriter, r *http.Request) {})
 	mux.Handle("/create-warning", wrap(Warning(client, templates.Get("warning.gohtml"))))
+	mux.Handle("/create-event", wrap(Event(client, templates.Get("event.gohtml"))))
 
 	static := http.FileServer(http.Dir("web/static"))
 	mux.Handle("/assets/", static)

--- a/internal/sirius/case.go
+++ b/internal/sirius/case.go
@@ -1,0 +1,37 @@
+package sirius
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type Case struct {
+	UID      string `json:"uId"`
+	CaseType string `json:"caseType"`
+}
+
+func (c *Client) Case(ctx Context, id int) (Case, error) {
+	var v Case
+
+	req, err := c.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/cases/%d", id), nil)
+	if err != nil {
+		return v, err
+	}
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return v, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return v, newStatusError(res)
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
+		return v, err
+	}
+
+	return v, nil
+}

--- a/internal/sirius/case_test.go
+++ b/internal/sirius/case_test.go
@@ -9,39 +9,39 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateWarning(t *testing.T) {
+func TestCase(t *testing.T) {
 	pact := newPact()
 	defer pact.Teardown()
 
 	testCases := []struct {
-		name          string
-		setup         func()
-		cookies       []*http.Cookie
-		expectedError func(int) error
+		name             string
+		setup            func()
+		cookies          []*http.Cookie
+		expectedResponse Case
+		expectedError    func(int) error
 	}{
 		{
 			name: "OK",
 			setup: func() {
 				pact.
 					AddInteraction().
-					Given("A donor exists").
-					UponReceiving("A request to create a warning").
+					Given("I have a pending case assigned").
+					UponReceiving("A request for the case").
 					WithRequest(dsl.Request{
-						Method: http.MethodPost,
-						Path:   dsl.String("/api/v1/persons/189/warnings"),
-						Body: dsl.Like(map[string]interface{}{
-							"warningType": "Complaint Received",
-							"warningText": "Some warning notes",
-						}),
+						Method: http.MethodGet,
+						Path:   dsl.String("/api/v1/cases/800"),
 						Headers: dsl.MapMatcher{
 							"X-XSRF-TOKEN":        dsl.String("abcde"),
 							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
 							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
 						},
 					}).
 					WillRespondWith(dsl.Response{
-						Status:  http.StatusCreated,
+						Status: http.StatusOK,
+						Body: dsl.Like(map[string]interface{}{
+							"uId":      dsl.String("7000-0000-0000"),
+							"caseType": dsl.String("LPA"),
+						}),
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
@@ -49,17 +49,18 @@ func TestCreateWarning(t *testing.T) {
 				{Name: "XSRF-TOKEN", Value: "abcde"},
 				{Name: "Other", Value: "other"},
 			},
+			expectedResponse: Case{UID: "7000-0000-0000", CaseType: "LPA"},
 		},
 		{
 			name: "Unauthorized",
 			setup: func() {
 				pact.
 					AddInteraction().
-					Given("A donor exists").
-					UponReceiving("A request to create a warning without cookies").
+					Given("I have a pending case assigned").
+					UponReceiving("A request for the case without cookies").
 					WithRequest(dsl.Request{
-						Method: http.MethodPost,
-						Path:   dsl.String("/api/v1/persons/189/warnings"),
+						Method: http.MethodGet,
+						Path:   dsl.String("/api/v1/cases/800"),
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusUnauthorized,
@@ -68,8 +69,8 @@ func TestCreateWarning(t *testing.T) {
 			expectedError: func(port int) error {
 				return StatusError{
 					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/api/v1/persons/189/warnings", port),
-					Method: http.MethodPost,
+					URL:    fmt.Sprintf("http://localhost:%d/api/v1/cases/800", port),
+					Method: http.MethodGet,
 				}
 			},
 		},
@@ -82,8 +83,10 @@ func TestCreateWarning(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.CreateWarning(getContext(tc.cookies), 189, "Complaint Received", "Some warning notes")
-				if (tc.expectedError) == nil {
+				caseitem, err := client.Case(getContext(tc.cookies), 800)
+
+				assert.Equal(t, tc.expectedResponse, caseitem)
+				if tc.expectedError == nil {
 					assert.Nil(t, err)
 				} else {
 					assert.Equal(t, tc.expectedError(pact.Server.Port), err)

--- a/internal/sirius/client.go
+++ b/internal/sirius/client.go
@@ -13,6 +13,14 @@ type Context struct {
 	XSRFToken string
 }
 
+func (ctx Context) With(c context.Context) Context {
+	return Context{
+		Context:   c,
+		Cookies:   ctx.Cookies,
+		XSRFToken: ctx.XSRFToken,
+	}
+}
+
 func NewClient(httpClient *http.Client, baseURL string) *Client {
 	return &Client{
 		http:    httpClient,

--- a/internal/sirius/client_test.go
+++ b/internal/sirius/client_test.go
@@ -5,8 +5,20 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/pact-foundation/pact-go/dsl"
 	"github.com/stretchr/testify/assert"
 )
+
+func newPact() *dsl.Pact {
+	return &dsl.Pact{
+		Consumer:          "sirius-lpa-frontend",
+		Provider:          "sirius",
+		Host:              "localhost",
+		PactFileWriteMode: "merge",
+		LogDir:            "../../logs",
+		PactDir:           "../../pacts",
+	}
+}
 
 func getContext(cookies []*http.Cookie) Context {
 	return Context{

--- a/internal/sirius/create_note.go
+++ b/internal/sirius/create_note.go
@@ -3,6 +3,7 @@ package sirius
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -13,6 +14,27 @@ type NoteFile struct {
 	Type   string `json:"type"`
 }
 
+type EntityType string
+
+const (
+	EntityTypeLpa    = EntityType("lpa")
+	EntityTypeEpa    = EntityType("epa")
+	EntityTypePerson = EntityType("person")
+)
+
+func ParseEntityType(s string) (EntityType, error) {
+	switch s {
+	case "lpa":
+		return EntityTypeLpa, nil
+	case "epa":
+		return EntityTypeEpa, nil
+	case "person":
+		return EntityTypePerson, nil
+	}
+
+	return EntityType(""), errors.New("could not parse entity type")
+}
+
 type noteRequest struct {
 	Name        string    `json:"name"`
 	Description string    `json:"description"`
@@ -20,7 +42,7 @@ type noteRequest struct {
 	File        *NoteFile `json:"file,omitempty"`
 }
 
-func (c *Client) CreateNote(ctx Context, entityID int, entityType, noteType, name, description string, file *NoteFile) error {
+func (c *Client) CreateNote(ctx Context, entityID int, entityType EntityType, noteType, name, description string, file *NoteFile) error {
 	data, err := json.Marshal(noteRequest{
 		Name:        name,
 		Description: description,

--- a/internal/sirius/create_note.go
+++ b/internal/sirius/create_note.go
@@ -1,0 +1,58 @@
+package sirius
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type NoteFile struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	Type   string `json:"type"`
+}
+
+type noteRequest struct {
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	Type        string    `json:"type"`
+	File        *NoteFile `json:"file,omitempty"`
+}
+
+func (c *Client) CreateNote(ctx Context, entityID int, entityType, noteType, name, description string, file *NoteFile) error {
+	data, err := json.Marshal(noteRequest{
+		Name:        name,
+		Description: description,
+		Type:        noteType,
+		File:        file,
+	})
+	if err != nil {
+		return err
+	}
+
+	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("/api/v1/%ss/%d/notes", entityType, entityID), bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusBadRequest {
+		var v ValidationError
+		if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
+			return err
+		}
+		return v
+	}
+
+	if res.StatusCode != http.StatusCreated {
+		return newStatusError(res)
+	}
+
+	return nil
+}

--- a/internal/sirius/create_note_test.go
+++ b/internal/sirius/create_note_test.go
@@ -1,0 +1,139 @@
+package sirius
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/pact-foundation/pact-go/dsl"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateNote(t *testing.T) {
+	pact := newPact()
+	defer pact.Teardown()
+
+	testCases := []struct {
+		name          string
+		setup         func()
+		cookies       []*http.Cookie
+		expectedError func(int) error
+		file          *NoteFile
+	}{
+		{
+			name: "OK",
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("I have a pending case assigned").
+					UponReceiving("A request to create a note").
+					WithRequest(dsl.Request{
+						Method: http.MethodPost,
+						Path:   dsl.String("/api/v1/lpas/800/notes"),
+						Body: dsl.Like(map[string]interface{}{
+							"name":        "Something",
+							"description": "More words",
+							"type":        "Application processing",
+						}),
+						Headers: dsl.MapMatcher{
+							"X-XSRF-TOKEN":        dsl.String("abcde"),
+							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
+							"OPG-Bypass-Membrane": dsl.String("1"),
+							"Content-Type":        dsl.String("application/json"),
+						},
+					}).
+					WillRespondWith(dsl.Response{
+						Status:  http.StatusCreated,
+						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+					})
+			},
+			cookies: []*http.Cookie{
+				{Name: "XSRF-TOKEN", Value: "abcde"},
+				{Name: "Other", Value: "other"},
+			},
+		},
+		{
+			name: "OK with file",
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("I have a pending case assigned").
+					UponReceiving("A request to create a note with a file").
+					WithRequest(dsl.Request{
+						Method: http.MethodPost,
+						Path:   dsl.String("/api/v1/lpas/800/notes"),
+						Body: dsl.Like(map[string]interface{}{
+							"name":        "Something",
+							"description": "More words",
+							"type":        "Application processing",
+							"file": dsl.Like(map[string]interface{}{
+								"name":   "words.txt",
+								"type":   "plain/text",
+								"source": "SGVsbG8gdGhlcmUK",
+							}),
+						}),
+						Headers: dsl.MapMatcher{
+							"X-XSRF-TOKEN":        dsl.String("abcde"),
+							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
+							"OPG-Bypass-Membrane": dsl.String("1"),
+							"Content-Type":        dsl.String("application/json"),
+						},
+					}).
+					WillRespondWith(dsl.Response{
+						Status:  http.StatusCreated,
+						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+					})
+			},
+			cookies: []*http.Cookie{
+				{Name: "XSRF-TOKEN", Value: "abcde"},
+				{Name: "Other", Value: "other"},
+			},
+			file: &NoteFile{
+				Name:   "words.txt",
+				Type:   "plain/text",
+				Source: "SGVsbG8gdGhlcmUK",
+			},
+		},
+		{
+			name: "Unauthorized",
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("I have a pending case assigned").
+					UponReceiving("A request to create a note without cookies").
+					WithRequest(dsl.Request{
+						Method: http.MethodPost,
+						Path:   dsl.String("/api/v1/lpas/800/notes"),
+					}).
+					WillRespondWith(dsl.Response{
+						Status: http.StatusUnauthorized,
+					})
+			},
+			expectedError: func(port int) error {
+				return StatusError{
+					Code:   http.StatusUnauthorized,
+					URL:    fmt.Sprintf("http://localhost:%d/api/v1/lpas/800/notes", port),
+					Method: http.MethodPost,
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+
+			assert.Nil(t, pact.Verify(func() error {
+				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
+
+				err := client.CreateNote(getContext(tc.cookies), 800, "lpa", "Application processing", "Something", "More words", tc.file)
+				if (tc.expectedError) == nil {
+					assert.Nil(t, err)
+				} else {
+					assert.Equal(t, tc.expectedError(pact.Server.Port), err)
+				}
+				return nil
+			}))
+		})
+	}
+}

--- a/internal/sirius/note_types.go
+++ b/internal/sirius/note_types.go
@@ -1,0 +1,30 @@
+package sirius
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func (c *Client) NoteTypes(ctx Context) ([]string, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, "/api/v1/note-types/lpa", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, newStatusError(res)
+	}
+
+	var v []string
+	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}

--- a/internal/sirius/note_types_test.go
+++ b/internal/sirius/note_types_test.go
@@ -9,39 +9,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateWarning(t *testing.T) {
+func TestNoteTypes(t *testing.T) {
 	pact := newPact()
 	defer pact.Teardown()
 
 	testCases := []struct {
-		name          string
-		setup         func()
-		cookies       []*http.Cookie
-		expectedError func(int) error
+		name             string
+		setup            func()
+		cookies          []*http.Cookie
+		expectedResponse []string
+		expectedError    func(int) error
 	}{
 		{
 			name: "OK",
 			setup: func() {
 				pact.
 					AddInteraction().
-					Given("A donor exists").
-					UponReceiving("A request to create a warning").
+					Given("Some note types exist").
+					UponReceiving("A request for note types").
 					WithRequest(dsl.Request{
-						Method: http.MethodPost,
-						Path:   dsl.String("/api/v1/persons/189/warnings"),
-						Body: dsl.Like(map[string]interface{}{
-							"warningType": "Complaint Received",
-							"warningText": "Some warning notes",
-						}),
+						Method: http.MethodGet,
+						Path:   dsl.String("/api/v1/note-types/lpa"),
 						Headers: dsl.MapMatcher{
 							"X-XSRF-TOKEN":        dsl.String("abcde"),
 							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
 							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
 						},
 					}).
 					WillRespondWith(dsl.Response{
-						Status:  http.StatusCreated,
+						Status:  http.StatusOK,
+						Body:    dsl.EachLike(dsl.String("Application processing"), 1),
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
@@ -49,17 +46,18 @@ func TestCreateWarning(t *testing.T) {
 				{Name: "XSRF-TOKEN", Value: "abcde"},
 				{Name: "Other", Value: "other"},
 			},
+			expectedResponse: []string{"Application processing"},
 		},
 		{
 			name: "Unauthorized",
 			setup: func() {
 				pact.
 					AddInteraction().
-					Given("A donor exists").
-					UponReceiving("A request to create a warning without cookies").
+					Given("Some note types exist").
+					UponReceiving("A request for note types without cookies").
 					WithRequest(dsl.Request{
-						Method: http.MethodPost,
-						Path:   dsl.String("/api/v1/persons/189/warnings"),
+						Method: http.MethodGet,
+						Path:   dsl.String("/api/v1/note-types/lpa"),
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusUnauthorized,
@@ -68,8 +66,8 @@ func TestCreateWarning(t *testing.T) {
 			expectedError: func(port int) error {
 				return StatusError{
 					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/api/v1/persons/189/warnings", port),
-					Method: http.MethodPost,
+					URL:    fmt.Sprintf("http://localhost:%d/api/v1/note-types/lpa", port),
+					Method: http.MethodGet,
 				}
 			},
 		},
@@ -82,8 +80,10 @@ func TestCreateWarning(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.CreateWarning(getContext(tc.cookies), 189, "Complaint Received", "Some warning notes")
-				if (tc.expectedError) == nil {
+				types, err := client.NoteTypes(getContext(tc.cookies))
+
+				assert.Equal(t, tc.expectedResponse, types)
+				if tc.expectedError == nil {
 					assert.Nil(t, err)
 				} else {
 					assert.Equal(t, tc.expectedError(pact.Server.Port), err)
@@ -92,4 +92,5 @@ func TestCreateWarning(t *testing.T) {
 			}))
 		})
 	}
+
 }

--- a/internal/sirius/person.go
+++ b/internal/sirius/person.go
@@ -1,0 +1,37 @@
+package sirius
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type Person struct {
+	Firstname string `json:"firstname"`
+	Surname   string `json:"surname"`
+}
+
+func (c *Client) Person(ctx Context, id int) (Person, error) {
+	var v Person
+
+	req, err := c.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/persons/%d", id), nil)
+	if err != nil {
+		return v, err
+	}
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return v, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return v, newStatusError(res)
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
+		return v, err
+	}
+
+	return v, nil
+}

--- a/internal/sirius/warning_types_test.go
+++ b/internal/sirius/warning_types_test.go
@@ -10,15 +10,7 @@ import (
 )
 
 func TestWarningTypes(t *testing.T) {
-	pact := &dsl.Pact{
-		Consumer:          "sirius-lpa-frontend",
-		Provider:          "sirius",
-		Host:              "localhost",
-		PactFileWriteMode: "merge",
-		LogDir:            "../../logs",
-		PactDir:           "../../pacts",
-	}
-
+	pact := newPact()
 	defer pact.Teardown()
 
 	testCases := []struct {

--- a/web/template/event.gohtml
+++ b/web/template/event.gohtml
@@ -1,0 +1,75 @@
+{{ template "page" . }}
+
+{{ define "title" }}{{ if .Errors }}Error: {{ end }}Create Event{{ end }}
+
+{{ define "main" }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body"><strong>{{ .Entity }}</strong></p>
+
+      {{ template "error-summary" .Errors }}
+
+      {{ if .Success }}
+        {{ template "success-banner" "You have successfully created an event." }}
+      {{ end }}
+
+      <h1 class="govuk-heading-l app-!-embedded-hide">Create Event</h1>
+
+      <form class="form" enctype="multipart/form-data" method="POST">
+        <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
+
+        <div class="govuk-form-group {{ if .Errors.type }}govuk-form-group--error{{ end }}">
+          <label class="govuk-label" for="f-type">
+            Event type
+          </label>
+          {{ range .Errors.type }}
+            <p class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> {{ . }}
+            </p>
+          {{ end }}
+          <select class="govuk-select {{ if .Errors.type }}govuk-select--error{{ end }}" id="f-type" name="type">
+            <option hidden {{ if eq "" .Type }}selected{{ end }} disabled></option>
+            {{ range .NoteTypes }}
+              <option value="{{ . }}" {{ if eq . $.Type }}selected{{ end }} >{{ . }}</option>
+            {{ end }}
+          </select>
+        </div>
+
+        <div class="govuk-form-group {{ if .Errors.name }}govuk-form-group--error{{ end }}">
+          <label class="govuk-label" for="f-name">Subject</label>
+          {{ range .Errors.name }}
+            <p class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> {{ . }}
+            </p>
+          {{ end }}
+          <input class="govuk-input {{ if .Errors.name }}govuk-input--error{{ end }}" id="f-name" name="name" value="{{ .Name }}" />
+        </div>
+
+        <div class="govuk-form-group {{ if .Errors.description }}govuk-form-group--error{{ end }}">
+          <label class="govuk-label" for="f-description">Notes</label>
+          {{ range .Errors.description }}
+            <p class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> {{ . }}
+            </p>
+          {{ end }}
+          <textarea class="govuk-textarea {{ if .Errors.description }}govuk-textarea--error{{ end }}" id="f-description" name="description">{{ .Description }}</textarea>
+        </div>
+
+        <div class="govuk-form-group {{ if .Errors.file  }}govuk-form-group--error{{ end }}">
+          <label class="govuk-label" for="f-file">File upload</label>
+          {{ range .Errors.file }}
+            <p class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> {{ . }}
+            </p>
+          {{ end }}
+          <input class="govuk-file-upload {{ if .Errors.file }}govuk-file-upload--error{{ end }}" type="file" name="file" id="f-file" />
+        </div>
+
+        <div class="govuk-button-group">
+          <button class="govuk-button" data-module="govuk-button" type="submit">Save and exit</button>
+          <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+{{ end }}


### PR DESCRIPTION
Because we switch between using the words "event" and "note" I've tried to stick to using "note" in `internal/sirius`, because that matches the API, and "event" everywhere else.