### PR TITLE
VEGA-1446 remove auth from pact tests

### DIFF
--- a/cypress/e2e/add-complaint.cy.js
+++ b/cypress/e2e/add-complaint.cy.js
@@ -1,8 +1,5 @@
 describe("Add a complaint", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/add-complaint?id=800&case=lpa");
   });
 

--- a/cypress/e2e/add-payment.cy.js
+++ b/cypress/e2e/add-payment.cy.js
@@ -1,8 +1,5 @@
 describe("Add a payment", () => {
     beforeEach(() => {
-        cy.setCookie("Other", "other");
-        cy.setCookie("XSRF-TOKEN", "abcde");
-        cy.setCookie("OPG-Bypass-Membrane", "1");
         cy.visit("/add-payment?id=800");
     });
 

--- a/cypress/e2e/allocate-cases.cy.js
+++ b/cypress/e2e/allocate-cases.cy.js
@@ -1,8 +1,5 @@
 describe("Allocate cases", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/allocate-cases?id=800");
   });
 

--- a/cypress/e2e/assign-task.cy.js
+++ b/cypress/e2e/assign-task.cy.js
@@ -1,8 +1,5 @@
 describe("Assign task", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/assign-task?id=990");
   });
 

--- a/cypress/e2e/change-status.cy.js
+++ b/cypress/e2e/change-status.cy.js
@@ -1,8 +1,5 @@
 describe("Change status", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/change-status?id=800&case=lpa");
   });
 

--- a/cypress/e2e/create-donor.cy.js
+++ b/cypress/e2e/create-donor.cy.js
@@ -1,8 +1,5 @@
 describe("Create donor", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/create-donor");
   });
 

--- a/cypress/e2e/create-event.cy.js
+++ b/cypress/e2e/create-event.cy.js
@@ -1,8 +1,5 @@
 describe("Create an event", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/create-event?id=800&entity=lpa");
   });
 

--- a/cypress/e2e/create-relationship.cy.js
+++ b/cypress/e2e/create-relationship.cy.js
@@ -1,8 +1,5 @@
 describe("Create a relationship", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/create-relationship?id=189");
   });
 

--- a/cypress/e2e/create-task.cy.js
+++ b/cypress/e2e/create-task.cy.js
@@ -1,8 +1,5 @@
 describe("Create a task", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/create-task?id=800");
   });
 

--- a/cypress/e2e/create-warning.cy.js
+++ b/cypress/e2e/create-warning.cy.js
@@ -1,8 +1,5 @@
 describe("Create a warning", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/create-warning?id=189");
   });
 

--- a/cypress/e2e/delete-relationship.cy.js
+++ b/cypress/e2e/delete-relationship.cy.js
@@ -1,8 +1,5 @@
 describe("Delete a relationship", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/delete-relationship?id=189");
   });
 

--- a/cypress/e2e/edit-complaint.cy.js
+++ b/cypress/e2e/edit-complaint.cy.js
@@ -1,8 +1,5 @@
 describe("Edit complaint", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/edit-complaint?id=986");
   });
 

--- a/cypress/e2e/edit-dates.cy.js
+++ b/cypress/e2e/edit-dates.cy.js
@@ -1,8 +1,5 @@
 describe("Edit dates", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/edit-dates?id=800&case=lpa");
   });
 

--- a/cypress/e2e/edit-donor.cy.js
+++ b/cypress/e2e/edit-donor.cy.js
@@ -1,8 +1,5 @@
 describe("Create donor", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/edit-donor?id=189");
   });
 

--- a/cypress/e2e/edit-payment.cy.js
+++ b/cypress/e2e/edit-payment.cy.js
@@ -1,8 +1,5 @@
 describe("Edit a payment", () => {
     beforeEach(() => {
-        cy.setCookie("Other", "other");
-        cy.setCookie("XSRF-TOKEN", "abcde");
-        cy.setCookie("OPG-Bypass-Membrane", "1");
         cy.visit("/edit-payment?id=800&payment=123");
     });
 

--- a/cypress/e2e/mi-reporting.cy.js
+++ b/cypress/e2e/mi-reporting.cy.js
@@ -1,8 +1,5 @@
 describe("MI Reporting", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/mi-reporting");
   });
 

--- a/cypress/e2e/unlink-person.cy.js
+++ b/cypress/e2e/unlink-person.cy.js
@@ -1,8 +1,5 @@
 describe("Unlink records", () => {
   beforeEach(() => {
-    cy.setCookie("Other", "other");
-    cy.setCookie("XSRF-TOKEN", "abcde");
-    cy.setCookie("OPG-Bypass-Membrane", "1");
     cy.visit("/unlink-person?id=189");
   });
 

--- a/internal/sirius/add_complaint_test.go
+++ b/internal/sirius/add_complaint_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -39,45 +40,12 @@ func TestAddComplaint(t *testing.T) {
 							"subCategory":  "07",
 							"summary":      "This and that",
 						}),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusCreated,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 						Body:    dsl.Like(map[string]interface{}{"id": dsl.Integer()}),
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("I have a pending case assigned").
-					UponReceiving("A request to add a complaint to the case without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodPost,
-						Path:   dsl.String("/lpa-api/v1/lpas/800/complaints"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/lpas/800/complaints", port),
-					Method: http.MethodPost,
-				}
 			},
 		},
 	}
@@ -89,7 +57,7 @@ func TestAddComplaint(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.AddComplaint(getContext(tc.cookies), 800, CaseTypeLpa, Complaint{
+				err := client.AddComplaint(Context{Context: context.Background()}, 800, CaseTypeLpa, Complaint{
 					Category:     "01",
 					Description:  "This is seriously bad",
 					ReceivedDate: DateString("2022-04-05"),

--- a/internal/sirius/add_payment_test.go
+++ b/internal/sirius/add_payment_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"github.com/pact-foundation/pact-go/dsl"
 	"github.com/stretchr/testify/assert"
@@ -35,49 +36,11 @@ func TestAddPayment(t *testing.T) {
 							"source":      "MAKE",
 							"paymentDate": "25/04/2022",
 						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusCreated,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("I have a pending case assigned").
-					UponReceiving("A request to create a payment without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodPost,
-						Path:   dsl.String("/lpa-api/v1/cases/800/payments"),
-						Body: map[string]interface{}{
-							"amount":      4100,
-							"source":      "MAKE",
-							"paymentDate": "25/04/2022",
-						},
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/cases/800/payments", port),
-					Method: http.MethodPost,
-				}
 			},
 		},
 	}
@@ -89,7 +52,7 @@ func TestAddPayment(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.AddPayment(getContext(tc.cookies), 800, 4100, "MAKE", DateString("2022-04-25"))
+				err := client.AddPayment(Context{Context: context.Background()}, 800, 4100, "MAKE", DateString("2022-04-25"))
 
 				if tc.expectedError == nil {
 					assert.Nil(t, err)

--- a/internal/sirius/case_test.go
+++ b/internal/sirius/case_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -32,11 +33,6 @@ func TestCase(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/cases/800"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -48,34 +44,7 @@ func TestCase(t *testing.T) {
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			expectedResponse: Case{UID: "7000-0000-0000", CaseType: "LPA", Status: "Pending"},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("I have a pending case assigned").
-					UponReceiving("A request for the case without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/lpa-api/v1/cases/800"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/cases/800", port),
-					Method: http.MethodGet,
-				}
-			},
 		},
 	}
 
@@ -86,7 +55,7 @@ func TestCase(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				caseitem, err := client.Case(getContext(tc.cookies), 800)
+				caseitem, err := client.Case(Context{Context: context.Background()}, 800)
 
 				assert.Equal(t, tc.expectedResponse, caseitem)
 				if tc.expectedError == nil {

--- a/internal/sirius/complaint_test.go
+++ b/internal/sirius/complaint_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -32,11 +33,6 @@ func TestComplaint(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/complaints/986"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -51,10 +47,6 @@ func TestComplaint(t *testing.T) {
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			expectedResponse: Complaint{
 				Category:     "01",
 				Description:  "This is seriously bad",
@@ -62,29 +54,6 @@ func TestComplaint(t *testing.T) {
 				Severity:     "Major",
 				SubCategory:  "07",
 				Summary:      "This and that",
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("A complaint exists").
-					UponReceiving("A request for the complaint without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/lpa-api/v1/complaints/986"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/complaints/986", port),
-					Method: http.MethodGet,
-				}
 			},
 		},
 	}
@@ -96,7 +65,7 @@ func TestComplaint(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				complaint, err := client.Complaint(getContext(tc.cookies), 986)
+				complaint, err := client.Complaint(Context{Context: context.Background()}, 986)
 
 				assert.Equal(t, tc.expectedResponse, complaint)
 				if tc.expectedError == nil {

--- a/internal/sirius/create_donor_test.go
+++ b/internal/sirius/create_donor_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -82,12 +83,6 @@ func TestCreateDonor(t *testing.T) {
 							"correspondenceByWelsh": false,
 							"researchOptOut":        true,
 						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusCreated,
@@ -98,65 +93,9 @@ func TestCreateDonor(t *testing.T) {
 						},
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			expectedPerson: Person{
 				ID:  771,
 				UID: "7000-0290-0192",
-			},
-		},
-		{
-			name: "Unauthorized",
-			personData: Person{
-				Firstname: "Guillermo",
-				Surname:   "Prothero",
-			},
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("I am a Lay Team user").
-					UponReceiving("A request to create a donor without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodPost,
-						Path:   dsl.String("/lpa-api/v1/donors"),
-						Body: map[string]interface{}{
-							"salutation":            "",
-							"firstname":             "Guillermo",
-							"middlenames":           "",
-							"surname":               "Prothero",
-							"dob":                   nil,
-							"previousNames":         "",
-							"otherNames":            "",
-							"addressLine1":          "",
-							"addressLine2":          "",
-							"addressLine3":          "",
-							"town":                  "",
-							"county":                "",
-							"postcode":              "",
-							"country":               "",
-							"phoneNumber":           "",
-							"email":                 "",
-							"sageId":                "",
-							"isAirmailRequired":     false,
-							"correspondenceByPost":  false,
-							"correspondenceByEmail": false,
-							"correspondenceByPhone": false,
-							"correspondenceByWelsh": false,
-							"researchOptOut":        false,
-						},
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/donors", port),
-					Method: http.MethodPost,
-				}
 			},
 		},
 	}
@@ -168,7 +107,7 @@ func TestCreateDonor(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				person, err := client.CreateDonor(getContext(tc.cookies), tc.personData)
+				person, err := client.CreateDonor(Context{Context: context.Background()}, tc.personData)
 				if (tc.expectedError) == nil {
 					assert.Equal(t, tc.expectedPerson, person)
 					assert.Nil(t, err)

--- a/internal/sirius/create_note_test.go
+++ b/internal/sirius/create_note_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -37,21 +38,11 @@ func TestCreateNote(t *testing.T) {
 							"description": "More words",
 							"type":        "Application processing",
 						}),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusCreated,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 		},
 		{
@@ -74,49 +65,16 @@ func TestCreateNote(t *testing.T) {
 								"source": "SGVsbG8gdGhlcmUK",
 							}),
 						}),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusCreated,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			file: &NoteFile{
 				Name:   "words.txt",
 				Type:   "plain/text",
 				Source: "SGVsbG8gdGhlcmUK",
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("I have a pending case assigned").
-					UponReceiving("A request to create a note without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodPost,
-						Path:   dsl.String("/lpa-api/v1/lpas/800/notes"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/lpas/800/notes", port),
-					Method: http.MethodPost,
-				}
 			},
 		},
 	}
@@ -128,7 +86,7 @@ func TestCreateNote(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.CreateNote(getContext(tc.cookies), 800, "lpa", "Application processing", "Something", "More words", tc.file)
+				err := client.CreateNote(Context{Context: context.Background()}, 800, "lpa", "Application processing", "Something", "More words", tc.file)
 				if (tc.expectedError) == nil {
 					assert.Nil(t, err)
 				} else {

--- a/internal/sirius/create_person_reference_test.go
+++ b/internal/sirius/create_person_reference_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -35,48 +36,11 @@ func TestCreatePersonReference(t *testing.T) {
 							"referencedUid": dsl.Like("7000-9999-0001"),
 							"reason":        dsl.Like("Mother"),
 						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusCreated,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("A donor exists to be referenced").
-					UponReceiving("A request to create a person reference without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodPost,
-						Path:   dsl.String("/lpa-api/v1/persons/189/references"),
-						Body: map[string]interface{}{
-							"referencedUid": dsl.Like("7000-9999-0001"),
-							"reason":        dsl.Like("Mother"),
-						},
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/persons/189/references", port),
-					Method: http.MethodPost,
-				}
 			},
 		},
 	}
@@ -88,7 +52,7 @@ func TestCreatePersonReference(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.CreatePersonReference(getContext(tc.cookies), 189, "7000-9999-0001", "Mother")
+				err := client.CreatePersonReference(Context{Context: context.Background()}, 189, "7000-9999-0001", "Mother")
 				if (tc.expectedError) == nil {
 					assert.Nil(t, err)
 				} else {

--- a/internal/sirius/create_task_test.go
+++ b/internal/sirius/create_task_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -40,44 +41,11 @@ func TestCreateTask(t *testing.T) {
 							"description": dsl.String("More words"),
 							"dueDate":     dsl.Term("04/05/2731", `^\d{1,2}/\d{1,2}/\d{4}$`),
 						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusCreated,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("I have a pending case assigned").
-					UponReceiving("A request to create a task without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodPost,
-						Path:   dsl.String("/lpa-api/v1/tasks"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/tasks", port),
-					Method: http.MethodPost,
-				}
 			},
 		},
 	}
@@ -89,7 +57,7 @@ func TestCreateTask(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.CreateTask(getContext(tc.cookies), TaskRequest{
+				err := client.CreateTask(Context{Context: context.Background()}, TaskRequest{
 					CaseID:      800,
 					AssigneeID:  1,
 					Type:        "Change of Address",

--- a/internal/sirius/create_warning_test.go
+++ b/internal/sirius/create_warning_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -35,44 +36,11 @@ func TestCreateWarning(t *testing.T) {
 							"warningType": "Complaint Received",
 							"warningText": "Some warning notes",
 						}),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusCreated,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("A donor exists").
-					UponReceiving("A request to create a warning without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodPost,
-						Path:   dsl.String("/lpa-api/v1/persons/189/warnings"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/persons/189/warnings", port),
-					Method: http.MethodPost,
-				}
 			},
 		},
 	}
@@ -84,7 +52,7 @@ func TestCreateWarning(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.CreateWarning(getContext(tc.cookies), 189, "Complaint Received", "Some warning notes")
+				err := client.CreateWarning(Context{Context: context.Background()}, 189, "Complaint Received", "Some warning notes")
 				if (tc.expectedError) == nil {
 					assert.Nil(t, err)
 				} else {

--- a/internal/sirius/delete_person_reference_test.go
+++ b/internal/sirius/delete_person_reference_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -31,42 +32,10 @@ func TestDeletePersonReferences(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodDelete,
 						Path:   dsl.String("/lpa-api/v1/person-references/768"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusNoContent,
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("A donor with a reference").
-					UponReceiving("A request to delete the person reference without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodDelete,
-						Path:   dsl.String("/lpa-api/v1/person-references/768"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/person-references/768", port),
-					Method: http.MethodDelete,
-				}
 			},
 		},
 	}
@@ -78,7 +47,7 @@ func TestDeletePersonReferences(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.DeletePersonReference(getContext(tc.cookies), 768)
+				err := client.DeletePersonReference(Context{Context: context.Background()}, 768)
 
 				if tc.expectedError == nil {
 					assert.Nil(t, err)

--- a/internal/sirius/edit_case_test.go
+++ b/internal/sirius/edit_case_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -32,11 +33,6 @@ func TestEditCase(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodPut,
 						Path:   dsl.String("/lpa-api/v1/lpas/800"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 						Body: map[string]interface{}{
 							"status": "Suspended",
 						},
@@ -45,10 +41,6 @@ func TestEditCase(t *testing.T) {
 						Status:  http.StatusOK,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			caseType: CaseTypeLpa,
 		},
@@ -62,11 +54,6 @@ func TestEditCase(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodPut,
 						Path:   dsl.String("/lpa-api/v1/epas/800"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 						Body: map[string]interface{}{
 							"status": "Suspended",
 						},
@@ -76,35 +63,7 @@ func TestEditCase(t *testing.T) {
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			caseType: CaseTypeEpa,
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("I have a pending case assigned").
-					UponReceiving("A request to edit the LPA without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodPut,
-						Path:   dsl.String("/lpa-api/v1/lpas/800"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/lpas/800", port),
-					Method: http.MethodPut,
-				}
-			},
-			caseType: CaseTypeLpa,
 		},
 	}
 
@@ -115,7 +74,7 @@ func TestEditCase(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.EditCase(getContext(tc.cookies), 800, tc.caseType, Case{Status: "Suspended"})
+				err := client.EditCase(Context{Context: context.Background()}, 800, tc.caseType, Case{Status: "Suspended"})
 
 				if tc.expectedError == nil {
 					assert.Nil(t, err)

--- a/internal/sirius/edit_complaint_test.go
+++ b/internal/sirius/edit_complaint_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -42,44 +43,11 @@ func TestEditComplaint(t *testing.T) {
 							"resolutionInfo": "We did stuff",
 							"resolutionDate": "07/06/2022",
 						}),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("A complaint exists").
-					UponReceiving("A request to edit the complaint without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodPut,
-						Path:   dsl.String("/lpa-api/v1/complaints/986"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/complaints/986", port),
-					Method: http.MethodPut,
-				}
 			},
 		},
 	}
@@ -91,7 +59,7 @@ func TestEditComplaint(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.EditComplaint(getContext(tc.cookies), 986, Complaint{
+				err := client.EditComplaint(Context{Context: context.Background()}, 986, Complaint{
 					Category:       "01",
 					Description:    "This is seriously bad",
 					ReceivedDate:   DateString("2022-04-05"),

--- a/internal/sirius/edit_dates_test.go
+++ b/internal/sirius/edit_dates_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -31,11 +32,6 @@ func TestEditDates(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodPut,
 						Path:   dsl.String("/lpa-api/v1/lpas/800/edit-dates"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 						Body: map[string]interface{}{
 							"rejectedDate": "04/03/2022",
 						},
@@ -44,33 +40,6 @@ func TestEditDates(t *testing.T) {
 						Status:  http.StatusOK,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("I have a pending case assigned").
-					UponReceiving("A request to edit the dates without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodPut,
-						Path:   dsl.String("/lpa-api/v1/lpas/800/edit-dates"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/lpas/800/edit-dates", port),
-					Method: http.MethodPut,
-				}
 			},
 		},
 	}
@@ -82,7 +51,7 @@ func TestEditDates(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.EditDates(getContext(tc.cookies), 800, "lpa", Dates{RejectedDate: DateString("2022-03-04")})
+				err := client.EditDates(Context{Context: context.Background()}, 800, "lpa", Dates{RejectedDate: DateString("2022-03-04")})
 
 				if tc.expectedError == nil {
 					assert.Nil(t, err)

--- a/internal/sirius/edit_donor_test.go
+++ b/internal/sirius/edit_donor_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -81,73 +82,11 @@ func TestEditDonor(t *testing.T) {
 							"correspondenceByWelsh": true,
 							"researchOptOut":        true,
 						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
-		},
-		{
-			name: "Unauthorized",
-			personData: Person{
-				Firstname: "Will",
-				Surname:   "Niesborella",
-			},
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("A donor exists").
-					UponReceiving("A request to edit a donor without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodPut,
-						Path:   dsl.String("/lpa-api/v1/donors/189"),
-						Body: map[string]interface{}{
-							"salutation":            "",
-							"firstname":             "Will",
-							"middlenames":           "",
-							"surname":               "Niesborella",
-							"dob":                   nil,
-							"previousNames":         "",
-							"otherNames":            "",
-							"addressLine1":          "",
-							"addressLine2":          "",
-							"addressLine3":          "",
-							"town":                  "",
-							"county":                "",
-							"postcode":              "",
-							"country":               "",
-							"phoneNumber":           "",
-							"email":                 "",
-							"sageId":                "",
-							"isAirmailRequired":     false,
-							"correspondenceByPost":  false,
-							"correspondenceByEmail": false,
-							"correspondenceByPhone": false,
-							"correspondenceByWelsh": false,
-							"researchOptOut":        false,
-						},
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/donors/189", port),
-					Method: http.MethodPut,
-				}
 			},
 		},
 	}
@@ -159,7 +98,7 @@ func TestEditDonor(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.EditDonor(getContext(tc.cookies), 189, tc.personData)
+				err := client.EditDonor(Context{Context: context.Background()}, 189, tc.personData)
 				if (tc.expectedError) == nil {
 					assert.Nil(t, err)
 				} else {

--- a/internal/sirius/edit_payment_test.go
+++ b/internal/sirius/edit_payment_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"github.com/pact-foundation/pact-go/dsl"
 	"github.com/stretchr/testify/assert"
@@ -35,49 +36,11 @@ func TestEditPayment(t *testing.T) {
 							"source":      dsl.String("PHONE"),
 							"paymentDate": dsl.Term("27/04/2022", `^\d{1,2}/\d{1,2}/\d{4}$`),
 						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("I have an lpa which has been paid for").
-					UponReceiving("A request to edit a payment without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodPut,
-						Path:   dsl.String("/lpa-api/v1/payments/123"),
-						Body: map[string]interface{}{
-							"amount":      dsl.Like(2550),
-							"source":      dsl.String("PHONE"),
-							"paymentDate": dsl.Term("27/04/2022", `^\d{1,2}/\d{1,2}/\d{4}$`),
-						},
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/payments/123", port),
-					Method: http.MethodPut,
-				}
 			},
 		},
 	}
@@ -89,7 +52,7 @@ func TestEditPayment(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.EditPayment(getContext(tc.cookies), 123, Payment{Amount: 2550, Source: "PHONE", PaymentDate: DateString("2022-04-27")})
+				err := client.EditPayment(Context{Context: context.Background()}, 123, Payment{Amount: 2550, Source: "PHONE", PaymentDate: DateString("2022-04-27")})
 
 				if tc.expectedError == nil {
 					assert.Nil(t, err)

--- a/internal/sirius/link_people_test.go
+++ b/internal/sirius/link_people_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -35,47 +36,10 @@ func TestLinkPeople(t *testing.T) {
 							"parentId": dsl.Like(189),
 							"childId":  dsl.Like(190),
 						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusNoContent,
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("2 donors exist").
-					UponReceiving("A request to link two people without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodPost,
-						Path:   dsl.String("/lpa-api/v1/person-links"),
-						Body: map[string]interface{}{
-							"parentId": dsl.Like(189),
-							"childId":  dsl.Like(190),
-						},
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/person-links", port),
-					Method: http.MethodPost,
-				}
 			},
 		},
 	}
@@ -87,7 +51,7 @@ func TestLinkPeople(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.LinkPeople(getContext(tc.cookies), 189, 190)
+				err := client.LinkPeople(Context{Context: context.Background()}, 189, 190)
 				if (tc.expectedError) == nil {
 					assert.Nil(t, err)
 				} else {

--- a/internal/sirius/mi_report_test.go
+++ b/internal/sirius/mi_report_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -36,10 +37,6 @@ func TestMiReport(t *testing.T) {
 						Query: dsl.MapMatcher{
 							"reportType": dsl.String("epasReceived"),
 						},
-						Headers: dsl.MapMatcher{
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
@@ -53,40 +50,10 @@ func TestMiReport(t *testing.T) {
 						}),
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			expectedResult: &MiReportResponse{
 				ResultCount:       10,
 				ReportType:        "epasReceived",
 				ReportDescription: "Number of EPAs received",
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("I have a pending case assigned").
-					UponReceiving("A request for an MI report without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/api/reporting/applications"),
-						Query: dsl.MapMatcher{
-							"reportType": dsl.String("epasReceived"),
-						},
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/api/reporting/applications?reportType=epasReceived", port),
-					Method: http.MethodGet,
-				}
 			},
 		},
 	}
@@ -101,7 +68,7 @@ func TestMiReport(t *testing.T) {
 				form := url.Values{
 					"reportType": {"epasReceived"},
 				}
-				result, err := client.MiReport(getContext(tc.cookies), form)
+				result, err := client.MiReport(Context{Context: context.Background()}, form)
 
 				assert.Equal(t, tc.expectedResult, result)
 				if tc.expectedError == nil {

--- a/internal/sirius/note_types_test.go
+++ b/internal/sirius/note_types_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -32,11 +33,6 @@ func TestNoteTypes(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/note-types/lpa"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
@@ -44,34 +40,7 @@ func TestNoteTypes(t *testing.T) {
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			expectedResponse: []string{"Application processing"},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("Some note types exist").
-					UponReceiving("A request for note types without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/lpa-api/v1/note-types/lpa"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/note-types/lpa", port),
-					Method: http.MethodGet,
-				}
-			},
 		},
 	}
 
@@ -82,7 +51,7 @@ func TestNoteTypes(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				types, err := client.NoteTypes(getContext(tc.cookies))
+				types, err := client.NoteTypes(Context{Context: context.Background()})
 
 				assert.Equal(t, tc.expectedResponse, types)
 				if tc.expectedError == nil {

--- a/internal/sirius/payment_test.go
+++ b/internal/sirius/payment_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"github.com/pact-foundation/pact-go/dsl"
 	"github.com/stretchr/testify/assert"
@@ -31,11 +32,6 @@ func TestPayment(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/cases/9/payments"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -48,10 +44,6 @@ func TestPayment(t *testing.T) {
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			expectedResponse: []Payment{
 				{
 					ID:          2,
@@ -59,29 +51,6 @@ func TestPayment(t *testing.T) {
 					Amount:      4100,
 					PaymentDate: DateString("2022-01-23"),
 				},
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("I have an lpa which has been paid for").
-					UponReceiving("A request for the payments without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/lpa-api/v1/cases/9/payments"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/cases/9/payments", port),
-					Method: http.MethodGet,
-				}
 			},
 		},
 	}
@@ -93,7 +62,7 @@ func TestPayment(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				payments, err := client.Payments(getContext(tc.cookies), 9)
+				payments, err := client.Payments(Context{Context: context.Background()}, 9)
 
 				assert.Equal(t, tc.expectedResponse, payments)
 				if tc.expectedError == nil {
@@ -130,11 +99,6 @@ func TestPaymentByID(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/payments/123"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -147,38 +111,11 @@ func TestPaymentByID(t *testing.T) {
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			expectedResponse: Payment{
 				ID:          123,
 				Source:      "PHONE",
 				Amount:      4100,
 				PaymentDate: DateString("2022-01-23"),
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("I have an lpa which has been paid for").
-					UponReceiving("A request for that payment by ID without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/lpa-api/v1/payments/123"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/payments/123", port),
-					Method: http.MethodGet,
-				}
 			},
 		},
 	}
@@ -190,7 +127,7 @@ func TestPaymentByID(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				payment, err := client.PaymentByID(getContext(tc.cookies), 123)
+				payment, err := client.PaymentByID(Context{Context: context.Background()}, 123)
 
 				assert.Equal(t, tc.expectedResponse, payment)
 				if tc.expectedError == nil {

--- a/internal/sirius/person_by_uid_test.go
+++ b/internal/sirius/person_by_uid_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -32,11 +33,6 @@ func TestPersonByUid(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/persons/by-uid/7000-0000-0001"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -49,10 +45,6 @@ func TestPersonByUid(t *testing.T) {
 						}),
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			expectedResponse: Person{
 				ID:          103,
@@ -72,11 +64,6 @@ func TestPersonByUid(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/persons/by-uid/7000-0000-0001"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -93,10 +80,6 @@ func TestPersonByUid(t *testing.T) {
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			expectedResponse: Person{
 				ID:          103,
 				UID:         "7000-0000-0001",
@@ -110,29 +93,6 @@ func TestPersonByUid(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("A donor exists").
-					UponReceiving("A request for the person by UID without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/lpa-api/v1/persons/by-uid/7000-0000-0001"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/persons/by-uid/7000-0000-0001", port),
-					Method: http.MethodGet,
-				}
-			},
-		},
 	}
 
 	for _, tc := range testCases {
@@ -142,7 +102,7 @@ func TestPersonByUid(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				caseitem, err := client.PersonByUid(getContext(tc.cookies), "7000-0000-0001")
+				caseitem, err := client.PersonByUid(Context{Context: context.Background()}, "7000-0000-0001")
 
 				assert.Equal(t, tc.expectedResponse, caseitem)
 				if tc.expectedError == nil {

--- a/internal/sirius/person_references_test.go
+++ b/internal/sirius/person_references_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -32,11 +33,6 @@ func TestPersonReferences(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/persons/189/references"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -50,10 +46,6 @@ func TestPersonReferences(t *testing.T) {
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			expectedResponse: []PersonReference{{
 				ReferenceID: 768,
 				ID:          189,
@@ -61,29 +53,6 @@ func TestPersonReferences(t *testing.T) {
 				DisplayName: "John Doe",
 				Reason:      "Friend",
 			}},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("A donor with a reference").
-					UponReceiving("A request for person references without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/lpa-api/v1/persons/189/references"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/persons/189/references", port),
-					Method: http.MethodGet,
-				}
-			},
 		},
 	}
 
@@ -94,7 +63,7 @@ func TestPersonReferences(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				caseitem, err := client.PersonReferences(getContext(tc.cookies), 189)
+				caseitem, err := client.PersonReferences(Context{Context: context.Background()}, 189)
 
 				assert.Equal(t, tc.expectedResponse, caseitem)
 				if tc.expectedError == nil {

--- a/internal/sirius/person_test.go
+++ b/internal/sirius/person_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -32,11 +33,6 @@ func TestPerson(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/persons/189"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -58,10 +54,6 @@ func TestPerson(t *testing.T) {
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			expectedResponse: Person{
 				ID:          189,
 				UID:         "7000-0000-0001",
@@ -78,29 +70,6 @@ func TestPerson(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("A donor exists").
-					UponReceiving("A request for the person without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/lpa-api/v1/persons/189"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/persons/189", port),
-					Method: http.MethodGet,
-				}
-			},
-		},
 	}
 
 	for _, tc := range testCases {
@@ -110,7 +79,7 @@ func TestPerson(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				caseitem, err := client.Person(getContext(tc.cookies), 189)
+				caseitem, err := client.Person(Context{Context: context.Background()}, 189)
 
 				assert.Equal(t, tc.expectedResponse, caseitem)
 				if tc.expectedError == nil {

--- a/internal/sirius/search_users_test.go
+++ b/internal/sirius/search_users_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -35,11 +36,6 @@ func TestSearchUsers(t *testing.T) {
 						Query: dsl.MapMatcher{
 							"query": dsl.String("admin"),
 						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
@@ -50,45 +46,11 @@ func TestSearchUsers(t *testing.T) {
 						}, 1),
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			expectedResponse: []User{
 				{
 					ID:          47,
 					DisplayName: "system admin",
 				},
-			},
-		},
-
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("User exists").
-					UponReceiving("A search for admin users without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/lpa-api/v1/search/users"),
-						Query: dsl.MapMatcher{
-							"query": dsl.String("admin"),
-						},
-						Headers: dsl.MapMatcher{
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/search/users?query=admin", port),
-					Method: http.MethodGet,
-				}
 			},
 		},
 	}
@@ -100,7 +62,7 @@ func TestSearchUsers(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				users, err := client.SearchUsers(getContext(tc.cookies), "admin")
+				users, err := client.SearchUsers(Context{Context: context.Background()}, "admin")
 				assert.Equal(t, tc.expectedResponse, users)
 				if tc.expectedError == nil {
 					assert.Nil(t, err)

--- a/internal/sirius/task_test.go
+++ b/internal/sirius/task_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -32,11 +33,6 @@ func TestTask(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/tasks/990"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -53,10 +49,6 @@ func TestTask(t *testing.T) {
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			expectedResponse: Task{
 				ID:      990,
 				Status:  "Not Started",
@@ -68,29 +60,6 @@ func TestTask(t *testing.T) {
 				}},
 			},
 		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("I have a case with an open task assigned").
-					UponReceiving("A request for a task without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/lpa-api/v1/tasks/990"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/tasks/990", port),
-					Method: http.MethodGet,
-				}
-			},
-		},
 	}
 
 	for _, tc := range testCases {
@@ -100,7 +69,7 @@ func TestTask(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				task, err := client.Task(getContext(tc.cookies), 990)
+				task, err := client.Task(Context{Context: context.Background()}, 990)
 
 				assert.Equal(t, tc.expectedResponse, task)
 				if tc.expectedError == nil {

--- a/internal/sirius/task_types_test.go
+++ b/internal/sirius/task_types_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -32,11 +33,6 @@ func TestTaskTypes(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/tasktypes/lpa"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -48,34 +44,7 @@ func TestTaskTypes(t *testing.T) {
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			expectedResponse: []string{"Check Application"},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("Some task types exist").
-					UponReceiving("A request for task types without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/lpa-api/v1/tasktypes/lpa"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/tasktypes/lpa", port),
-					Method: http.MethodGet,
-				}
-			},
 		},
 	}
 
@@ -86,7 +55,7 @@ func TestTaskTypes(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				types, err := client.TaskTypes(getContext(tc.cookies))
+				types, err := client.TaskTypes(Context{Context: context.Background()})
 
 				assert.Equal(t, tc.expectedResponse, types)
 				if tc.expectedError == nil {

--- a/internal/sirius/teams_test.go
+++ b/internal/sirius/teams_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -32,11 +33,6 @@ func TestTeams(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/teams"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status:  http.StatusOK,
@@ -46,10 +42,6 @@ func TestTeams(t *testing.T) {
 							"displayName": dsl.Like("Cool Team"),
 						}, 1),
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
 			},
 			expectedResponse: []Team{
 				{
@@ -93,7 +85,7 @@ func TestTeams(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				users, err := client.Teams(getContext(tc.cookies))
+				users, err := client.Teams(Context{Context: context.Background()})
 				assert.Equal(t, tc.expectedResponse, users)
 				if tc.expectedError == nil {
 					assert.Nil(t, err)

--- a/internal/sirius/unlink_person_test.go
+++ b/internal/sirius/unlink_person_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -34,46 +35,10 @@ func TestUnlinkPerson(t *testing.T) {
 						Body: map[string]interface{}{
 							"childIds": []int{105},
 						},
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-							"Content-Type":        dsl.String("application/json"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusNoContent,
 					})
-			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("A donor exists with children").
-					UponReceiving("A request to unlink those cases without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodPatch,
-						Path:   dsl.String("/lpa-api/v1/person-links/189"),
-						Body: map[string]interface{}{
-							"childIds": []int{105},
-						},
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/person-links/189", port),
-					Method: http.MethodPatch,
-				}
 			},
 		},
 	}
@@ -85,7 +50,7 @@ func TestUnlinkPerson(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.UnlinkPerson(getContext(tc.cookies), 189, 105)
+				err := client.UnlinkPerson(Context{Context: context.Background()}, 189, 105)
 
 				if tc.expectedError == nil {
 					assert.Nil(t, err)

--- a/internal/sirius/warning_types_test.go
+++ b/internal/sirius/warning_types_test.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -32,11 +33,6 @@ func TestWarningTypes(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/reference-data/warningType"),
-						Headers: dsl.MapMatcher{
-							"X-XSRF-TOKEN":        dsl.String("abcde"),
-							"Cookie":              dsl.String("XSRF-TOKEN=abcde; Other=other"),
-							"OPG-Bypass-Membrane": dsl.String("1"),
-						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -47,38 +43,11 @@ func TestWarningTypes(t *testing.T) {
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			cookies: []*http.Cookie{
-				{Name: "XSRF-TOKEN", Value: "abcde"},
-				{Name: "Other", Value: "other"},
-			},
 			expectedResponse: []RefDataItem{
 				{
 					Handle: "Complaint Received",
 					Label:  "Complaint Received",
 				},
-			},
-		},
-		{
-			name: "Unauthorized",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("Some warning types exist").
-					UponReceiving("A request for warning types without cookies").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/lpa-api/v1/reference-data/warningType"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusUnauthorized,
-					})
-			},
-			expectedError: func(port int) error {
-				return StatusError{
-					Code:   http.StatusUnauthorized,
-					URL:    fmt.Sprintf("http://localhost:%d/lpa-api/v1/reference-data/warningType", port),
-					Method: http.MethodGet,
-				}
 			},
 		},
 	}
@@ -90,7 +59,7 @@ func TestWarningTypes(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				types, err := client.WarningTypes(getContext(tc.cookies))
+				types, err := client.WarningTypes(Context{Context: context.Background()})
 
 				assert.Equal(t, tc.expectedResponse, types)
 				if tc.expectedError == nil {


### PR DESCRIPTION
Requests in the pact-proxy will now be authorised sirius side, allowing us to remove 401 tests, and the headers and cookies from pact/cypress tests
#minor