### PR TITLE
VEGA-1369 Trim whitespace before and after inputs

### DIFF
--- a/internal/server/add_complaint.go
+++ b/internal/server/add_complaint.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
@@ -89,7 +90,8 @@ var complaintCategories = map[string]complaintCategory{
 
 func getValidSubcategory(category string, subCategories []string) string {
 	if category, ok := complaintCategories[category]; ok {
-		for _, s := range subCategories {
+		for _, subCategory := range subCategories {
+			s := strings.TrimSpace(subCategory)
 			if _, ok := category.Children[s]; ok {
 				return s
 			}
@@ -136,12 +138,12 @@ func AddComplaint(client AddComplaintClient, tmpl template.Template) Handler {
 
 		if r.Method == http.MethodPost {
 			complaint := sirius.Complaint{
-				Category:     r.FormValue("category"),
-				Description:  r.FormValue("description"),
-				ReceivedDate: sirius.DateString(r.FormValue("receivedDate")),
-				Severity:     r.FormValue("severity"),
-				SubCategory:  getValidSubcategory(r.FormValue("category"), r.PostForm["subCategory"]),
-				Summary:      r.FormValue("summary"),
+				Category:     postFormString(r, "category"),
+				Description:  postFormString(r, "description"),
+				ReceivedDate: postFormDateString(r, "receivedDate"),
+				Severity:     postFormString(r, "severity"),
+				SubCategory:  getValidSubcategory(postFormString(r, "category"), r.PostForm["subCategory"]),
+				Summary:      postFormString(r, "summary"),
 			}
 
 			err = client.AddComplaint(ctx, caseID, caseType, complaint)

--- a/internal/server/add_complaint_test.go
+++ b/internal/server/add_complaint_test.go
@@ -154,7 +154,7 @@ func TestPostAddComplaint(t *testing.T) {
 			}
 
 			r, _ := http.NewRequest(http.MethodPost, "/?id=123&case="+caseType, strings.NewReader(form.Encode()))
-			r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			r.Header.Add("Content-Type", formUrlEncoded)
 			w := httptest.NewRecorder()
 
 			err := AddComplaint(client, template.Func)(w, r)
@@ -198,7 +198,7 @@ func TestPostAddComplaintWhenAddComplaintValidationError(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123&case=lpa", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := AddComplaint(client, template.Func)(w, r)
@@ -227,7 +227,7 @@ func TestPostAddComplaintWhenAddComplaintOtherError(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123&case=lpa", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := AddComplaint(client, nil)(w, r)

--- a/internal/server/allocate_cases.go
+++ b/internal/server/allocate_cases.go
@@ -93,17 +93,17 @@ func AllocateCases(client AllocateCasesClient, tmpl template.Template) Handler {
 
 		if r.Method == http.MethodPost {
 			var assigneeID int
-			assignTo := r.FormValue("assignTo")
+			assignTo := postFormString(r, "assignTo")
 
 			switch assignTo {
 			case "user":
-				parts := strings.SplitN(r.FormValue("assigneeUser"), ":", 2)
+				parts := strings.SplitN(postFormString(r, "assigneeUser"), ":", 2)
 				if len(parts) == 2 {
 					assigneeID, _ = strconv.Atoi(parts[0])
 					data.AssigneeUserName = parts[1]
 				}
 			case "team":
-				assigneeID, _ = strconv.Atoi(r.FormValue("assigneeTeam"))
+				assigneeID, _ = postFormInt(r, "assigneeTeam")
 			}
 
 			err := client.AllocateCases(ctx, assigneeID, allocations)

--- a/internal/server/allocate_cases_test.go
+++ b/internal/server/allocate_cases_test.go
@@ -207,7 +207,7 @@ func TestPostAllocateCases(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := AllocateCases(client, template.Func)(w, r)
@@ -257,7 +257,7 @@ func TestPostAllocateCasesMultiple(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123&id=456", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := AllocateCases(client, template.Func)(w, r)
@@ -288,7 +288,7 @@ func TestPostAllocateCasesWhenAllocateCasesFails(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := AllocateCases(client, nil)(w, r)
@@ -331,7 +331,7 @@ func TestPostAllocateCasesWhenAssignToNotSet(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := AllocateCases(client, template.Func)(w, r)
@@ -396,7 +396,7 @@ func TestPostAllocateCasesWhenValidationError(t *testing.T) {
 			form.Add(tc.field, tc.value)
 
 			r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-			r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			r.Header.Add("Content-Type", formUrlEncoded)
 			w := httptest.NewRecorder()
 
 			err := AllocateCases(client, template.Func)(w, r)

--- a/internal/server/change_status.go
+++ b/internal/server/change_status.go
@@ -53,7 +53,7 @@ func ChangeStatus(client ChangeStatusClient, tmpl template.Template) Handler {
 			XSRFToken:         ctx.XSRFToken,
 			Entity:            fmt.Sprintf("%s %s", caseitem.CaseType, caseitem.UID),
 			AvailableStatuses: availableStatuses,
-			NewStatus:         r.FormValue("status"),
+			NewStatus:         postFormString(r, "status"),
 		}
 
 		if r.Method == http.MethodPost {

--- a/internal/server/change_status_test.go
+++ b/internal/server/change_status_test.go
@@ -190,7 +190,7 @@ func TestPostChangeStatus(t *testing.T) {
 			}
 
 			r, _ := http.NewRequest(http.MethodPost, "/?id=123&case="+caseType, strings.NewReader(form.Encode()))
-			r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			r.Header.Add("Content-Type", formUrlEncoded)
 			w := httptest.NewRecorder()
 
 			err := ChangeStatus(client, template.Func)(w, r)
@@ -227,7 +227,7 @@ func TestPostChangeStatusWhenChangeStatusErrors(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123&case=lpa", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := ChangeStatus(client, nil)(w, r)

--- a/internal/server/delete_relationship.go
+++ b/internal/server/delete_relationship.go
@@ -35,7 +35,7 @@ func DeleteRelationship(client DeleteRelationshipClient, tmpl template.Template)
 		data := deleteRelationshipData{XSRFToken: ctx.XSRFToken}
 
 		if r.Method == http.MethodPost {
-			referenceID, err := strconv.Atoi(r.FormValue("reference-id"))
+			referenceID, err := postFormInt(r, "reference-id")
 			if err != nil {
 				return err
 			}

--- a/internal/server/delete_relationship_test.go
+++ b/internal/server/delete_relationship_test.go
@@ -162,7 +162,7 @@ func TestPostDeleteRelationship(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := DeleteRelationship(client, template.Func)(w, r)
@@ -186,7 +186,7 @@ func TestPostDeleteRelationshipWhenDeletePersonReferenceErrors(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := DeleteRelationship(client, nil)(w, r)

--- a/internal/server/edit_complaint.go
+++ b/internal/server/edit_complaint.go
@@ -39,15 +39,15 @@ func EditComplaint(client EditComplaintClient, tmpl template.Template) Handler {
 
 		if r.Method == http.MethodPost {
 			complaint := sirius.Complaint{
-				Category:       r.FormValue("category"),
-				Description:    r.FormValue("description"),
-				ReceivedDate:   sirius.DateString(r.FormValue("receivedDate")),
-				Severity:       r.FormValue("severity"),
-				SubCategory:    getValidSubcategory(r.FormValue("category"), r.PostForm["subCategory"]),
-				Summary:        r.FormValue("summary"),
-				Resolution:     r.FormValue("resolution"),
-				ResolutionInfo: r.FormValue("resolutionInfo"),
-				ResolutionDate: sirius.DateString(r.FormValue("resolutionDate")),
+				Category:       postFormString(r, "category"),
+				Description:    postFormString(r, "description"),
+				ReceivedDate:   postFormDateString(r, "receivedDate"),
+				Severity:       postFormString(r, "severity"),
+				SubCategory:    getValidSubcategory(postFormString(r, "category"), r.PostForm["subCategory"]),
+				Summary:        postFormString(r, "summary"),
+				Resolution:     postFormString(r, "resolution"),
+				ResolutionInfo: postFormString(r, "resolutionInfo"),
+				ResolutionDate: postFormDateString(r, "resolutionDate"),
 			}
 
 			err = client.EditComplaint(ctx, id, complaint)

--- a/internal/server/edit_complaint_test.go
+++ b/internal/server/edit_complaint_test.go
@@ -154,7 +154,7 @@ func TestPostEditComplaint(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := EditComplaint(client, template.Func)(w, r)
@@ -195,7 +195,7 @@ func TestPostEditComplaintWhenEditComplaintValidationError(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := EditComplaint(client, template.Func)(w, r)
@@ -221,7 +221,7 @@ func TestPostEditComplaintWhenEditComplaintOtherError(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := EditComplaint(client, nil)(w, r)

--- a/internal/server/edit_dates.go
+++ b/internal/server/edit_dates.go
@@ -39,14 +39,14 @@ func EditDates(client EditDatesClient, tmpl template.Template) Handler {
 
 		if r.Method == http.MethodPost {
 			dates := sirius.Dates{
-				CancellationDate: sirius.DateString(r.FormValue("cancellationDate")),
-				DispatchDate:     sirius.DateString(r.FormValue("dispatchDate")),
-				DueDate:          sirius.DateString(r.FormValue("dueDate")),
-				InvalidDate:      sirius.DateString(r.FormValue("invalidDate")),
-				ReceiptDate:      sirius.DateString(r.FormValue("receiptDate")),
-				RegistrationDate: sirius.DateString(r.FormValue("registrationDate")),
-				RejectedDate:     sirius.DateString(r.FormValue("rejectedDate")),
-				WithdrawnDate:    sirius.DateString(r.FormValue("withdrawnDate")),
+				CancellationDate: postFormDateString(r, "cancellationDate"),
+				DispatchDate:     postFormDateString(r, "dispatchDate"),
+				DueDate:          postFormDateString(r, "dueDate"),
+				InvalidDate:      postFormDateString(r, "invalidDate"),
+				ReceiptDate:      postFormDateString(r, "receiptDate"),
+				RegistrationDate: postFormDateString(r, "registrationDate"),
+				RejectedDate:     postFormDateString(r, "rejectedDate"),
+				WithdrawnDate:    postFormDateString(r, "withdrawnDate"),
 			}
 
 			err = client.EditDates(ctx, caseID, caseType, dates)

--- a/internal/server/edit_dates_test.go
+++ b/internal/server/edit_dates_test.go
@@ -163,7 +163,7 @@ func TestPostEditDates(t *testing.T) {
 			}
 
 			r, _ := http.NewRequest(http.MethodPost, "/?id=123&case="+caseType, strings.NewReader(form.Encode()))
-			r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			r.Header.Add("Content-Type", formUrlEncoded)
 			w := httptest.NewRecorder()
 
 			err := EditDates(client, template.Func)(w, r)
@@ -191,7 +191,7 @@ func TestPostEditDatesWhenEditDatesErrors(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123&case=lpa", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := EditDates(client, nil)(w, r)

--- a/internal/server/event.go
+++ b/internal/server/event.go
@@ -91,9 +91,9 @@ func Event(client EventClient, tmpl template.Template) Handler {
 			}
 
 			var (
-				noteType    = r.FormValue("type")
-				name        = r.FormValue("name")
-				description = r.FormValue("description")
+				noteType    = postFormString(r, "type")
+				name        = postFormString(r, "name")
+				description = postFormString(r, "description")
 				file, err   = findNoteFile(r.MultipartForm, "file")
 			)
 			if err != nil {

--- a/internal/server/link_person.go
+++ b/internal/server/link_person.go
@@ -40,7 +40,7 @@ func LinkPerson(client LinkPersonClient, tmpl template.Template) Handler {
 		}
 
 		if r.Method == http.MethodPost {
-			data.OtherPerson, err = client.PersonByUid(ctx, r.FormValue("uid"))
+			data.OtherPerson, err = client.PersonByUid(ctx, postFormString(r, "uid"))
 			if ve, ok := err.(sirius.StatusError); ok && ve.Code == http.StatusNotFound {
 				w.WriteHeader(http.StatusBadRequest)
 				data.Error = sirius.ValidationError{
@@ -66,9 +66,9 @@ func LinkPerson(client LinkPersonClient, tmpl template.Template) Handler {
 				data.CanChangePrimary = true
 			}
 
-			if r.FormValue("primary-id") != "" {
+			if postFormString(r, "primary-id") != "" {
 				if data.CanChangePrimary {
-					data.PrimaryId, err = strconv.Atoi(r.FormValue("primary-id"))
+					data.PrimaryId, err = postFormInt(r, "primary-id")
 					if err != nil {
 						return err
 					}

--- a/internal/server/link_person_test.go
+++ b/internal/server/link_person_test.go
@@ -194,7 +194,7 @@ func TestLinkPersonSearch(t *testing.T) {
 			}
 
 			r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-			r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			r.Header.Add("Content-Type", formUrlEncoded)
 			w := httptest.NewRecorder()
 
 			err := LinkPerson(client, template.Func)(w, r)
@@ -236,7 +236,7 @@ func TestLinkPersonSearchNotFound(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := LinkPerson(client, template.Func)(w, r)
@@ -278,7 +278,7 @@ func TestLinkPersonSave(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := LinkPerson(client, template.Func)(w, r)
@@ -320,7 +320,7 @@ func TestLinkPersonSaveOtherPrimary(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := LinkPerson(client, template.Func)(w, r)
@@ -363,7 +363,7 @@ func TestLinkPersonSaveValidationError(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := LinkPerson(client, template.Func)(w, r)

--- a/internal/server/relationship.go
+++ b/internal/server/relationship.go
@@ -47,12 +47,12 @@ func Relationship(client RelationshipClient, tmpl template.Template) Handler {
 
 		if r.Method == http.MethodPost {
 			var (
-				reason     = r.FormValue("reason")
+				reason     = postFormString(r, "reason")
 				searchUID  string
 				searchName string
 			)
 
-			parts := strings.SplitN(r.FormValue("search"), ":", 2)
+			parts := strings.SplitN(postFormString(r, "search"), ":", 2)
 			if len(parts) == 2 {
 				searchUID = parts[0]
 				searchName = parts[1]

--- a/internal/server/relationship_test.go
+++ b/internal/server/relationship_test.go
@@ -140,7 +140,7 @@ func TestPostRelationship(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := Relationship(client, template.Func)(w, r)
@@ -181,7 +181,7 @@ func TestPostRelationshipWhenCreatePersonReferenceValidationError(t *testing.T) 
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := Relationship(client, template.Func)(w, r)
@@ -208,7 +208,7 @@ func TestPostRelationshipWhenCreatePersonReferenceOtherError(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := Relationship(client, nil)(w, r)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,8 @@ package server
 import (
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 
 	"github.com/ministryofjustice/opg-go-common/securityheaders"
 	"github.com/ministryofjustice/opg-go-common/template"
@@ -125,4 +127,16 @@ func errorHandler(logger Logger, tmplError template.Template, prefix, siriusURL 
 			}
 		})
 	}
+}
+
+func postFormString(r *http.Request, name string) string {
+	return strings.TrimSpace(r.PostFormValue(name))
+}
+
+func postFormInt(r *http.Request, name string) (int, error) {
+	return strconv.Atoi(postFormString(r, name))
+}
+
+func postFormDateString(r *http.Request, name string) sirius.DateString {
+	return sirius.DateString(postFormString(r, name))
 }

--- a/internal/server/task.go
+++ b/internal/server/task.go
@@ -81,23 +81,23 @@ func Task(client TaskClient, tmpl template.Template) Handler {
 		if r.Method == http.MethodPost {
 			task := sirius.Task{
 				CaseID:      caseID,
-				Type:        r.FormValue("type"),
-				DueDate:     sirius.DateString(r.FormValue("dueDate")),
-				Name:        r.FormValue("name"),
-				Description: r.FormValue("description"),
+				Type:        postFormString(r, "type"),
+				DueDate:     postFormDateString(r, "dueDate"),
+				Name:        postFormString(r, "name"),
+				Description: postFormString(r, "description"),
 			}
-			assignTo := r.FormValue("assignTo")
+			assignTo := postFormString(r, "assignTo")
 
 			switch assignTo {
 			case "user":
-				parts := strings.SplitN(r.FormValue("assigneeUser"), ":", 2)
+				parts := strings.SplitN(postFormString(r, "assigneeUser"), ":", 2)
 				if len(parts) == 2 {
 					assigneeID, _ := strconv.Atoi(parts[0])
 					task.AssigneeID = assigneeID
 					data.AssigneeUserName = parts[1]
 				}
 			case "team":
-				assigneeID, _ := strconv.Atoi(r.FormValue("assigneeTeam"))
+				assigneeID, _ := postFormInt(r, "assigneeTeam")
 				task.AssigneeID = assigneeID
 			}
 

--- a/internal/server/task_test.go
+++ b/internal/server/task_test.go
@@ -222,7 +222,7 @@ func TestPostTask(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := Task(client, template.Func)(w, r)
@@ -268,7 +268,7 @@ func TestPostTaskWhenCreateTaskFails(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := Task(client, template.Func)(w, r)
@@ -324,7 +324,7 @@ func TestPostTaskWhenAssignToNotSet(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := Task(client, template.Func)(w, r)
@@ -405,7 +405,7 @@ func TestPostTaskWhenValidationError(t *testing.T) {
 			form.Add(tc.field, tc.value)
 
 			r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
-			r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			r.Header.Add("Content-Type", formUrlEncoded)
 			w := httptest.NewRecorder()
 
 			err := Task(client, template.Func)(w, r)

--- a/internal/server/unlink_person.go
+++ b/internal/server/unlink_person.go
@@ -1,10 +1,11 @@
 package server
 
 import (
-	"github.com/ministryofjustice/opg-go-common/template"
-	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 	"net/http"
 	"strconv"
+
+	"github.com/ministryofjustice/opg-go-common/template"
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 )
 
 type UnlinkPersonClient interface {
@@ -32,7 +33,7 @@ func UnlinkPerson(client UnlinkPersonClient, tmpl template.Template) Handler {
 
 		if r.Method == http.MethodPost {
 			var childId int
-			id := r.FormValue("child-id")
+			id := postFormString(r, "child-id")
 
 			if id == "" {
 				w.WriteHeader(http.StatusBadRequest)

--- a/internal/server/unlink_person_test.go
+++ b/internal/server/unlink_person_test.go
@@ -2,14 +2,15 @@ package server
 
 import (
 	"errors"
-	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type mockUnlinkPerson struct {
@@ -152,7 +153,7 @@ func TestPostUnlinkPersonWhenChildNotSelected(t *testing.T) {
 		Return(nil)
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=189", nil)
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := UnlinkPerson(client, template.Func)(w, r)
@@ -196,7 +197,7 @@ func TestUnlinkPersonWhenValidationError(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=189", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := UnlinkPerson(client, template.Func)(w, r)
@@ -248,7 +249,7 @@ func TestPostUnlinkPerson(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=189", strings.NewReader(form.Encode()))
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 
 	err := UnlinkPerson(client, template.Func)(w, r)

--- a/internal/server/warning.go
+++ b/internal/server/warning.go
@@ -41,8 +41,8 @@ func Warning(client WarningClient, tmpl template.Template) Handler {
 		}
 
 		if r.Method == http.MethodPost {
-			warningType := r.FormValue("warning-type")
-			warningNotes := r.FormValue("warning-notes")
+			warningType := postFormString(r, "warning-type")
+			warningNotes := postFormString(r, "warning-notes")
 
 			err := client.CreateWarning(ctx, personId, warningType, warningNotes)
 

--- a/internal/server/warning_test.go
+++ b/internal/server/warning_test.go
@@ -95,7 +95,7 @@ func TestPostWarning(t *testing.T) {
 		"warning-notes": {"Some random warning notes"},
 	}.Encode()))
 
-	req.Header.Add("content-type", "application/x-www-form-urlencoded")
+	req.Header.Add("content-type", formUrlEncoded)
 
 	w := httptest.NewRecorder()
 	err := Warning(siriusClient, template.Func)(w, req)
@@ -142,7 +142,7 @@ func TestPostWarningValidationErrors(t *testing.T) {
 		"warning-notes": {""},
 	}.Encode()))
 
-	req.Header.Add("content-type", "application/x-www-form-urlencoded")
+	req.Header.Add("content-type", formUrlEncoded)
 
 	w := httptest.NewRecorder()
 	err := Warning(siriusClient, template.Func)(w, req)
@@ -172,7 +172,7 @@ func TestCreateWarningReturnsError(t *testing.T) {
 		"warning-notes": {"Some notes"},
 	}.Encode()))
 
-	req.Header.Add("content-type", "application/x-www-form-urlencoded")
+	req.Header.Add("content-type", formUrlEncoded)
 
 	w := httptest.NewRecorder()
 	err := Warning(siriusClient, nil)(w, req)
@@ -189,7 +189,7 @@ func TestGetWarningTypesFail(t *testing.T) {
 		"warning-notes": {"Some notes"},
 	}.Encode()))
 
-	req.Header.Add("content-type", "application/x-www-form-urlencoded")
+	req.Header.Add("content-type", formUrlEncoded)
 
 	w := httptest.NewRecorder()
 	err := Warning(siriusClient, nil)(w, req)


### PR DESCRIPTION
It's now consistently using `r.PostForm` for the data that was posted in a form and `r.Form` for things that come from the URL. I added some helpers for the common types we are using.

I also made a constant for `"application/x-www-form-urlencoded"` because I'm bored of typing it.