### PR TITLE
Compile "metatemplates" to templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "accessible-autocomplete": "^2.0.4",
     "cypress": "10.3.1",
     "govuk-frontend": "^4.2.0",
-    "jquery": "^3.6.0"
+    "jquery": "^3.6.0",
+    "nunjucks": "^3.2.3"
   },
   "devDependencies": {
     "esbuild": "^0.14.27",

--- a/render.js
+++ b/render.js
@@ -1,0 +1,19 @@
+const nunjucks = require('nunjucks');
+const path = require('path');
+const fs = require('fs');
+
+var views = [
+    path.join(__dirname, '/node_modules/govuk-frontend/'),
+    path.join(__dirname, '/node_modules/govuk-frontend/components'),
+    path.join(__dirname, '/node_modules/govuk_template_jinja/views/layouts'),
+    path.join(__dirname, '/web/metatemplate'),
+];
+
+const nunjucksEnv = nunjucks.configure(views, {});
+
+const s = nunjucksEnv.render('add_complaint.njk', {})
+    .replace(/\{\!/g, '{{')
+    .replace(/\!\}/g, '}}')
+    .replace(/<div class="govuk-form-group govuk-form-group--error">([\s\S]+?)<p id="[a-z\- ]+" class="govuk-error-message">\s+<span class="govuk-visually-hidden">Error:<\/span>\s+([A-Za-z.]+)\s+<\/p>/gm, '<div class="govuk-form-group {{ if $2 }}govuk-form-group--error{{ end }}">$1{{ template "errors" $2 }}')
+
+fs.writeFileSync(path.join(__dirname, '/web/template/add_complaint.gohtml'), `{{ define "page" }}${s}{{ end }}`);

--- a/web/metatemplate/add_complaint.njk
+++ b/web/metatemplate/add_complaint.njk
@@ -1,0 +1,128 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% extends "govuk/template.njk" %}
+
+{% block pageTitle %}
+  {! if .Error.Any !}Error: {! end !}Add Complaint
+{% endblock %}
+
+{% block head %}
+  <!--[if !IE 8]><!-->
+    <link href="{! prefixAsset "/stylesheets/all.css" !}" rel="stylesheet">
+  <!--<![endif]-->
+{% endblock %}
+
+{% block header %}
+  <script src="{! prefixAsset "/javascript/load-classes.js" !}"></script>
+  {! template "header" . !}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body"><strong>{! .Entity !}</strong></p>
+
+      {! template "error-summary" .Error !}
+
+      {! if .Success !}
+        {! template "success-banner" "You have successfully added a complaint." !}
+      {! end !}
+
+      <h1 class="govuk-heading-l app-!-embedded-hide">Add Complaint</h1>
+
+      <form class="form" method="POST">
+        <input type="hidden" name="xsrfToken" value="{! .XSRFToken !}"/>
+
+        {{ govukRadios({
+          idPrefix: "f-severity",
+          name: "severity",
+          fieldset: {
+            legend: {
+              text: "Severity"
+            }
+          },
+          items: [
+            {
+              value: "Minor",
+              text: "Minor"
+            },
+            {
+              value: "Major",
+              text: "Major"
+            },
+            {
+              value: "Security Breach",
+              text: "Security Breach"
+            }
+          ],
+          errorMessage: {
+            html: ".Error.Field.severity"
+          }
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Title"
+          },
+          id: "summary",
+          name: "summary",
+          value: "{! .Complaint.Summary !}",
+          errorMessage: {
+            html: ".Error.Field.summary"
+          }
+        }) }}
+        
+        {! template "input" (field "summary" "Title" .Complaint.Summary .Error.Field.summary) !}
+
+        {! template "textarea" (field "description" "Description" .Complaint.Description .Error.Field.description) !}
+
+        {! template "input-date" (field "receivedDate" "Received date" .Complaint.ReceivedDate .Error.Field.receivedDate "max" today) !}
+
+        <div class="govuk-form-group {! if .Error.Field.category !}govuk-form-group--error{! end !}">
+          <label class="govuk-label" for="f-category">
+            Complaint category
+          </label>
+          {! template "errors" .Error.Field.category !}
+
+          <div class="govuk-radios" data-module="govuk-radios">
+            {! range $k, $v := .Categories !}
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="f-category-{! $k !}" name="category" type="radio" value="{! $k !}" data-aria-controls="conditional-category-{! $k !}" {! if eq $k $.Complaint.Category !}checked{! end !}>
+                <label class="govuk-label govuk-radios__label" for="f-category-{! $k !}">
+                  {! $v.Label !}
+                </label>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-category-{! $k !}">
+                <div class="govuk-!-width-one-half govuk-form-group {! if $.Error.Field.subCategory !}govuk-form-group--error{! end !}">
+                  <label class="govuk-label" for="f-subCategory-{! $k !}">Subcategory</label>
+                  {! template "errors" $.Error.Field.subCategory !}
+                  <select class="govuk-select {! if $.Error.Field.subCategory !}govuk-select--error{! end !}" id="f-subCategory-{! $k !}" name="subCategory">
+                    <option hidden {! if eq "" $.Complaint.SubCategory !}selected{! end !} disabled></option>
+                    {! range $id, $label := $v.Children !}
+                      <option value="{! $id !}" {! if eq $id $.Complaint.SubCategory !}selected{! end !} >{! $label !}</option>
+                    {! end !}
+                  </select>
+                </div>
+              </div>
+            {! end !}
+          </div>
+        </div>
+
+        <div class="govuk-button-group">
+          <button class="govuk-button" data-module="govuk-button" type="submit">Save and exit</button>
+          <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock %}
+
+{% block footer %}
+  <footer class="govuk-footer app-!-embedded-hide" role="contentinfo"></footer>
+{% endblock %}
+
+{% block bodyEnd %}
+  <script src="{! prefixAsset "/javascript/main.js" !}"></script>
+{% endblock %}

--- a/web/template/add_complaint.gohtml
+++ b/web/template/add_complaint.gohtml
@@ -1,8 +1,52 @@
-{{ template "page" . }}
+{{ define "page" }}<!DOCTYPE html>
+<html lang="en" class="govuk-template ">
+  <head>
+    <meta charset="utf-8">
+    <title>
+  {{ if .Error.Any }}Error: {{ end }}Add Complaint
+</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c"> 
+    
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-{{ define "title" }}{{ if .Error.Any }}Error: {{ end }}Add Complaint{{ end }}
+    
+      <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.ico" type="image/x-icon">
+      <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="#0b0c0c"> 
+      <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/govuk-apple-touch-icon-180x180.png">
+      <link rel="apple-touch-icon" sizes="167x167" href="/assets/images/govuk-apple-touch-icon-167x167.png">
+      <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/govuk-apple-touch-icon-152x152.png">
+      <link rel="apple-touch-icon" href="/assets/images/govuk-apple-touch-icon.png">
+    
 
-{{ define "main" }}
+    
+  <!--[if !IE 8]><!-->
+    <link href="{{ prefixAsset "/stylesheets/all.css" }}" rel="stylesheet">
+  <!--<![endif]-->
+
+    
+    
+    <meta property="og:image" content="/assets/images/govuk-opengraph-image.png">
+  </head>
+  <body class="govuk-template__body ">
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    
+
+    
+      <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+    
+
+    
+  <script src="{{ prefixAsset "/javascript/load-classes.js" }}"></script>
+  {{ template "header" . }}
+
+
+    
+      <div class="govuk-width-container ">
+        
+        <main class="govuk-main-wrapper " id="main-content" role="main">
+          
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-body"><strong>{{ .Entity }}</strong></p>
@@ -18,37 +62,95 @@
       <form class="form" method="POST">
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
 
-        <div class="govuk-form-group {{ if .Error.Field.severity }}govuk-form-group--error{{ end }}">
-          <fieldset class="govuk-fieldset">
-            <legend class="govuk-fieldset__legend">
-              <h1 class="govuk-fieldset__heading">
-                Severity
-              </h1>
-            </legend>
-            {{ template "errors" .Error.Field.severity }}
-            <div class="govuk-radios" data-module="govuk-radios">
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="f-severity" name="severity" type="radio" value="Minor" {{ if eq "Minor" .Complaint.Severity }}checked{{ end }}>
-                <label class="govuk-label govuk-radios__label" for="f-severity">
-                  Minor
-                </label>
-              </div>
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="f-severity-2" name="severity" type="radio" value="Major" {{ if eq "Major" .Complaint.Severity }}checked{{ end }}>
-                <label class="govuk-label govuk-radios__label" for="f-severity-2">
-                  Major
-                </label>
-              </div>
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="f-severity-3" name="severity" type="radio" value="Security Breach" {{ if eq "Security Breach" .Complaint.Severity }}checked{{ end }}>
-                <label class="govuk-label govuk-radios__label" for="f-severity-3">
-                  Security Breach
-                </label>
-              </div>
-            </div>
-          </fieldset>
-        </div>
+        
 
+<div class="govuk-form-group {{ if .Error.Field.severity }}govuk-form-group--error{{ end }}">
+
+  <fieldset class="govuk-fieldset" aria-describedby="f-severity-error">
+  
+  <legend class="govuk-fieldset__legend">
+  
+    Severity
+  
+  </legend>
+  
+
+  {{ template "errors" .Error.Field.severity }}
+
+  <div class="govuk-radios"
+    data-module="govuk-radios">
+    
+      
+          
+        
+        
+        
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="f-severity" name="severity" type="radio" value="Minor">
+          <label class="govuk-label govuk-radios__label" for="f-severity">
+        Minor
+      </label>
+          
+        </div>
+        
+        
+      
+    
+      
+        
+        
+        
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="f-severity-2" name="severity" type="radio" value="Major">
+          <label class="govuk-label govuk-radios__label" for="f-severity-2">
+        Major
+      </label>
+          
+        </div>
+        
+        
+      
+    
+      
+        
+        
+        
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="f-severity-3" name="severity" type="radio" value="Security Breach">
+          <label class="govuk-label govuk-radios__label" for="f-severity-3">
+        Security Breach
+      </label>
+          
+        </div>
+        
+        
+      
+    
+  </div>
+  
+
+</fieldset>
+
+
+</div>
+
+
+        
+
+<div class="govuk-form-group {{ if .Error.Field.summary }}govuk-form-group--error{{ end }}">
+  <label class="govuk-label" for="summary">
+    Title
+  </label>
+
+
+  
+  
+  {{ template "errors" .Error.Field.summary }}
+<input class="govuk-input govuk-input--error" id="summary" name="summary" type="text" value="{{ .Complaint.Summary }}" aria-describedby="summary-error">
+
+</div>
+
+        
         {{ template "input" (field "summary" "Title" .Complaint.Summary .Error.Field.summary) }}
 
         {{ template "textarea" (field "description" "Description" .Complaint.Description .Error.Field.description) }}
@@ -92,4 +194,18 @@
       </form>
     </div>
   </div>
+
+        </main>
+      </div>
+    
+
+    
+  <footer class="govuk-footer app-!-embedded-hide" role="contentinfo"></footer>
+
+
+    
+  <script src="{{ prefixAsset "/javascript/main.js" }}"></script>
+
+  </body>
+</html>
 {{ end }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,6 +69,11 @@
   dependencies:
     "@types/node" "*"
 
+a-sync-waterfall@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz#75b6b6aa72598b497a125e7a2770f14f4c8a1fa7"
+  integrity sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==
+
 accessible-autocomplete@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz#e295256c8d268b97c5ab456a1cb084b553ed3eb0"
@@ -120,6 +125,11 @@ arch@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/arch/-/arch-2.2.0.tgz#1bc47818f305764f23ab3306b0bfc086c5a29d11"
   integrity sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
+
+asap@^2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
 asn1@~0.2.3:
   version "0.2.6"
@@ -1034,6 +1044,15 @@ npm-run-path@^4.0.0:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+nunjucks@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/nunjucks/-/nunjucks-3.2.3.tgz#1b33615247290e94e28263b5d855ece765648a31"
+  integrity sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==
+  dependencies:
+    a-sync-waterfall "^1.0.0"
+    asap "^2.0.3"
+    commander "^5.1.0"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Playing with this I think the problem becomes obvious, errors. I've hacked together a regex to tackle the radio button, but then you realise that other inputs apply classes too which makes it very difficult. The real solution would be to actually parse the HTML, which isn't impossible, but I think would be more effort than making small reusable templates like https://github.com/ministryofjustice/opg-sirius-lpa-frontend/blob/main/web/template/layout/input.gohtml.

![image](https://user-images.githubusercontent.com/146390/182824359-93a9b00e-45d1-4a8c-bd0f-1b2706586359.png)

(The other "solution" would be to duplicate each form component and use an if-else to display the non-error or the error version, but that would only make templates worse)