### PR TITLE
VEGA-1453 Retrieve case data from the payment api endpoint

### DIFF
--- a/cypress/e2e/edit-payment.cy.js
+++ b/cypress/e2e/edit-payment.cy.js
@@ -1,6 +1,6 @@
 describe("Edit a payment", () => {
     beforeEach(() => {
-        cy.visit("/edit-payment?id=800&payment=123");
+        cy.visit("/edit-payment?payment=123");
     });
 
     it("edits a payment on the case", () => {

--- a/internal/server/edit_payment.go
+++ b/internal/server/edit_payment.go
@@ -28,7 +28,7 @@ type editPaymentData struct {
 
 func EditPayment(client EditPaymentClient, tmpl template.Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
-		caseID, err := strconv.Atoi(r.FormValue("id"))
+		_, err := strconv.Atoi(r.FormValue("id"))
 		if err != nil {
 			return err
 		}
@@ -51,7 +51,7 @@ func EditPayment(client EditPaymentClient, tmpl template.Template) Handler {
 			PaymentDate: p.PaymentDate,
 		}
 
-		data.Case, err = client.Case(ctx, caseID)
+		data.Case, err = client.Case(ctx, p.Case.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/server/edit_payment.go
+++ b/internal/server/edit_payment.go
@@ -11,7 +11,7 @@ import (
 type EditPaymentClient interface {
 	EditPayment(ctx sirius.Context, paymentID int, payment sirius.Payment) error
 	Case(sirius.Context, int) (sirius.Case, error)
-	PaymentByID(ctx sirius.Context, id int) (sirius.PaymentDetails, error)
+	PaymentByID(ctx sirius.Context, id int) (sirius.Payment, error)
 }
 
 type editPaymentData struct {
@@ -28,7 +28,7 @@ type editPaymentData struct {
 
 func EditPayment(client EditPaymentClient, tmpl template.Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
-		_, err := strconv.Atoi(r.FormValue("id"))
+		caseID, err := strconv.Atoi(r.FormValue("id"))
 		if err != nil {
 			return err
 		}
@@ -38,7 +38,7 @@ func EditPayment(client EditPaymentClient, tmpl template.Template) Handler {
 		}
 
 		ctx := getContext(r)
-		pd, err := client.PaymentByID(ctx, paymentID)
+		p, err := client.PaymentByID(ctx, paymentID)
 		if err != nil {
 			return err
 		}
@@ -46,12 +46,12 @@ func EditPayment(client EditPaymentClient, tmpl template.Template) Handler {
 		data := editPaymentData{
 			XSRFToken:   ctx.XSRFToken,
 			PaymentID:   paymentID,
-			Amount:      fmt.Sprintf("%.2f", sirius.PenceToPounds(pd.Payment.Amount)),
-			Source:      pd.Payment.Source,
-			PaymentDate: pd.Payment.PaymentDate,
+			Amount:      fmt.Sprintf("%.2f", sirius.PenceToPounds(p.Amount)),
+			Source:      p.Source,
+			PaymentDate: p.PaymentDate,
 		}
 
-		data.Case, err = client.Case(ctx, pd.CaseId)
+		data.Case, err = client.Case(ctx, caseID)
 		if err != nil {
 			return err
 		}

--- a/internal/server/edit_payment.go
+++ b/internal/server/edit_payment.go
@@ -28,10 +28,6 @@ type editPaymentData struct {
 
 func EditPayment(client EditPaymentClient, tmpl template.Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
-		_, err := strconv.Atoi(r.FormValue("id"))
-		if err != nil {
-			return err
-		}
 		paymentID, err := strconv.Atoi(r.FormValue("payment"))
 		if err != nil {
 			return err

--- a/internal/server/edit_payment.go
+++ b/internal/server/edit_payment.go
@@ -11,7 +11,7 @@ import (
 type EditPaymentClient interface {
 	EditPayment(ctx sirius.Context, paymentID int, payment sirius.Payment) error
 	Case(sirius.Context, int) (sirius.Case, error)
-	PaymentByID(ctx sirius.Context, id int) (sirius.Payment, error)
+	PaymentByID(ctx sirius.Context, id int) (sirius.PaymentDetails, error)
 }
 
 type editPaymentData struct {
@@ -28,7 +28,7 @@ type editPaymentData struct {
 
 func EditPayment(client EditPaymentClient, tmpl template.Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
-		caseID, err := strconv.Atoi(r.FormValue("id"))
+		_, err := strconv.Atoi(r.FormValue("id"))
 		if err != nil {
 			return err
 		}
@@ -38,7 +38,7 @@ func EditPayment(client EditPaymentClient, tmpl template.Template) Handler {
 		}
 
 		ctx := getContext(r)
-		p, err := client.PaymentByID(ctx, paymentID)
+		pd, err := client.PaymentByID(ctx, paymentID)
 		if err != nil {
 			return err
 		}
@@ -46,12 +46,12 @@ func EditPayment(client EditPaymentClient, tmpl template.Template) Handler {
 		data := editPaymentData{
 			XSRFToken:   ctx.XSRFToken,
 			PaymentID:   paymentID,
-			Amount:      fmt.Sprintf("%.2f", sirius.PenceToPounds(p.Amount)),
-			Source:      p.Source,
-			PaymentDate: p.PaymentDate,
+			Amount:      fmt.Sprintf("%.2f", sirius.PenceToPounds(pd.Payment.Amount)),
+			Source:      pd.Payment.Source,
+			PaymentDate: pd.Payment.PaymentDate,
 		}
 
-		data.Case, err = client.Case(ctx, caseID)
+		data.Case, err = client.Case(ctx, pd.CaseId)
 		if err != nil {
 			return err
 		}

--- a/internal/server/edit_payment_test.go
+++ b/internal/server/edit_payment_test.go
@@ -16,9 +16,9 @@ type mockEditPaymentClient struct {
 	mock.Mock
 }
 
-func (m *mockEditPaymentClient) PaymentByID(ctx sirius.Context, id int) (sirius.Payment, error) {
+func (m *mockEditPaymentClient) PaymentByID(ctx sirius.Context, id int) (sirius.PaymentDetails, error) {
 	args := m.Called(ctx, id)
-	return args.Get(0).(sirius.Payment), args.Error(1)
+	return args.Get(0).(sirius.PaymentDetails), args.Error(1)
 }
 
 func (m *mockEditPaymentClient) EditPayment(ctx sirius.Context, paymentID int, payment sirius.Payment) error {
@@ -36,11 +36,14 @@ func TestGetEditPayment(t *testing.T) {
 		SubType: "pfa",
 	}
 
-	payment := sirius.Payment{
-		ID:          123,
-		Amount:      8200,
-		Source:      "PHONE",
-		PaymentDate: sirius.DateString("2022-07-23"),
+	paymentDetails := sirius.PaymentDetails{
+		CaseId: 4,
+		Payment: sirius.Payment{
+			ID:          123,
+			Amount:      8200,
+			Source:      "PHONE",
+			PaymentDate: sirius.DateString("2022-07-23"),
+		},
 	}
 
 	client := &mockEditPaymentClient{}
@@ -49,7 +52,7 @@ func TestGetEditPayment(t *testing.T) {
 		Return(caseItem, nil)
 	client.
 		On("PaymentByID", mock.Anything, 123).
-		Return(payment, nil)
+		Return(paymentDetails, nil)
 
 	template := &mockTemplate{}
 	template.
@@ -100,7 +103,7 @@ func TestEditPaymentWhenFailureOnGetPaymentByID(t *testing.T) {
 	client := &mockEditPaymentClient{}
 	client.
 		On("PaymentByID", mock.Anything, 123).
-		Return(sirius.Payment{}, expectedError)
+		Return(sirius.PaymentDetails{}, expectedError)
 
 	r, _ := http.NewRequest(http.MethodGet, "/?id=4&payment=123", nil)
 	w := httptest.NewRecorder()
@@ -114,17 +117,20 @@ func TestEditPaymentWhenFailureOnGetPaymentByID(t *testing.T) {
 func TestEditPaymentWhenFailureOnGetCase(t *testing.T) {
 	expectedError := errors.New("err")
 
-	payment := sirius.Payment{
-		ID:          123,
-		Amount:      8200,
-		Source:      "PHONE",
-		PaymentDate: sirius.DateString("2022-07-23"),
+	paymentDetails := sirius.PaymentDetails{
+		CaseId: 4,
+		Payment: sirius.Payment{
+			ID:          123,
+			Amount:      8200,
+			Source:      "PHONE",
+			PaymentDate: sirius.DateString("2022-07-23"),
+		},
 	}
 
 	client := &mockEditPaymentClient{}
 	client.
 		On("PaymentByID", mock.Anything, 123).
-		Return(payment, nil)
+		Return(paymentDetails, nil)
 	client.
 		On("Case", mock.Anything, 4).
 		Return(sirius.Case{}, expectedError)
@@ -144,17 +150,20 @@ func TestEditPaymentWhenTemplateErrors(t *testing.T) {
 		SubType: "pfa",
 	}
 
-	payment := sirius.Payment{
-		ID:          123,
-		Amount:      8200,
-		Source:      "PHONE",
-		PaymentDate: sirius.DateString("2022-07-23"),
+	paymentDetails := sirius.PaymentDetails{
+		CaseId: 4,
+		Payment: sirius.Payment{
+			ID:          123,
+			Amount:      8200,
+			Source:      "PHONE",
+			PaymentDate: sirius.DateString("2022-07-23"),
+		},
 	}
 
 	client := &mockEditPaymentClient{}
 	client.
 		On("PaymentByID", mock.Anything, 123).
-		Return(payment, nil)
+		Return(paymentDetails, nil)
 	client.
 		On("Case", mock.Anything, 4).
 		Return(caseItem, nil)
@@ -186,17 +195,20 @@ func TestPostEditPaymentAmountIncorrectFormat(t *testing.T) {
 		t.Run(amount, func(t *testing.T) {
 			caseItem := sirius.Case{CaseType: "lpa", UID: "700700"}
 
-			payment := sirius.Payment{
-				ID:          123,
-				Amount:      8200,
-				Source:      "PHONE",
-				PaymentDate: sirius.DateString("2022-07-23"),
+			paymentDetails := sirius.PaymentDetails{
+				CaseId: 4,
+				Payment: sirius.Payment{
+					ID:          123,
+					Amount:      8200,
+					Source:      "PHONE",
+					PaymentDate: sirius.DateString("2022-07-23"),
+				},
 			}
 
 			client := &mockEditPaymentClient{}
 			client.
 				On("PaymentByID", mock.Anything, 123).
-				Return(payment, nil)
+				Return(paymentDetails, nil)
 			client.
 				On("Case", mock.Anything, 4).
 				Return(caseItem, nil)
@@ -243,11 +255,14 @@ func TestPostEditPaymentAmountIncorrectFormat(t *testing.T) {
 func TestPostEditPayment(t *testing.T) {
 	caseItem := sirius.Case{CaseType: "lpa", UID: "700700"}
 
-	payment := sirius.Payment{
-		ID:          123,
-		Amount:      8200,
-		Source:      "PHONE",
-		PaymentDate: sirius.DateString("2022-02-18"),
+	paymentDetails := sirius.PaymentDetails{
+		CaseId: 4,
+		Payment: sirius.Payment{
+			ID:          123,
+			Amount:      8200,
+			Source:      "PHONE",
+			PaymentDate: sirius.DateString("2022-02-18"),
+		},
 	}
 
 	editedPayment := sirius.Payment{
@@ -259,7 +274,7 @@ func TestPostEditPayment(t *testing.T) {
 	client := &mockEditPaymentClient{}
 	client.
 		On("PaymentByID", mock.Anything, 123).
-		Return(payment, nil)
+		Return(paymentDetails, nil)
 	client.
 		On("Case", mock.Anything, 4).
 		Return(caseItem, nil)

--- a/internal/server/edit_payment_test.go
+++ b/internal/server/edit_payment_test.go
@@ -63,7 +63,7 @@ func TestGetEditPayment(t *testing.T) {
 		}).
 		Return(nil)
 
-	r, _ := http.NewRequest(http.MethodGet, "/?id=4&payment=123", nil)
+	r, _ := http.NewRequest(http.MethodGet, "/?payment=123", nil)
 	w := httptest.NewRecorder()
 
 	err := EditPayment(client, template.Func)(w, r)
@@ -74,27 +74,6 @@ func TestGetEditPayment(t *testing.T) {
 	mock.AssertExpectationsForObjects(t, client, template)
 }
 
-func TestEditPaymentInvalidURLParams(t *testing.T) {
-	testCases := map[string]string{
-		"no-params":      "/",
-		"no-case-id":     "/?payment=123",
-		"no-payment-id":  "/?id=2",
-		"bad-case- id":   "/?id=test&payment=123",
-		"bad-payment-id": "/?id=2&payment=test",
-	}
-
-	for name, testUrl := range testCases {
-		t.Run(name, func(t *testing.T) {
-			r, _ := http.NewRequest(http.MethodGet, testUrl, nil)
-			w := httptest.NewRecorder()
-
-			err := EditPayment(nil, nil)(w, r)
-
-			assert.NotNil(t, err)
-		})
-	}
-}
-
 func TestEditPaymentWhenFailureOnGetPaymentByID(t *testing.T) {
 	expectedError := errors.New("err")
 
@@ -103,7 +82,7 @@ func TestEditPaymentWhenFailureOnGetPaymentByID(t *testing.T) {
 		On("PaymentByID", mock.Anything, 123).
 		Return(sirius.Payment{}, expectedError)
 
-	r, _ := http.NewRequest(http.MethodGet, "/?id=4&payment=123", nil)
+	r, _ := http.NewRequest(http.MethodGet, "/?payment=123", nil)
 	w := httptest.NewRecorder()
 
 	err := EditPayment(client, nil)(w, r)
@@ -131,7 +110,7 @@ func TestEditPaymentWhenFailureOnGetCase(t *testing.T) {
 		On("Case", mock.Anything, 4).
 		Return(sirius.Case{}, expectedError)
 
-	r, _ := http.NewRequest(http.MethodGet, "/?id=4&payment=123", nil)
+	r, _ := http.NewRequest(http.MethodGet, "/?payment=123", nil)
 	w := httptest.NewRecorder()
 
 	err := EditPayment(client, nil)(w, r)
@@ -175,7 +154,7 @@ func TestEditPaymentWhenTemplateErrors(t *testing.T) {
 		}).
 		Return(expectedError)
 
-	r, _ := http.NewRequest(http.MethodGet, "/?id=4&payment=123", nil)
+	r, _ := http.NewRequest(http.MethodGet, "/?payment=123", nil)
 	w := httptest.NewRecorder()
 
 	err := EditPayment(client, template.Func)(w, r)
@@ -230,7 +209,7 @@ func TestPostEditPaymentAmountIncorrectFormat(t *testing.T) {
 				"paymentDate": {"2022-01-23"},
 			}
 
-			r, _ := http.NewRequest(http.MethodPost, "/?id=4&payment=123", strings.NewReader(form.Encode()))
+			r, _ := http.NewRequest(http.MethodPost, "/?payment=123", strings.NewReader(form.Encode()))
 			r.Header.Add("Content-Type", formUrlEncoded)
 			w := httptest.NewRecorder()
 
@@ -290,7 +269,7 @@ func TestPostEditPayment(t *testing.T) {
 		"paymentDate": {"2022-02-18"},
 	}
 
-	r, _ := http.NewRequest(http.MethodPost, "/?id=4&payment=123", strings.NewReader(form.Encode()))
+	r, _ := http.NewRequest(http.MethodPost, "/?payment=123", strings.NewReader(form.Encode()))
 	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 

--- a/internal/server/edit_payment_test.go
+++ b/internal/server/edit_payment_test.go
@@ -16,9 +16,9 @@ type mockEditPaymentClient struct {
 	mock.Mock
 }
 
-func (m *mockEditPaymentClient) PaymentByID(ctx sirius.Context, id int) (sirius.PaymentDetails, error) {
+func (m *mockEditPaymentClient) PaymentByID(ctx sirius.Context, id int) (sirius.Payment, error) {
 	args := m.Called(ctx, id)
-	return args.Get(0).(sirius.PaymentDetails), args.Error(1)
+	return args.Get(0).(sirius.Payment), args.Error(1)
 }
 
 func (m *mockEditPaymentClient) EditPayment(ctx sirius.Context, paymentID int, payment sirius.Payment) error {
@@ -36,14 +36,11 @@ func TestGetEditPayment(t *testing.T) {
 		SubType: "pfa",
 	}
 
-	paymentDetails := sirius.PaymentDetails{
-		CaseId: 4,
-		Payment: sirius.Payment{
-			ID:          123,
-			Amount:      8200,
-			Source:      "PHONE",
-			PaymentDate: sirius.DateString("2022-07-23"),
-		},
+	payment := sirius.Payment{
+		ID:          123,
+		Amount:      8200,
+		Source:      "PHONE",
+		PaymentDate: sirius.DateString("2022-07-23"),
 	}
 
 	client := &mockEditPaymentClient{}
@@ -52,7 +49,7 @@ func TestGetEditPayment(t *testing.T) {
 		Return(caseItem, nil)
 	client.
 		On("PaymentByID", mock.Anything, 123).
-		Return(paymentDetails, nil)
+		Return(payment, nil)
 
 	template := &mockTemplate{}
 	template.
@@ -103,7 +100,7 @@ func TestEditPaymentWhenFailureOnGetPaymentByID(t *testing.T) {
 	client := &mockEditPaymentClient{}
 	client.
 		On("PaymentByID", mock.Anything, 123).
-		Return(sirius.PaymentDetails{}, expectedError)
+		Return(sirius.Payment{}, expectedError)
 
 	r, _ := http.NewRequest(http.MethodGet, "/?id=4&payment=123", nil)
 	w := httptest.NewRecorder()
@@ -117,20 +114,17 @@ func TestEditPaymentWhenFailureOnGetPaymentByID(t *testing.T) {
 func TestEditPaymentWhenFailureOnGetCase(t *testing.T) {
 	expectedError := errors.New("err")
 
-	paymentDetails := sirius.PaymentDetails{
-		CaseId: 4,
-		Payment: sirius.Payment{
-			ID:          123,
-			Amount:      8200,
-			Source:      "PHONE",
-			PaymentDate: sirius.DateString("2022-07-23"),
-		},
+	payment := sirius.Payment{
+		ID:          123,
+		Amount:      8200,
+		Source:      "PHONE",
+		PaymentDate: sirius.DateString("2022-07-23"),
 	}
 
 	client := &mockEditPaymentClient{}
 	client.
 		On("PaymentByID", mock.Anything, 123).
-		Return(paymentDetails, nil)
+		Return(payment, nil)
 	client.
 		On("Case", mock.Anything, 4).
 		Return(sirius.Case{}, expectedError)
@@ -150,20 +144,17 @@ func TestEditPaymentWhenTemplateErrors(t *testing.T) {
 		SubType: "pfa",
 	}
 
-	paymentDetails := sirius.PaymentDetails{
-		CaseId: 4,
-		Payment: sirius.Payment{
-			ID:          123,
-			Amount:      8200,
-			Source:      "PHONE",
-			PaymentDate: sirius.DateString("2022-07-23"),
-		},
+	payment := sirius.Payment{
+		ID:          123,
+		Amount:      8200,
+		Source:      "PHONE",
+		PaymentDate: sirius.DateString("2022-07-23"),
 	}
 
 	client := &mockEditPaymentClient{}
 	client.
 		On("PaymentByID", mock.Anything, 123).
-		Return(paymentDetails, nil)
+		Return(payment, nil)
 	client.
 		On("Case", mock.Anything, 4).
 		Return(caseItem, nil)
@@ -195,20 +186,17 @@ func TestPostEditPaymentAmountIncorrectFormat(t *testing.T) {
 		t.Run(amount, func(t *testing.T) {
 			caseItem := sirius.Case{CaseType: "lpa", UID: "700700"}
 
-			paymentDetails := sirius.PaymentDetails{
-				CaseId: 4,
-				Payment: sirius.Payment{
-					ID:          123,
-					Amount:      8200,
-					Source:      "PHONE",
-					PaymentDate: sirius.DateString("2022-07-23"),
-				},
+			payment := sirius.Payment{
+				ID:          123,
+				Amount:      8200,
+				Source:      "PHONE",
+				PaymentDate: sirius.DateString("2022-07-23"),
 			}
 
 			client := &mockEditPaymentClient{}
 			client.
 				On("PaymentByID", mock.Anything, 123).
-				Return(paymentDetails, nil)
+				Return(payment, nil)
 			client.
 				On("Case", mock.Anything, 4).
 				Return(caseItem, nil)
@@ -255,14 +243,11 @@ func TestPostEditPaymentAmountIncorrectFormat(t *testing.T) {
 func TestPostEditPayment(t *testing.T) {
 	caseItem := sirius.Case{CaseType: "lpa", UID: "700700"}
 
-	paymentDetails := sirius.PaymentDetails{
-		CaseId: 4,
-		Payment: sirius.Payment{
-			ID:          123,
-			Amount:      8200,
-			Source:      "PHONE",
-			PaymentDate: sirius.DateString("2022-02-18"),
-		},
+	payment := sirius.Payment{
+		ID:          123,
+		Amount:      8200,
+		Source:      "PHONE",
+		PaymentDate: sirius.DateString("2022-02-18"),
 	}
 
 	editedPayment := sirius.Payment{
@@ -274,7 +259,7 @@ func TestPostEditPayment(t *testing.T) {
 	client := &mockEditPaymentClient{}
 	client.
 		On("PaymentByID", mock.Anything, 123).
-		Return(paymentDetails, nil)
+		Return(payment, nil)
 	client.
 		On("Case", mock.Anything, 4).
 		Return(caseItem, nil)

--- a/internal/server/edit_payment_test.go
+++ b/internal/server/edit_payment_test.go
@@ -41,6 +41,7 @@ func TestGetEditPayment(t *testing.T) {
 		Amount:      8200,
 		Source:      "PHONE",
 		PaymentDate: sirius.DateString("2022-07-23"),
+		Case:        &sirius.Case{ID: 4},
 	}
 
 	client := &mockEditPaymentClient{}
@@ -119,6 +120,7 @@ func TestEditPaymentWhenFailureOnGetCase(t *testing.T) {
 		Amount:      8200,
 		Source:      "PHONE",
 		PaymentDate: sirius.DateString("2022-07-23"),
+		Case:        &sirius.Case{ID: 4},
 	}
 
 	client := &mockEditPaymentClient{}
@@ -149,6 +151,7 @@ func TestEditPaymentWhenTemplateErrors(t *testing.T) {
 		Amount:      8200,
 		Source:      "PHONE",
 		PaymentDate: sirius.DateString("2022-07-23"),
+		Case:        &sirius.Case{ID: 4},
 	}
 
 	client := &mockEditPaymentClient{}
@@ -191,6 +194,7 @@ func TestPostEditPaymentAmountIncorrectFormat(t *testing.T) {
 				Amount:      8200,
 				Source:      "PHONE",
 				PaymentDate: sirius.DateString("2022-07-23"),
+				Case:        &sirius.Case{ID: 4},
 			}
 
 			client := &mockEditPaymentClient{}
@@ -248,6 +252,7 @@ func TestPostEditPayment(t *testing.T) {
 		Amount:      8200,
 		Source:      "PHONE",
 		PaymentDate: sirius.DateString("2022-02-18"),
+		Case:        &sirius.Case{ID: 4},
 	}
 
 	editedPayment := sirius.Payment{

--- a/internal/sirius/payment.go
+++ b/internal/sirius/payment.go
@@ -10,6 +10,7 @@ type Payment struct {
 	Source      string     `json:"source"`
 	Amount      int        `json:"amount"`
 	PaymentDate DateString `json:"paymentDate"`
+	Case        *Case      `json:"case,omitempty"`
 }
 
 func (c *Client) Payments(ctx Context, id int) ([]Payment, error) {

--- a/internal/sirius/payment.go
+++ b/internal/sirius/payment.go
@@ -12,6 +12,11 @@ type Payment struct {
 	PaymentDate DateString `json:"paymentDate"`
 }
 
+type PaymentDetails struct {
+	CaseId      int     `json:"caseId"`
+	Payment     Payment `json:"payment"`
+}
+
 func (c *Client) Payments(ctx Context, id int) ([]Payment, error) {
 	var p []Payment
 
@@ -23,8 +28,8 @@ func (c *Client) Payments(ctx Context, id int) ([]Payment, error) {
 	return p, nil
 }
 
-func (c *Client) PaymentByID(ctx Context, id int) (Payment, error) {
-	var p Payment
+func (c *Client) PaymentByID(ctx Context, id int) (PaymentDetails, error) {
+	var p PaymentDetails
 	err := c.get(ctx, fmt.Sprintf("/lpa-api/v1/payments/%d", id), &p)
 
 	return p, err

--- a/internal/sirius/payment.go
+++ b/internal/sirius/payment.go
@@ -12,11 +12,6 @@ type Payment struct {
 	PaymentDate DateString `json:"paymentDate"`
 }
 
-type PaymentDetails struct {
-	CaseId      int     `json:"caseId"`
-	Payment     Payment `json:"payment"`
-}
-
 func (c *Client) Payments(ctx Context, id int) ([]Payment, error) {
 	var p []Payment
 
@@ -28,8 +23,8 @@ func (c *Client) Payments(ctx Context, id int) ([]Payment, error) {
 	return p, nil
 }
 
-func (c *Client) PaymentByID(ctx Context, id int) (PaymentDetails, error) {
-	var p PaymentDetails
+func (c *Client) PaymentByID(ctx Context, id int) (Payment, error) {
+	var p Payment
 	err := c.get(ctx, fmt.Sprintf("/lpa-api/v1/payments/%d", id), &p)
 
 	return p, err

--- a/internal/sirius/payment_test.go
+++ b/internal/sirius/payment_test.go
@@ -39,6 +39,9 @@ func TestPayment(t *testing.T) {
 							"source":      dsl.Like("MAKE"),
 							"amount":      dsl.Like(4100),
 							"paymentDate": dsl.String("23/01/2022"),
+							"case": dsl.Like(map[string]interface{}{
+								"id": dsl.Like(9),
+							}),
 						}, 1),
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
@@ -49,6 +52,7 @@ func TestPayment(t *testing.T) {
 					Source:      "MAKE",
 					Amount:      4100,
 					PaymentDate: DateString("2022-01-23"),
+					Case:        &Case{ID: 9},
 				},
 			},
 		},
@@ -106,6 +110,9 @@ func TestPaymentByID(t *testing.T) {
 							"source":      dsl.Like("PHONE"),
 							"amount":      dsl.Like(4100),
 							"paymentDate": dsl.String("23/01/2022"),
+							"case": dsl.Like(map[string]interface{}{
+								"id": dsl.Like(800),
+							}),
 						}),
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
@@ -115,6 +122,7 @@ func TestPaymentByID(t *testing.T) {
 				Source:      "PHONE",
 				Amount:      4100,
 				PaymentDate: DateString("2022-01-23"),
+				Case:        &Case{ID: 800},
 			},
 		},
 	}

--- a/internal/sirius/payment_test.go
+++ b/internal/sirius/payment_test.go
@@ -86,7 +86,7 @@ func TestPaymentByID(t *testing.T) {
 		setup            func()
 		cookies          []*http.Cookie
 		expectedError    func(int) error
-		expectedResponse Payment
+		expectedResponse PaymentDetails
 	}{
 		{
 			name: "OK",
@@ -102,19 +102,25 @@ func TestPaymentByID(t *testing.T) {
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
 						Body: dsl.Like(map[string]interface{}{
-							"id":          dsl.Like(123),
-							"source":      dsl.Like("PHONE"),
-							"amount":      dsl.Like(4100),
-							"paymentDate": dsl.String("23/01/2022"),
+							"caseId":          dsl.Like(1),
+							"payment": dsl.Like(map[string]interface{}{
+								"id":          dsl.Like(123),
+								"source":      dsl.Like("PHONE"),
+								"amount":      dsl.Like(4100),
+								"paymentDate": dsl.String("23/01/2022"),
+							}),
 						}),
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			expectedResponse: Payment{
-				ID:          123,
-				Source:      "PHONE",
-				Amount:      4100,
-				PaymentDate: DateString("2022-01-23"),
+			expectedResponse: PaymentDetails{
+				1,
+				Payment{
+					ID:          123,
+					Source:      "PHONE",
+					Amount:      4100,
+					PaymentDate: DateString("2022-01-23"),
+				},
 			},
 		},
 	}

--- a/internal/sirius/payment_test.go
+++ b/internal/sirius/payment_test.go
@@ -86,7 +86,7 @@ func TestPaymentByID(t *testing.T) {
 		setup            func()
 		cookies          []*http.Cookie
 		expectedError    func(int) error
-		expectedResponse PaymentDetails
+		expectedResponse Payment
 	}{
 		{
 			name: "OK",
@@ -102,25 +102,19 @@ func TestPaymentByID(t *testing.T) {
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
 						Body: dsl.Like(map[string]interface{}{
-							"caseId":          dsl.Like(1),
-							"payment": dsl.Like(map[string]interface{}{
-								"id":          dsl.Like(123),
-								"source":      dsl.Like("PHONE"),
-								"amount":      dsl.Like(4100),
-								"paymentDate": dsl.String("23/01/2022"),
-							}),
+							"id":          dsl.Like(123),
+							"source":      dsl.Like("PHONE"),
+							"amount":      dsl.Like(4100),
+							"paymentDate": dsl.String("23/01/2022"),
 						}),
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},
-			expectedResponse: PaymentDetails{
-				1,
-				Payment{
-					ID:          123,
-					Source:      "PHONE",
-					Amount:      4100,
-					PaymentDate: DateString("2022-01-23"),
-				},
+			expectedResponse: Payment{
+				ID:          123,
+				Source:      "PHONE",
+				Amount:      4100,
+				PaymentDate: DateString("2022-01-23"),
 			},
 		},
 	}


### PR DESCRIPTION
Case id is now returned along with the payment information when retrieving a payment by id. This is to prevent users from potentially being able to amend the url param to return payment data for a different case and display unrelated case data for the payment.

#minor