### PR TITLE
Reduce font size for embedded forms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.1.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
+golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -51,6 +51,7 @@ if (selectUser) {
 }
 
 if (window.self !== window.parent) {
+  document.documentElement.className += " app-!-html-class--embedded";
   document.body.className += " app-!-embedded";
 
   const success = document.querySelector(".moj-banner--success");

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -10,6 +10,10 @@ $moj-page-width: 1220px;
   display: none;
 }
 
+.app-\!-html-class--embedded {
+  font-size: 0.875em;
+}
+
 .autocomplete__wrapper {
   font-family: $govuk-font-family;
 }

--- a/web/template/layout/page.gohtml
+++ b/web/template/layout/page.gohtml
@@ -16,7 +16,7 @@
       <link rel="apple-touch-icon" sizes="152x152" href="{{ prefix "/assets/images/govuk-apple-touch-icon-152x152.png" }}">
       <link rel="apple-touch-icon" href="{{ prefix "/assets/images/govuk-apple-touch-icon.png" }}">
 
-      <link href="{{ prefix "/stylesheets/all.css?v1" }}" rel="stylesheet">
+      <link href="{{ prefixAsset "/stylesheets/all.css" }}" rel="stylesheet">
     </head>
 
     <body class="govuk-template__body app-body-class" data-prefix="{{ prefix "" }}">
@@ -34,7 +34,7 @@
 
       <footer class="govuk-footer app-!-embedded-hide" role="contentinfo"></footer>
 
-      <script src="{{ prefix "/javascript/all.js?v1" }}"></script>
+      <script src="{{ prefixAsset "/javascript/all.js" }}"></script>
     </body>
   </html>
 {{ end }}


### PR DESCRIPTION
Reduces the base font size by the same factor as Sirius themes so that the text embedded forms isn't larger than the rest of the page.

This has to be applied to the `<html>` element so that it's properly cascaded to all other elements.

Also introduces a proper cache-busting query string based on the sha sum of the contents of `./web/static`

Fixes VEGA-1278 and VEGA-1276 #minor