### PR TITLE
Include Correlation ID in error pages, if set

### DIFF
--- a/internal/sirius/client.go
+++ b/internal/sirius/client.go
@@ -73,16 +73,18 @@ func (c *Client) get(ctx Context, path string, v interface{}) error {
 }
 
 type StatusError struct {
-	Code   int    `json:"code"`
-	URL    string `json:"url"`
-	Method string `json:"method"`
+	Code          int    `json:"code"`
+	URL           string `json:"url"`
+	Method        string `json:"method"`
+	CorrelationId string
 }
 
 func newStatusError(resp *http.Response) StatusError {
 	return StatusError{
-		Code:   resp.StatusCode,
-		URL:    resp.Request.URL.String(),
-		Method: resp.Request.Method,
+		Code:          resp.StatusCode,
+		URL:           resp.Request.URL.String(),
+		Method:        resp.Request.Method,
+		CorrelationId: resp.Header.Get("Correlation-Id"),
 	}
 }
 

--- a/web/template/error.gohtml
+++ b/web/template/error.gohtml
@@ -40,6 +40,9 @@ Sorry, there is a problem with the service
         {{ if .Error }}
         <p class="govuk-body"><strong>Further information:</strong> {{ .Error }}</p>
         {{ end }}
+        {{ if .CorrelationId }}
+        <p class="govuk-body"><strong>Correlation ID:</strong> {{ .CorrelationId }}</p>
+        {{ end }}
         {{ end }}
     </div>
 </div>


### PR DESCRIPTION
If an API response has a Correlation-Id header, include it in the error response page.

Fixes VEGA-1473 #minor