### PR TITLE
Cache refdata responses

### DIFF
--- a/internal/sirius/cache.go
+++ b/internal/sirius/cache.go
@@ -1,0 +1,34 @@
+package sirius
+
+import (
+	"time"
+)
+
+type cacheItem struct {
+	time  time.Time
+	value []RefDataItem
+}
+
+var cache map[string]cacheItem
+
+func getCached(category string) ([]RefDataItem, bool) {
+	var v []RefDataItem
+	oneHourAgo := time.Now().Add(-1 * time.Hour)
+
+	if cache[category].time.After(oneHourAgo) && len(cache[category].value) > 0 {
+		return cache[category].value, true
+	}
+
+	return v, false
+}
+
+func setCached(category string, value []RefDataItem) {
+	if cache == nil {
+		cache = map[string]cacheItem{}
+	}
+
+	cache[category] = cacheItem{
+		time:  time.Now(),
+		value: value,
+	}
+}

--- a/internal/sirius/cache_test.go
+++ b/internal/sirius/cache_test.go
@@ -1,0 +1,39 @@
+package sirius
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func getCountries() []RefDataItem {
+	return []RefDataItem{
+		{
+			Handle: "UK",
+			Label:  "United Kingdom",
+		},
+	}
+}
+
+func TestCacheWhenEmpty(t *testing.T) {
+	val, ok := getCached("not set")
+
+	assert.Len(t, val, 0)
+	assert.Equal(t, ok, false)
+}
+
+func TestCacheWhenSet(t *testing.T) {
+	setCached("countries", getCountries())
+	val, ok := getCached("countries")
+
+	assert.Equal(t, val, getCountries())
+	assert.Equal(t, ok, true)
+}
+
+func TestCacheWhenMiss(t *testing.T) {
+	setCached("countries", getCountries())
+	val, ok := getCached("cities")
+
+	assert.Len(t, val, 0)
+	assert.Equal(t, ok, false)
+}

--- a/internal/sirius/ref_data.go
+++ b/internal/sirius/ref_data.go
@@ -1,6 +1,8 @@
 package sirius
 
-import "fmt"
+import (
+	"fmt"
+)
 
 const (
 	PaymentSourceCategory string = "paymentSource"
@@ -16,7 +18,14 @@ type RefDataItem struct {
 
 func (c *Client) RefDataByCategory(ctx Context, category string) ([]RefDataItem, error) {
 	var v []RefDataItem
+
+	if cached, ok := getCached(category); ok {
+		return cached, nil
+	}
+
 	err := c.get(ctx, fmt.Sprintf("/lpa-api/v1/reference-data/%s", category), &v)
+
+	setCached(category, v)
 
 	return v, err
 }


### PR DESCRIPTION
To reduce the number of calls we make to `/ref-data/*` endpoints, cache the responses for an hour.

The cache will also be reset when the service is redeployed.

For VEGA-1178 #patch