### PR TITLE
Don't run SonarQube for dependabot PRs #patch

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     name: SonarQube
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
As an external collaborator, dependabot doesn't have access to the necessary secrets to run SonarQube