### PR TITLE
Add dark mode design

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "build": "yarn build:js && yarn build:css && yarn build:images",
-    "build:js": "esbuild --bundle web/assets/main.js --minify --outfile=web/static/javascript/all.js --sourcemap",
+    "build:js": "esbuild --bundle web/assets/load-classes.js web/assets/main.js --minify --outdir=web/static/javascript --sourcemap",
     "build:css": "sass --load-path . --style compressed web/assets/main.scss web/static/stylesheets/all.css",
     "build:images": "mkdir -p web/static/assets/images && cp node_modules/govuk-frontend/govuk/assets/images/* node_modules/@ministryofjustice/frontend/moj/assets/images/* web/static/assets/images",
     "clean": "rm -rf web/static",

--- a/web/assets/dark.scss
+++ b/web/assets/dark.scss
@@ -60,4 +60,18 @@ $sirius-bg-color: #29292e;
     background-color: $sirius-bg-color;
     color: govuk-colour("white");
   }
+
+  .autocomplete__menu {
+    background-color: $sirius-bg-color;
+    color: govuk-colour("white");
+  }
+
+  .autocomplete__option--odd {
+    background-color: govuk-colour("black");
+  }
+
+  .autocomplete__option--focused,
+  .autocomplete__option:hover {
+    background-color: govuk-colour("blue");
+  }
 }

--- a/web/assets/dark.scss
+++ b/web/assets/dark.scss
@@ -1,0 +1,63 @@
+$sirius-bg-color: #29292e;
+
+.app-\!-html-class--dark {
+  background-color: $sirius-bg-color;
+  color: govuk-colour("white");
+  color-scheme: dark;
+
+  body.govuk-template__body,
+  .govuk-template {
+    background-color: $sirius-bg-color;
+    color: govuk-colour("white");
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  .govuk-heading-xl,
+  .govuk-heading-l,
+  .govuk-heading-m,
+  .govuk-heading-s,
+  .govuk-heading-xs,
+  p,
+  .govuk-list {
+    color: govuk-colour("white");
+  }
+
+  .govuk-link:link {
+    color: lighten(govuk-colour("light-blue"), 20%);
+  }
+
+  .govuk-link:visited {
+    color: govuk-colour("light-pink");
+  }
+
+  .govuk-link--no-visited-state:visited {
+    color: lighten(govuk-colour("light-blue"), 20%);
+  }
+
+  .govuk-link:hover {
+    color: lighten(govuk-colour("light-blue"), 30%);
+  }
+
+  .govuk-link:active {
+    color: $govuk-link-active-colour;
+  }
+
+  .govuk-label,
+  .govuk-file-upload,
+  .moj-banner__message {
+    color: govuk-colour("white");
+  }
+
+  .govuk-input,
+  .govuk-textarea,
+  .govuk-select,
+  .autocomplete__input {
+    background-color: $sirius-bg-color;
+    color: govuk-colour("white");
+  }
+}

--- a/web/assets/load-classes.js
+++ b/web/assets/load-classes.js
@@ -1,0 +1,12 @@
+document.body.className = document.body.className
+  ? document.body.className + " js-enabled"
+  : "js-enabled";
+
+if (window.self !== window.parent) {
+  document.documentElement.className += " app-!-html-class--embedded";
+  document.body.className += " app-!-embedded";
+
+  if (document.cookie.indexOf("siriusTheme=dark") > -1 || document.cookie.indexOf("siriusTheme=accessible-dark") > -1) {
+    document.documentElement.className += " app-!-html-class--dark";
+  }
+}

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -3,10 +3,6 @@ import accessibleAutocomplete from "accessible-autocomplete";
 import GOVUKFrontend from "govuk-frontend/govuk/all.js";
 import $ from "jquery";
 
-document.body.className = document.body.className
-  ? document.body.className + " js-enabled"
-  : "js-enabled";
-
 // Expose jQuery on window so MOJFrontend can use it
 window.$ = $;
 
@@ -51,9 +47,6 @@ if (selectUser) {
 }
 
 if (window.self !== window.parent) {
-  document.documentElement.className += " app-!-html-class--embedded";
-  document.body.className += " app-!-embedded";
-
   const success = document.querySelector(".moj-banner--success");
   if (success) {
     window.parent.postMessage(

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -5,6 +5,7 @@ $moj-page-width: 1220px;
 @import "node_modules/govuk-frontend/govuk/all";
 @import "node_modules/@ministryofjustice/frontend/moj/all";
 @import "node_modules/accessible-autocomplete/src/autocomplete";
+@import "./dark.scss";
 
 .app-\!-embedded .app-\!-embedded-hide {
   display: none;

--- a/web/template/layout/page.gohtml
+++ b/web/template/layout/page.gohtml
@@ -20,6 +20,7 @@
     </head>
 
     <body class="govuk-template__body app-body-class" data-prefix="{{ prefix "" }}">
+      <script src="{{ prefixAsset "/javascript/load-classes.js" }}"></script>
       <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
       {{ template "header" . }}
@@ -34,7 +35,7 @@
 
       <footer class="govuk-footer app-!-embedded-hide" role="contentinfo"></footer>
 
-      <script src="{{ prefixAsset "/javascript/all.js" }}"></script>
+      <script src="{{ prefixAsset "/javascript/main.js" }}"></script>
     </body>
   </html>
 {{ end }}


### PR DESCRIPTION
Adds support for a dark mode, which is applied if the `siriusTheme` cookie is set to "dark" or "accessible-dark"

I've created a new `load-classes` JavaScript file which adds the following classes:

- `js-enabled`: Always
- `app-!-html-class--embedded` and `app-!-embedded`: If the page is loaded in a frame
- `app-!-html-class--dark`: If the `siriusTheme` cookie is set as above

It blocks the rest of the page loading to ensure the styles are applied ASAP, rather than showing a flash of mis-styled content

![image](https://user-images.githubusercontent.com/100852/165281366-7ce6c739-995a-4bfd-b7f6-1e15e775f93b.png) ![image](https://user-images.githubusercontent.com/100852/165281301-9c94ac9e-38eb-42ac-9426-cef667afc3aa.png)


VEGA-1282 #major