### PR TITLE
Prevent users from rerunning report

### DIFF
--- a/cypress/e2e/mi-reporting.cy.js
+++ b/cypress/e2e/mi-reporting.cy.js
@@ -13,5 +13,17 @@ describe("MI Reporting", () => {
 
     cy.contains("Number of EPAs received");
     cy.contains("10");
+
+    // Make the link open in a new tab because otherwise Cypress
+    // throws cross-domain errors
+    cy.contains("a", "Download").then(($input) => {
+      $input[0].setAttribute("target", "_blank");
+    });
+
+    cy.contains("a", "Download").click();
+    cy.contains("a", "Download")
+      .invoke("attr", "class")
+      .should("contain", "govuk-button--disabled");
+    cy.contains("Your download will open in a new window when ready");
   });
 });

--- a/web/assets/loading-button.js
+++ b/web/assets/loading-button.js
@@ -1,0 +1,32 @@
+const loadingButton = () => {
+  /** @type HTMLAnchorElement|null loadingButton */
+  const loadingButton = document.querySelector(
+    '[data-module="app-loading-button"]'
+  );
+
+  if (loadingButton) {
+    loadingButton.addEventListener(
+      "click",
+      (e) => {
+        if (loadingButton.classList.contains("govuk-button--disabled")) {
+          e.preventDefault();
+          return false;
+        }
+
+        loadingButton.ariaDisabled = "true";
+        loadingButton.classList.add("govuk-button--disabled");
+
+        const messageSelector =
+          loadingButton.getAttribute("data-loading-button-message") ?? "";
+        const message = document.querySelector(messageSelector);
+
+        if (message !== null) {
+          message.classList.remove("govuk-!-display-none");
+        }
+      },
+      false
+    );
+  }
+};
+
+export default loadingButton;

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -2,6 +2,7 @@ import MOJFrontend from "@ministryofjustice/frontend/moj/all.js";
 import * as GOVUKFrontend from "govuk-frontend";
 import $ from "jquery";
 import autoResizeTextArea from "./auto-resize-text-area.js";
+import loadingButton from "./loading-button.js";
 import select from "./select.js";
 import todaysDate from "./todays-date.js";
 
@@ -18,6 +19,7 @@ MOJFrontend.initAll();
 autoResizeTextArea();
 select(prefix);
 todaysDate();
+loadingButton();
 
 if (window.self !== window.parent) {
   const success = document.querySelector(".moj-banner--success");

--- a/web/template/mi_reporting.gohtml
+++ b/web/template/mi_reporting.gohtml
@@ -13,8 +13,14 @@
 
         <p class="govuk-heading-xl">{{ .ResultCount }}</p>
 
+        <div class="govuk-notification-banner govuk-!-display-none" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner" id="download-warning-message">
+          <div class="govuk-notification-banner__content">
+            <p class="govuk-notification-banner__heading">Your download will open in a new window when ready</p>
+          </div>
+        </div>
+
         <div class="govuk-button-group">
-          <a class="govuk-button" data-module="govuk-button" href="{{ sirius .Download }}">Download</a>
+          <a class="govuk-button" data-module="app-loading-button" data-loading-button-message="#download-warning-message" href="{{ sirius .Download }}">Download</a>
           <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
         </div>
 


### PR DESCRIPTION
Because they're not given immediate feedback, we believe some users are clicking on the "Download" button multiple times and re-running the report.

This change disables the button after the first time it's pressed, and adds a notification banner to explain that it will open in a new window when ready.

Fixes VEGA-1506 #minor