### PR TITLE
Vega 1467 fee widget tweaks

### DIFF
--- a/internal/server/add_payment.go
+++ b/internal/server/add_payment.go
@@ -51,6 +51,16 @@ func AddPayment(client AddPaymentClient, tmpl template.Template) Handler {
 						"amount": {"reason": "Please enter the amount to 2 decimal places"},
 					},
 				}
+				if data.Source == "" {
+					data.Error.Field["source"] = map[string]string{
+						"reason": "Value is required and can't be empty",
+					}
+				}
+				if data.PaymentDate == "" {
+					data.Error.Field["paymentDate"] = map[string]string{
+						"reason": "Value is required and can't be empty",
+					}
+				}
 				return tmpl(w, data)
 			}
 

--- a/internal/server/edit_payment.go
+++ b/internal/server/edit_payment.go
@@ -68,6 +68,16 @@ func EditPayment(client EditPaymentClient, tmpl template.Template) Handler {
 						"amount": {"reason": "Please enter the amount to 2 decimal places"},
 					},
 				}
+				if data.Source == "" {
+					data.Error.Field["source"] = map[string]string{
+						"reason": "Value is required and can't be empty",
+					}
+				}
+				if data.PaymentDate == "" {
+					data.Error.Field["paymentDate"] = map[string]string{
+						"reason": "Value is required and can't be empty",
+					}
+				}
 				return tmpl(w, data)
 			}
 

--- a/main.go
+++ b/main.go
@@ -67,9 +67,6 @@ func main() {
 
 			return field
 		},
-		"plus1": func(index int) int {
-			return index + 1
-		},
 		"fee": func(amount int) string {
 			float := float64(amount)
 			return fmt.Sprintf("%.2f", float/100)

--- a/web/assets/dark.scss
+++ b/web/assets/dark.scss
@@ -27,6 +27,7 @@ $sirius-bg-color: #29292e;
     color: govuk-colour("white");
   }
 
+  .govuk-details__summary-text,
   .govuk-link:link {
     color: lighten(govuk-colour("light-blue"), 20%);
   }
@@ -49,6 +50,8 @@ $sirius-bg-color: #29292e;
 
   .govuk-label,
   .govuk-file-upload,
+  .govuk-summary-list__key,
+  .govuk-summary-list__value,
   .moj-banner__message {
     color: govuk-colour("white");
   }
@@ -67,6 +70,7 @@ $sirius-bg-color: #29292e;
     color: govuk-colour("white");
   }
 
+  .govuk-input__prefix,
   .autocomplete__option--odd {
     background-color: govuk-colour("black");
   }

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -22,3 +22,7 @@ $moj-page-width: 1220px;
 .unlink-table__label {
   width: 100%;
 }
+
+.table-row__no-border {
+   border-bottom: none;
+ }

--- a/web/template/add_payment.gohtml
+++ b/web/template/add_payment.gohtml
@@ -18,11 +18,9 @@
             <form class="form" method="POST">
                 <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
                 <div class="govuk-form-group">
-                    <h3 class="govuk-label-wrapper">
-                        <label class="govuk-label" for="f-amount">
-                            Enter amount paid
-                        </label>
-                    </h3>
+                    <label class="govuk-label" for="f-amount">
+                        Enter amount paid
+                    </label>
                     {{ template "errors" .Error.Field.amount }}
                     <div class="govuk-input__wrapper">
                         <div class="govuk-input__prefix" aria-hidden="true">£</div>

--- a/web/template/add_payment.gohtml
+++ b/web/template/add_payment.gohtml
@@ -10,17 +10,17 @@
             {{ template "error-summary" .Error }}
 
             {{ if .Success }}
-                {{ template "success-banner" ("Payment added!") }}
+                {{ template "success-banner" ("Payment added") }}
             {{ end }}
 
-            <h1 class="govuk-heading-l app-!-embedded-hide">Add a payment</h1>
+            <h1 class="govuk-heading-l">Add a payment</h1>
 
             <form class="form" method="POST">
                 <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
                 <div class="govuk-form-group">
                     <h3 class="govuk-label-wrapper">
                         <label class="govuk-label" for="f-amount">
-                            Enter amount
+                            Enter amount paid
                         </label>
                     </h3>
                     {{ template "errors" .Error.Field.amount }}
@@ -37,8 +37,8 @@
                     {{ template "errors" .Error.Field.source }}
                     <select class="govuk-select {{ if .Error.Field.source }}govuk-select--error{{ end }}" id="f-source" name="source">
                         <option hidden selected disabled></option>
-                        <option value="PHONE" {{ if eq .Source "PHONE" }}selected{{ end }}>Paid over the phone</option>
-                        <option value="ONLINE" {{ if eq .Source "ONLINE" }}selected{{ end }}>Paid online - Notify</option>
+                        <option value="PHONE" {{ if eq .Source "PHONE" }}selected{{ end }}>Telephone</option>
+                        <option value="ONLINE" {{ if eq .Source "ONLINE" }}selected{{ end }}>Online - Notify</option>
                     </select>
                 </div>
 
@@ -50,9 +50,9 @@
 
                 <a href="#" class="govuk-link govuk-link--no-visited-state govuk-!-display-inline-block" data-module="select-todays-date">Use today's date</a>
 
-                <div class="govuk-button-group">
+                <div class="govuk-button-group govuk-!-padding-top-6">
                     <button class="govuk-button" data-module="govuk-button" type="submit">Save</button>
-                    <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+                    <a class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/payments?id=%d" .Case.ID) }}">Cancel</a>
                 </div>
             </form>
 

--- a/web/template/add_payment.gohtml
+++ b/web/template/add_payment.gohtml
@@ -17,7 +17,7 @@
 
             <form class="form" method="POST">
                 <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
-                <div class="govuk-form-group">
+                <div class="govuk-form-group {{ if .Error.Field.amount }}govuk-form-group--error{{ end }}">
                     <label class="govuk-label" for="f-amount">
                         Enter amount paid
                     </label>
@@ -28,7 +28,7 @@
                     </div>
                 </div>
 
-                <div class="govuk-form-group">
+                <div class="govuk-form-group {{ if .Error.Field.source }}govuk-form-group--error{{ end }}">
                     <label class="govuk-label" for="f-source">
                         Payment method
                     </label>

--- a/web/template/edit_payment.gohtml
+++ b/web/template/edit_payment.gohtml
@@ -17,7 +17,7 @@
 
             <form class="form" method="POST">
                 <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
-                <div class="govuk-form-group">
+                <div class="govuk-form-group {{ if .Error.Field.source }}govuk-form-group--error{{ end }}">
                     <h3 class="govuk-label-wrapper">
                         <label class="govuk-label" for="f-amount">
                             Enter amount paid
@@ -30,7 +30,7 @@
                     </div>
                 </div>
 
-                <div class="govuk-form-group">
+                <div class="govuk-form-group {{ if .Error.Field.source }}govuk-form-group--error{{ end }}">
                     <label class="govuk-label" for="f-source">
                         Payment method
                     </label>

--- a/web/template/edit_payment.gohtml
+++ b/web/template/edit_payment.gohtml
@@ -17,7 +17,7 @@
 
             <form class="form" method="POST">
                 <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
-                <div class="govuk-form-group {{ if .Error.Field.source }}govuk-form-group--error{{ end }}">
+                <div class="govuk-form-group {{ if .Error.Field.amount }}govuk-form-group--error{{ end }}">
                     <h3 class="govuk-label-wrapper">
                         <label class="govuk-label" for="f-amount">
                             Enter amount paid

--- a/web/template/edit_payment.gohtml
+++ b/web/template/edit_payment.gohtml
@@ -10,10 +10,10 @@
             {{ template "error-summary" .Error }}
 
             {{ if .Success }}
-                {{ template "success-banner" ("Payment edited!") }}
+                {{ template "success-banner" ("Payment saved") }}
             {{ end }}
 
-            <h1 class="govuk-heading-l app-!-embedded-hide">Edit payment</h1>
+            <h1 class="govuk-heading-l">Edit payment</h1>
 
             <form class="form" method="POST">
                 <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
@@ -37,8 +37,8 @@
                     {{ template "errors" .Error.Field.source }}
                     <select class="govuk-select {{ if .Error.Field.source }}govuk-select--error{{ end }}" id="f-source" name="source">
                         <option hidden selected disabled></option>
-                        <option value="PHONE" {{ if eq .Source "PHONE" }}selected{{ end }}>Paid over the phone</option>
-                        <option value="ONLINE" {{ if eq .Source "ONLINE" }}selected{{ end }}>Paid online - Notify</option>
+                        <option value="PHONE" {{ if eq .Source "PHONE" }}selected{{ end }}>Telephone</option>
+                        <option value="ONLINE" {{ if eq .Source "ONLINE" }}selected{{ end }}>Online - Notify</option>
                     </select>
                 </div>
 
@@ -50,9 +50,9 @@
 
                 <a href="#" class="govuk-link govuk-link--no-visited-state govuk-!-display-inline-block" data-module="select-todays-date">Use today's date</a>
 
-                <div class="govuk-button-group">
+                <div class="govuk-button-group govuk-!-padding-top-6">
                     <button class="govuk-button" data-module="govuk-button" type="submit">Save</button>
-                    <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+                    <a class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/payments?id=%d" .Case.ID) }}">Cancel</a>
                 </div>
             </form>
 

--- a/web/template/edit_payment.gohtml
+++ b/web/template/edit_payment.gohtml
@@ -20,7 +20,7 @@
                 <div class="govuk-form-group">
                     <h3 class="govuk-label-wrapper">
                         <label class="govuk-label" for="f-amount">
-                            Enter amount
+                            Enter amount paid
                         </label>
                     </h3>
                     {{ template "errors" .Error.Field.amount }}

--- a/web/template/payments.gohtml
+++ b/web/template/payments.gohtml
@@ -50,7 +50,7 @@
                             {{ if or (eq .Source "PHONE") (eq .Source "ONLINE") }}
                                 <div class="govuk-summary-list__row">
                                     <dt class="govuk-summary-list__key">
-                                        <a class="govuk-link" href="{{ (printf "/edit-payment?id=%d&payment=%d" $.Case.ID .ID) }}">
+                                        <a class="govuk-link" href="{{ prefix (printf "/edit-payment?id=%d&payment=%d" $.Case.ID .ID) }}">
                                             Edit payment
                                         </a>
                                     </dt>
@@ -61,7 +61,7 @@
                 </details>
             {{ end }}
 
-            <a class="govuk-button govuk-button--secondary" href="{{ (printf "/add-payment?id=%d" .Case.ID) }}">
+            <a class="govuk-button govuk-button--secondary" href="{{ prefix (printf "/add-payment?id=%d" .Case.ID) }}">
                 Add a payment
             </a>
         </div>

--- a/web/template/payments.gohtml
+++ b/web/template/payments.gohtml
@@ -5,64 +5,72 @@
 {{ define "main" }}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body"><strong>{{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "lpa" }}LPA{{ end }} {{ .Case.UID }}</strong></p>
-            <p class="govuk-body"><strong>Total paid: £{{ fee .TotalPaid }}</strong></p>
+            <h1 class="govuk-heading-s govuk-!-padding-bottom-2"><strong>{{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "lpa" }}LPA{{ end }} {{ .Case.UID }}</strong></h1>
 
-            {{ range $i, $p := .Payments }}
-                <details class="govuk-details" data-module="govuk-details">
-                    <summary class="govuk-details__summary">
-                        <span class="govuk-details__summary-text">
-                            Payment {{ plus1 $i }}
-                        </span>
-                    </summary>
-                    <div class="govuk-details__text">
-                        <dl class="govuk-summary-list govuk-summary-list--no-border">
-                            <div class="govuk-summary-list__row">
-                                <dt class="govuk-summary-list__key">
-                                    Amount:
-                                </dt>
-                                <dd class="govuk-summary-list__value">
-                                    £{{ fee .Amount }}
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row">
-                                <dt class="govuk-summary-list__key">
-                                    Date:
-                                </dt>
-                                <dd class="govuk-summary-list__value">
-                                    {{ .PaymentDate }}
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row">
-                                <dt class="govuk-summary-list__key">
-                                    Method:
-                                </dt>
-                                <dd class="govuk-summary-list__value">
+            {{ if not .Payments }}
+            <h2 class="govuk-body govuk-!-padding-top-7 govuk-!-padding-bottom-7"><strong>There is currently no fee data available to display.</strong></h2>
+            {{ else }}
+            <table class="govuk-table my-table table__no-border">
+                <tbody class="govuk-table__body">
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header govuk-!-font-size-24">Total paid:</th>
+                    <td class="govuk-table__cell govuk-!-font-size-24"><strong>£{{ fee .TotalPaid }}</strong></td>
+                </tr>
+                </tbody>
+            </table>
+
+            <h3 class="govuk-heading-m govuk-!-padding-top-3 govuk-!-padding-bottom-2"><strong>Fee details</strong></h3>
+
+            <details class="govuk-details" data-module="govuk-details">
+                <summary class="govuk-details__summary">
+                    <span class="govuk-details__summary-text">
+                        Payments
+                    </span>
+                </summary>
+                <div class="govuk-details__text">
+
+                    {{ range $i, $p := .Payments }}
+                    <table class="govuk-table my-table table__no-border">
+                        <tbody class="govuk-table__body">
+                            <tr class="govuk-table__row">
+                                <th scope="row" class="govuk-table__header">Amount:</th>
+                                <td class="govuk-table__cell"><strong>£{{ fee .Amount }}</strong></td>
+                            </tr>
+                            <tr class="govuk-table__row">
+                                <th scope="row" class="govuk-table__header">Date:</th>
+                                <td class="govuk-table__cell">{{ .PaymentDate }}</td>
+                            </tr>
+                            <tr class="govuk-table__row">
+                                <th scope="row" class="govuk-table__header">Method:</th>
+                                <td class="govuk-table__cell">
                                     {{ if eq .Source "PHONE" }}
-                                        Over the phone
+                                        Telephone
                                     {{ else if eq .Source "MAKE" }}
                                         Online - Make
                                     {{ else if eq .Source "ONLINE" }}
                                         Online - Notify
                                     {{ end }}
-                                </dd>
-                            </div>
+                                </td>
+                            </tr>
                             {{ if or (eq .Source "PHONE") (eq .Source "ONLINE") }}
-                                <div class="govuk-summary-list__row">
-                                    <dt class="govuk-summary-list__key">
-                                        <a class="govuk-link" href="{{ prefix (printf "/edit-payment?id=%d&payment=%d" $.Case.ID .ID) }}">
-                                            Edit payment
-                                        </a>
-                                    </dt>
-                                </div>
+                            <tr class="govuk-table__row">
+                                <th scope="row" class="govuk-table__header table-row__no-border">
+                                    <a class="govuk-link" href="{{ prefix (printf "/edit-payment?id=%d&payment=%d" $.Case.ID .ID) }}">
+                                        Edit payment
+                                    </a>
+                                </th>
+                            </tr>
                             {{ end }}
-                        </dl>
-                    </div>
-                </details>
+                        </tbody>
+                    </table>
+                    {{ end }}
+
+                </div>
+            </details>
             {{ end }}
 
             <a class="govuk-button govuk-button--secondary" href="{{ prefix (printf "/add-payment?id=%d" .Case.ID) }}">
-                Add a payment
+                Add payment
             </a>
         </div>
     </div>

--- a/web/template/payments.gohtml
+++ b/web/template/payments.gohtml
@@ -8,7 +8,7 @@
             <h1 class="govuk-heading-s govuk-!-padding-bottom-2"><strong>{{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "lpa" }}LPA{{ end }} {{ .Case.UID }}</strong></h1>
 
             {{ if not .Payments }}
-            <p class="govuk-!-padding-top-7 govuk-!-padding-bottom-7"><strong>There is currently no fee data available to display.</strong></p>
+            <p class="govuk-body govuk-!-padding-top-7 govuk-!-padding-bottom-7"><strong>There is currently no fee data available to display.</strong></p>
             {{ else }}
             <table class="govuk-table my-table table__no-border">
                 <tbody class="govuk-table__body">

--- a/web/template/payments.gohtml
+++ b/web/template/payments.gohtml
@@ -37,7 +37,7 @@
                                 <td class="govuk-table__cell"><strong>£{{ fee .Amount }}</strong></td>
                             </tr>
                             <tr class="govuk-table__row">
-                                <th scope="row" class="govuk-table__header">Date:</th>
+                                <th scope="row" class="govuk-table__header">Date of payment:</th>
                                 <td class="govuk-table__cell">{{ .PaymentDate }}</td>
                             </tr>
                             <tr class="govuk-table__row">

--- a/web/template/payments.gohtml
+++ b/web/template/payments.gohtml
@@ -8,7 +8,7 @@
             <h1 class="govuk-heading-s govuk-!-padding-bottom-2"><strong>{{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "lpa" }}LPA{{ end }} {{ .Case.UID }}</strong></h1>
 
             {{ if not .Payments }}
-            <h2 class="govuk-body govuk-!-padding-top-7 govuk-!-padding-bottom-7"><strong>There is currently no fee data available to display.</strong></h2>
+            <p class="govuk-!-padding-top-7 govuk-!-padding-bottom-7"><strong>There is currently no fee data available to display.</strong></p>
             {{ else }}
             <table class="govuk-table my-table table__no-border">
                 <tbody class="govuk-table__body">
@@ -19,7 +19,7 @@
                 </tbody>
             </table>
 
-            <h3 class="govuk-heading-m govuk-!-padding-top-3 govuk-!-padding-bottom-2"><strong>Fee details</strong></h3>
+            <h2 class="govuk-heading-m govuk-!-padding-top-3 govuk-!-padding-bottom-2">Fee details</h2>
 
             <details class="govuk-details" data-module="govuk-details">
                 <summary class="govuk-details__summary">
@@ -30,7 +30,7 @@
                 <div class="govuk-details__text">
 
                     {{ range $i, $p := .Payments }}
-                    <table class="govuk-table my-table table__no-border">
+                    <table class="govuk-table table__no-border">
                         <tbody class="govuk-table__body">
                             <tr class="govuk-table__row">
                                 <th scope="row" class="govuk-table__header">Amount:</th>


### PR DESCRIPTION
Content and styling tweaks
Previously missed the fact that if you enter amount in an incorrect format and enter nothing for either source or payment date, a validation error message is shown for the amount however the source and payment date do not show any validation error messages because they were only being validated when we send the request to the API. Added in logic to correct this
VEGA-1467 #patch