### PR TITLE
Handle task summary if it has no case

### DIFF
--- a/internal/sirius/task.go
+++ b/internal/sirius/task.go
@@ -11,7 +11,11 @@ type Task struct {
 }
 
 func (t Task) Summary() string {
-	return fmt.Sprintf("%s: %s", t.CaseItems[0].Summary(), t.Name)
+	if len(t.CaseItems) > 0 {
+		return fmt.Sprintf("%s: %s", t.CaseItems[0].Summary(), t.Name)
+	} else {
+		return t.Name
+	}
 }
 
 func (c *Client) Task(ctx Context, id int) (Task, error) {

--- a/internal/sirius/task_test.go
+++ b/internal/sirius/task_test.go
@@ -81,3 +81,43 @@ func TestTask(t *testing.T) {
 		})
 	}
 }
+
+func TestTaskSummary(t *testing.T) {
+	task := Task{
+		Name: "Review case details",
+		CaseItems: []Case{
+			{
+				CaseType: "LPA",
+				UID:      "7000-0420-0130",
+			},
+		},
+	}
+
+	assert.Equal(t, task.Summary(), "LPA 7000-0420-0130: Review case details")
+}
+
+func TestTaskSummaryMultipleCases(t *testing.T) {
+	task := Task{
+		Name: "Review case details",
+		CaseItems: []Case{
+			{
+				CaseType: "LPA",
+				UID:      "7000-0420-0130",
+			},
+			{
+				CaseType: "LPA",
+				UID:      "7000-2839-1010",
+			},
+		},
+	}
+
+	assert.Equal(t, task.Summary(), "LPA 7000-0420-0130: Review case details")
+}
+
+func TestTaskSummaryNoCase(t *testing.T) {
+	task := Task{
+		Name: "Review case details",
+	}
+
+	assert.Equal(t, task.Summary(), "Review case details")
+}


### PR DESCRIPTION
It's unusual, but a task can exist without a case. In that situation, the task summary needs to generate without referencing the case.

Fixes VEGA-1507 #patch