### PR TITLE
VEGA-1448 Allow payments by cheque

### DIFF
--- a/cypress/e2e/edit-payment.cy.js
+++ b/cypress/e2e/edit-payment.cy.js
@@ -1,6 +1,6 @@
 describe("Edit a payment", () => {
     beforeEach(() => {
-        cy.visit("/edit-payment?payment=123");
+        cy.visit("/edit-payment?id=123");
     });
 
     it("edits a payment on the case", () => {

--- a/internal/server/edit_payment.go
+++ b/internal/server/edit_payment.go
@@ -30,7 +30,7 @@ type editPaymentData struct {
 
 func EditPayment(client EditPaymentClient, tmpl template.Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
-		paymentID, err := strconv.Atoi(r.FormValue("payment"))
+		paymentID, err := strconv.Atoi(r.FormValue("id"))
 		if err != nil {
 			return err
 		}

--- a/internal/server/edit_payment_test.go
+++ b/internal/server/edit_payment_test.go
@@ -83,7 +83,7 @@ func TestGetEditPayment(t *testing.T) {
 		}).
 		Return(nil)
 
-	r, _ := http.NewRequest(http.MethodGet, "/?payment=123", nil)
+	r, _ := http.NewRequest(http.MethodGet, "/?id=123", nil)
 	w := httptest.NewRecorder()
 
 	err := EditPayment(client, template.Func)(w, r)
@@ -102,7 +102,7 @@ func TestEditPaymentWhenFailureOnGetPaymentByID(t *testing.T) {
 		On("PaymentByID", mock.Anything, 123).
 		Return(sirius.Payment{}, expectedError)
 
-	r, _ := http.NewRequest(http.MethodGet, "/?payment=123", nil)
+	r, _ := http.NewRequest(http.MethodGet, "/?id=123", nil)
 	w := httptest.NewRecorder()
 
 	err := EditPayment(client, nil)(w, r)
@@ -130,7 +130,7 @@ func TestEditPaymentWhenFailureOnGetCase(t *testing.T) {
 		On("Case", mock.Anything, 4).
 		Return(sirius.Case{}, expectedError)
 
-	r, _ := http.NewRequest(http.MethodGet, "/?payment=123", nil)
+	r, _ := http.NewRequest(http.MethodGet, "/?id=123", nil)
 	w := httptest.NewRecorder()
 
 	err := EditPayment(client, nil)(w, r)
@@ -150,6 +150,7 @@ func TestEditPaymentWhenFailureOnGetPaymentSourceRefData(t *testing.T) {
 		Amount:      8200,
 		Source:      "PHONE",
 		PaymentDate: sirius.DateString("2022-07-23"),
+		Case:        &sirius.Case{ID: 4},
 	}
 
 	expectedError := errors.New("err")
@@ -165,7 +166,7 @@ func TestEditPaymentWhenFailureOnGetPaymentSourceRefData(t *testing.T) {
 		On("RefDataByCategory", mock.Anything, sirius.PaymentSourceCategory).
 		Return([]sirius.RefDataItem{}, expectedError)
 
-	r, _ := http.NewRequest(http.MethodGet, "/?id=4&payment=123", nil)
+	r, _ := http.NewRequest(http.MethodGet, "/?id=123", nil)
 	w := httptest.NewRecorder()
 
 	err := EditPayment(client, nil)(w, r)
@@ -221,7 +222,7 @@ func TestEditPaymentWhenTemplateErrors(t *testing.T) {
 		}).
 		Return(expectedError)
 
-	r, _ := http.NewRequest(http.MethodGet, "/?payment=123", nil)
+	r, _ := http.NewRequest(http.MethodGet, "/?id=123", nil)
 	w := httptest.NewRecorder()
 
 	err := EditPayment(client, template.Func)(w, r)
@@ -288,7 +289,7 @@ func TestPostEditPaymentAmountIncorrectFormat(t *testing.T) {
 				"paymentDate": {"2022-01-23"},
 			}
 
-			r, _ := http.NewRequest(http.MethodPost, "/?payment=123", strings.NewReader(form.Encode()))
+			r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
 			r.Header.Add("Content-Type", formUrlEncoded)
 			w := httptest.NewRecorder()
 
@@ -360,7 +361,7 @@ func TestPostEditPayment(t *testing.T) {
 		"paymentDate": {"2022-02-18"},
 	}
 
-	r, _ := http.NewRequest(http.MethodPost, "/?payment=123", strings.NewReader(form.Encode()))
+	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
 	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 

--- a/internal/sirius/payment.go
+++ b/internal/sirius/payment.go
@@ -11,6 +11,7 @@ type Payment struct {
 	Amount      int        `json:"amount"`
 	PaymentDate DateString `json:"paymentDate"`
 	Case        *Case      `json:"case,omitempty"`
+	Locked      bool       `json:"locked,omitempty"`
 }
 
 func (c *Client) Payments(ctx Context, id int) ([]Payment, error) {

--- a/web/template/payments.gohtml
+++ b/web/template/payments.gohtml
@@ -48,10 +48,10 @@
                                     {{ end }}
                                 </td>
                             </tr>
-                            {{ if or (eq .Source "PHONE") (eq .Source "ONLINE") }}
+                            {{ if not .Locked }}
                             <tr class="govuk-table__row">
                                 <th scope="row" class="govuk-table__header table-row__no-border">
-                                    <a class="govuk-link" href="{{ prefix (printf "/edit-payment?id=%d&payment=%d" $.Case.ID .ID) }}">
+                                    <a class="govuk-link" href="{{ prefix (printf "/edit-payment?id=%d" .ID) }}">
                                         Edit payment
                                     </a>
                                 </th>


### PR DESCRIPTION
Enabled cheque payments to be editable by using the Locked field on payments.
Small refactoring tweaks to edit payment url param and test fixes
VEGA-1448 #minor