### PR TITLE
Improve success messages

### DIFF
--- a/internal/server/add_payment.go
+++ b/internal/server/add_payment.go
@@ -1,10 +1,12 @@
 package server
 
 import (
-	"github.com/ministryofjustice/opg-go-common/template"
-	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"fmt"
 	"net/http"
 	"strconv"
+
+	"github.com/ministryofjustice/opg-go-common/template"
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 )
 
 type AddPaymentClient interface {
@@ -15,7 +17,6 @@ type AddPaymentClient interface {
 
 type addPaymentData struct {
 	XSRFToken string
-	Success   bool
 	Error     sirius.ValidationError
 
 	Case           sirius.Case
@@ -85,7 +86,11 @@ func AddPayment(client AddPaymentClient, tmpl template.Template) Handler {
 			} else if err != nil {
 				return err
 			} else {
-				data.Success = true
+				SetFlash(w, FlashNotification{
+					Title:       "Payment added",
+					Description: "Please clear the task if you have completed it",
+				})
+				return RedirectError(fmt.Sprintf("/payments?id=%d", caseID))
 			}
 		}
 

--- a/internal/server/add_payment_test.go
+++ b/internal/server/add_payment_test.go
@@ -198,16 +198,6 @@ func TestPostAddPayment(t *testing.T) {
 		Return(paymentSources, nil)
 
 	template := &mockTemplate{}
-	template.
-		On("Func", mock.Anything, addPaymentData{
-			Success:        true,
-			Case:           caseitem,
-			Amount:         "41.00",
-			Source:         "MAKE",
-			PaymentDate:    sirius.DateString("2022-01-23"),
-			PaymentSources: paymentSources,
-		}).
-		Return(nil)
 
 	form := url.Values{
 		"amount":      {"41.00"},
@@ -222,7 +212,7 @@ func TestPostAddPayment(t *testing.T) {
 	err := AddPayment(client, template.Func)(w, r)
 	resp := w.Result()
 
-	assert.Nil(t, err)
+	assert.Equal(t, RedirectError("/payments?id=123"), err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	mock.AssertExpectationsForObjects(t, client, template)
 }
@@ -257,7 +247,6 @@ func TestPostAddPaymentAmountIncorrectFormat(t *testing.T) {
 			template := &mockTemplate{}
 			template.
 				On("Func", mock.Anything, addPaymentData{
-					Success:        false,
 					Case:           caseitem,
 					Amount:         amount,
 					Source:         "MAKE",

--- a/internal/server/apply_fee_reduction.go
+++ b/internal/server/apply_fee_reduction.go
@@ -1,10 +1,12 @@
 package server
 
 import (
-	"github.com/ministryofjustice/opg-go-common/template"
-	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"fmt"
 	"net/http"
 	"strconv"
+
+	"github.com/ministryofjustice/opg-go-common/template"
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 )
 
 type ApplyFeeReductionClient interface {
@@ -15,7 +17,6 @@ type ApplyFeeReductionClient interface {
 
 type applyFeeReductionData struct {
 	XSRFToken string
-	Success   bool
 	Error     sirius.ValidationError
 
 	Case              sirius.Case
@@ -58,7 +59,11 @@ func ApplyFeeReduction(client ApplyFeeReductionClient, tmpl template.Template) H
 			} else if err != nil {
 				return err
 			} else {
-				data.Success = true
+				SetFlash(w, FlashNotification{
+					Title:       fmt.Sprintf("%s approved", translateRefData(data.FeeReductionTypes, data.FeeReductionType)),
+					Description: "Please clear the task if you have completed it",
+				})
+				return RedirectError(fmt.Sprintf("/payments?id=%d", caseID))
 			}
 		}
 

--- a/internal/server/apply_fee_reduction_test.go
+++ b/internal/server/apply_fee_reduction_test.go
@@ -195,16 +195,6 @@ func TestPostFeeReduction(t *testing.T) {
 		Return(feeReductionTypes, nil)
 
 	template := &mockTemplate{}
-	template.
-		On("Func", mock.Anything, applyFeeReductionData{
-			Success:           true,
-			Case:              caseitem,
-			FeeReductionType:  "REMISSION",
-			PaymentDate:       "2022-01-23",
-			PaymentEvidence:   "Test evidence",
-			FeeReductionTypes: feeReductionTypes,
-		}).
-		Return(nil)
 
 	form := url.Values{
 		"feeReductionType": {"REMISSION"},
@@ -219,7 +209,7 @@ func TestPostFeeReduction(t *testing.T) {
 	err := ApplyFeeReduction(client, template.Func)(w, r)
 	resp := w.Result()
 
-	assert.Nil(t, err)
+	assert.Equal(t, RedirectError("/payments?id=123"), err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	mock.AssertExpectationsForObjects(t, client, template)
 }

--- a/internal/server/delete_payment_test.go
+++ b/internal/server/delete_payment_test.go
@@ -254,14 +254,6 @@ func TestPostDeletePayment(t *testing.T) {
 		Return(nil)
 
 	template := &mockTemplate{}
-	template.
-		On("Func", mock.Anything, deletePaymentData{
-			Success:           true,
-			Case:              caseItem,
-			Payment:           payment,
-			FeeReductionTypes: feeReductionTypes,
-		}).
-		Return(nil)
 
 	r, _ := http.NewRequest(http.MethodPost, "/?id=123", nil)
 	r.Header.Add("Content-Type", formUrlEncoded)
@@ -270,7 +262,7 @@ func TestPostDeletePayment(t *testing.T) {
 	err := DeletePayment(client, template.Func)(w, r)
 	resp := w.Result()
 
-	assert.Nil(t, err)
+	assert.Equal(t, RedirectError("/payments?id=4"), err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	mock.AssertExpectationsForObjects(t, client, template)
 }

--- a/internal/server/edit_fee_reduction.go
+++ b/internal/server/edit_fee_reduction.go
@@ -1,10 +1,12 @@
 package server
 
 import (
-	"github.com/ministryofjustice/opg-go-common/template"
-	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"fmt"
 	"net/http"
 	"strconv"
+
+	"github.com/ministryofjustice/opg-go-common/template"
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 )
 
 type EditFeeReductionClient interface {
@@ -16,7 +18,6 @@ type EditFeeReductionClient interface {
 
 type editFeeReductionData struct {
 	XSRFToken string
-	Success   bool
 	Error     sirius.ValidationError
 
 	Case              sirius.Case
@@ -66,7 +67,8 @@ func EditFeeReduction(client EditFeeReductionClient, tmpl template.Template) Han
 			} else if err != nil {
 				return err
 			} else {
-				data.Success = true
+				SetFlash(w, FlashNotification{Title: "Fee reduction edited"})
+				return RedirectError(fmt.Sprintf("/payments?id=%d", feeReduction.Case.ID))
 			}
 		}
 

--- a/internal/server/edit_fee_reduction_test.go
+++ b/internal/server/edit_fee_reduction_test.go
@@ -261,7 +261,6 @@ func TestPostEditFeeReductionValidationError(t *testing.T) {
 	template := &mockTemplate{}
 	template.
 		On("Func", mock.Anything, editFeeReductionData{
-			Success:           false,
 			Case:              caseItem,
 			PaymentID:         123,
 			FeeReduction:      feeReduction,
@@ -330,15 +329,6 @@ func TestPostEditFeeReduction(t *testing.T) {
 		Return(nil)
 
 	template := &mockTemplate{}
-	template.
-		On("Func", mock.Anything, editFeeReductionData{
-			Success:           true,
-			Case:              caseItem,
-			PaymentID:         123,
-			FeeReduction:      editedFeeReduction,
-			FeeReductionTypes: feeReductionTypes,
-		}).
-		Return(nil)
 
 	form := url.Values{
 		"id":               {"123"},
@@ -355,7 +345,7 @@ func TestPostEditFeeReduction(t *testing.T) {
 	err := EditFeeReduction(client, template.Func)(w, r)
 	resp := w.Result()
 
-	assert.Nil(t, err)
+	assert.Equal(t, RedirectError("/payments?id=4"), err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	mock.AssertExpectationsForObjects(t, client, template)
 }

--- a/internal/server/edit_payment.go
+++ b/internal/server/edit_payment.go
@@ -2,10 +2,11 @@ package server
 
 import (
 	"fmt"
-	"github.com/ministryofjustice/opg-go-common/template"
-	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 	"net/http"
 	"strconv"
+
+	"github.com/ministryofjustice/opg-go-common/template"
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 )
 
 type EditPaymentClient interface {
@@ -17,7 +18,6 @@ type EditPaymentClient interface {
 
 type editPaymentData struct {
 	XSRFToken string
-	Success   bool
 	Error     sirius.ValidationError
 
 	Case           sirius.Case
@@ -104,7 +104,8 @@ func EditPayment(client EditPaymentClient, tmpl template.Template) Handler {
 			} else if err != nil {
 				return err
 			} else {
-				data.Success = true
+				SetFlash(w, FlashNotification{Title: "Payment saved"})
+				return RedirectError(fmt.Sprintf("/payments?id=%d", p.Case.ID))
 			}
 		}
 

--- a/internal/server/edit_payment_test.go
+++ b/internal/server/edit_payment_test.go
@@ -273,7 +273,6 @@ func TestPostEditPaymentAmountIncorrectFormat(t *testing.T) {
 			template := &mockTemplate{}
 			template.
 				On("Func", mock.Anything, editPaymentData{
-					Success:        false,
 					Case:           caseItem,
 					PaymentID:      123,
 					Amount:         amount,
@@ -344,17 +343,6 @@ func TestPostEditPayment(t *testing.T) {
 		Return(nil)
 
 	template := &mockTemplate{}
-	template.
-		On("Func", mock.Anything, editPaymentData{
-			Success:        true,
-			Case:           caseItem,
-			PaymentID:      123,
-			Amount:         "33.00",
-			Source:         "PHONE",
-			PaymentDate:    sirius.DateString("2022-02-18"),
-			PaymentSources: paymentSources,
-		}).
-		Return(nil)
 
 	form := url.Values{
 		"amount":      {"33.00"},
@@ -369,7 +357,7 @@ func TestPostEditPayment(t *testing.T) {
 	err := EditPayment(client, template.Func)(w, r)
 	resp := w.Result()
 
-	assert.Nil(t, err)
+	assert.Equal(t, RedirectError("/payments?id=4"), err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	mock.AssertExpectationsForObjects(t, client, template)
 }

--- a/internal/server/flash.go
+++ b/internal/server/flash.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+const flashCookieName string = "flash-lpa-frontend"
+
+type FlashNotification struct {
+	Title       string `json:"name"`
+	Description string `json:"description"`
+}
+
+func SetFlash(w http.ResponseWriter, notification FlashNotification) {
+	str, err := json.Marshal(&notification)
+	if err != nil {
+		return
+	}
+
+	c := &http.Cookie{
+		Name:     flashCookieName,
+		Value:    base64.URLEncoding.EncodeToString(str),
+		HttpOnly: true,
+	}
+	http.SetCookie(w, c)
+}
+
+func GetFlash(w http.ResponseWriter, r *http.Request) (FlashNotification, error) {
+	c, err := r.Cookie(flashCookieName)
+
+	if err != nil {
+		switch err {
+		case http.ErrNoCookie:
+			return FlashNotification{}, nil
+		default:
+			return FlashNotification{}, err
+		}
+	}
+
+	str, err := base64.URLEncoding.DecodeString(c.Value)
+	if err != nil {
+		return FlashNotification{}, err
+	}
+
+	var v FlashNotification
+	err = json.Unmarshal([]byte(str), &v)
+
+	if err != nil {
+		return FlashNotification{}, err
+	}
+
+	dc := &http.Cookie{Name: flashCookieName, MaxAge: -1, Expires: time.Unix(1, 0)}
+	http.SetCookie(w, dc)
+	return v, nil
+}

--- a/internal/server/flash_test.go
+++ b/internal/server/flash_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockResponseWriter struct {
+	mock.Mock
+}
+
+func (m *mockResponseWriter) Header() http.Header {
+	args := m.Called()
+	return args.Get(0).(http.Header)
+}
+
+func (m *mockResponseWriter) Write([]byte) (int, error) {
+	args := m.Called()
+	return args.Get(0).(int), args.Error(1)
+}
+func (m *mockResponseWriter) WriteHeader(statusCode int) {
+	m.Called(statusCode)
+}
+
+func TestSetFlashAddsHeader(t *testing.T) {
+	header := http.Header{}
+	w := &mockResponseWriter{}
+	w.
+		On("Header").
+		Return(header)
+
+	SetFlash(w, FlashNotification{
+		Title:       "title",
+		Description: "description",
+	})
+
+	assert.Equal(t, "flash-lpa-frontend=eyJuYW1lIjoidGl0bGUiLCJkZXNjcmlwdGlvbiI6ImRlc2NyaXB0aW9uIn0=; HttpOnly", header.Get("Set-Cookie"))
+}
+
+func TestGetFlashGetsHeader(t *testing.T) {
+	header := http.Header{}
+	w := &mockResponseWriter{}
+	w.
+		On("Header").
+		Return(header)
+
+	r, _ := http.NewRequest("GET", "/some-url", nil)
+	r.AddCookie(&http.Cookie{
+		Name:  "flash-lpa-frontend",
+		Value: "eyJuYW1lIjoidGl0bGUiLCJkZXNjcmlwdGlvbiI6ImRlc2NyaXB0aW9uIn0=",
+	})
+
+	notification, err := GetFlash(w, r)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "title", notification.Title)
+	assert.Equal(t, "description", notification.Description)
+	assert.Contains(t, header.Get("Set-Cookie"), "flash-lpa-frontend=;")
+}
+
+func TestGetFlashReturnsEmptyIfNoCookie(t *testing.T) {
+	header := http.Header{}
+	w := &mockResponseWriter{}
+	w.
+		On("Header").
+		Return(header)
+
+	r, _ := http.NewRequest("GET", "/some-url", nil)
+
+	notification, err := GetFlash(w, r)
+
+	assert.Nil(t, err)
+	assert.Equal(t, FlashNotification{}, notification)
+}
+
+func TestGetFlashReturnsErrorIfCannotDecodeBase64(t *testing.T) {
+	header := http.Header{}
+	w := &mockResponseWriter{}
+	w.
+		On("Header").
+		Return(header)
+
+	r, _ := http.NewRequest("GET", "/some-url", nil)
+	r.AddCookie(&http.Cookie{
+		Name:  "flash-lpa-frontend",
+		Value: "badstring",
+	})
+
+	notification, err := GetFlash(w, r)
+
+	assert.NotNil(t, err)
+	assert.Equal(t, FlashNotification{}, notification)
+}
+
+func TestGetFlashReturnsErrorIfCannotDecodeJSON(t *testing.T) {
+	header := http.Header{}
+	w := &mockResponseWriter{}
+	w.
+		On("Header").
+		Return(header)
+
+	r, _ := http.NewRequest("GET", "/some-url", nil)
+	r.AddCookie(&http.Cookie{
+		Name:  "flash-lpa-frontend",
+		Value: "dGhpcyBpcyBub3QgSlNPTg==",
+	})
+
+	notification, err := GetFlash(w, r)
+
+	assert.NotNil(t, err)
+	assert.Equal(t, FlashNotification{}, notification)
+}

--- a/internal/server/get_payments.go
+++ b/internal/server/get_payments.go
@@ -28,6 +28,7 @@ type getPaymentsData struct {
 	TotalPaid         int
 	OutstandingFee    int
 	RefundAmount      int
+	FlashMessage      FlashNotification
 }
 
 func GetPayments(client GetPaymentsClient, tmpl template.Template) Handler {
@@ -99,6 +100,8 @@ func GetPayments(client GetPaymentsClient, tmpl template.Template) Handler {
 		}
 
 		data.IsReducedFeesUser = user.HasRole("Reduced Fees User")
+
+		data.FlashMessage, _ = GetFlash(w, r)
 
 		return tmpl(w, data)
 	}

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -22,7 +22,7 @@ todaysDate();
 loadingButton();
 
 if (window.self !== window.parent) {
-  const success = document.querySelector(".moj-banner--success");
+  const success = document.querySelector("[data-app-reload~=\"page\"]");
   if (success) {
     window.parent.postMessage(
       "form-done",

--- a/web/template/add_complaint.gohtml
+++ b/web/template/add_complaint.gohtml
@@ -10,6 +10,7 @@
       {{ template "error-summary" .Error }}
 
       {{ if .Success }}
+        <meta data-app-reload="page" />
         {{ template "success-banner" "You have successfully added a complaint." }}
       {{ end }}
 

--- a/web/template/add_payment.gohtml
+++ b/web/template/add_payment.gohtml
@@ -9,19 +9,6 @@
 
             {{ template "error-summary" .Error }}
 
-            {{ if .Success }}
-                <div class="moj-banner moj-banner--success">
-                    <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
-                        <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z" />
-                    </svg>
-
-                    <div class="moj-banner__message">
-                        <span class="moj-banner__assistive">Success</span><strong>Payment added</strong>
-                        <p class="govuk-body">Please clear the task if you have completed it</p>
-                    </div>
-                </div>
-            {{ end }}
-
             <h1 class="govuk-heading-l">Add a payment</h1>
 
             <form class="form" method="POST">

--- a/web/template/allocate_cases.gohtml
+++ b/web/template/allocate_cases.gohtml
@@ -15,6 +15,7 @@
       {{ template "error-summary" .Error }}
 
       {{ if .Success }}
+        <meta data-app-reload="page" />
         {{ template "success-banner" "You have successfully allocated cases." }}
       {{ end }}
 

--- a/web/template/apply_fee_reduction.gohtml
+++ b/web/template/apply_fee_reduction.gohtml
@@ -9,19 +9,6 @@
 
             {{ template "error-summary" .Error }}
 
-            {{ if .Success }}
-                <div class="moj-banner moj-banner--success">
-                    <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
-                        <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z" />
-                    </svg>
-
-                    <div class="moj-banner__message">
-                        <span class="moj-banner__assistive">Success</span><strong>{{ (printf "%s approved" (translateRefData .FeeReductionTypes .FeeReductionType)) }}</strong>
-                        <p class="govuk-body">Please clear the task if you have completed it</p>
-                    </div>
-                </div>
-            {{ end }}
-
             <h1 class="govuk-heading-l">Apply a fee reduction</h1>
 
             <form class="form" method="POST">

--- a/web/template/assign_task.gohtml
+++ b/web/template/assign_task.gohtml
@@ -15,6 +15,7 @@
       {{ template "error-summary" .Error }}
 
       {{ if .Success }}
+        <meta data-app-reload="page" />
         {{ template "success-banner" "You have successfully assigned a task." }}
       {{ end }}
 

--- a/web/template/change_status.gohtml
+++ b/web/template/change_status.gohtml
@@ -10,6 +10,7 @@
       {{ template "error-summary" .Error }}
 
       {{ if .Success }}
+        <meta data-app-reload="page" />
         {{ template "success-banner" (printf "Status changed to %s" .NewStatus) }}
       {{ end }}
 

--- a/web/template/delete_fee_reduction.gohtml
+++ b/web/template/delete_fee_reduction.gohtml
@@ -8,19 +8,6 @@
             <p class="govuk-body"><strong>{{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "lpa" }}LPA{{ end }} {{ .Case.UID }}</strong></p>
             {{$feeReductionTypeLabel := translateRefData .FeeReductionTypes .Payment.FeeReductionType}}
 
-            {{ if .Success }}
-                <div class="moj-banner moj-banner--success">
-                    <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
-                        <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z" />
-                    </svg>
-
-                    <div class="moj-banner__message">
-                        <span class="moj-banner__assistive">Success</span><strong>{{ (printf "%s deleted" $feeReductionTypeLabel) }}</strong>
-                        <p class="govuk-body">Please clear the task if you have completed it</p>
-                    </div>
-                </div>
-            {{ end }}
-
             <h1 class="govuk-heading-l">Delete {{$feeReductionTypeLabel | ToLower}}</h1>
 
             <p class="govuk-body govuk-!-padding-bottom-6">Are you sure you want to delete the <strong>{{$feeReductionTypeLabel | ToLower }}</strong>?</p>

--- a/web/template/delete_payment.gohtml
+++ b/web/template/delete_payment.gohtml
@@ -7,19 +7,6 @@
         <div class="govuk-grid-column-two-thirds">
             <p class="govuk-body"><strong>{{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "lpa" }}LPA{{ end }} {{ .Case.UID }}</strong></p>
 
-            {{ if .Success }}
-                <div class="moj-banner moj-banner--success">
-                    <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
-                        <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z" />
-                    </svg>
-
-                    <div class="moj-banner__message">
-                        <span class="moj-banner__assistive">Success</span><strong>Payment deleted</strong>
-                        <p class="govuk-body">Please clear the task if you have completed it</p>
-                    </div>
-                </div>
-            {{ end }}
-
             <h1 class="govuk-heading-l">Delete payment</h1>
 
             <p class="govuk-body govuk-!-padding-bottom-6">Are you sure you want to delete the payment of £{{ fee .Payment.Amount }}</p>

--- a/web/template/delete_relationship.gohtml
+++ b/web/template/delete_relationship.gohtml
@@ -8,6 +8,7 @@
       <p class="govuk-body"><strong>{{ .Entity }}</strong></p>
 
       {{ if .Success }}
+        <meta data-app-reload="page" />
         {{ template "success-banner" "You have successfully deleted a relationship." }}
       {{ end }}
 

--- a/web/template/donor.gohtml
+++ b/web/template/donor.gohtml
@@ -31,6 +31,7 @@
             </div>
           </div>
         {{ else }}
+          <meta data-app-reload="page" />
           {{ template "success-banner" "Donor was edited" }}
         {{ end }}
       {{ else }}

--- a/web/template/edit_complaint.gohtml
+++ b/web/template/edit_complaint.gohtml
@@ -8,6 +8,7 @@
       {{ template "error-summary" .Error }}
 
       {{ if .Success }}
+        <meta data-app-reload="page" />
         {{ template "success-banner" "You have successfully edited a complaint." }}
       {{ end }}
 

--- a/web/template/edit_dates.gohtml
+++ b/web/template/edit_dates.gohtml
@@ -8,6 +8,7 @@
       <p class="govuk-body"><strong>{{ .Entity }}</strong></p>
 
       {{ if .Success }}
+        <meta data-app-reload="page" />
         {{ template "success-banner" "You have successfully edited the dates." }}
       {{ end }}
 

--- a/web/template/edit_fee_reduction.gohtml
+++ b/web/template/edit_fee_reduction.gohtml
@@ -9,10 +9,6 @@
 
             {{ template "error-summary" .Error }}
 
-            {{ if .Success }}
-                {{ template "success-banner" ("Fee reduction edited") }}
-            {{ end }}
-
             <h1 class="govuk-heading-l">Edit fee reduction</h1>
 
             <form class="form" method="POST">

--- a/web/template/edit_payment.gohtml
+++ b/web/template/edit_payment.gohtml
@@ -9,10 +9,6 @@
 
             {{ template "error-summary" .Error }}
 
-            {{ if .Success }}
-                {{ template "success-banner" ("Payment saved") }}
-            {{ end }}
-
             <h1 class="govuk-heading-l">Edit payment</h1>
 
             <form class="form" method="POST">

--- a/web/template/event.gohtml
+++ b/web/template/event.gohtml
@@ -10,6 +10,7 @@
       {{ template "error-summary" .Error }}
 
       {{ if .Success }}
+        <meta data-app-reload="page" />
         {{ template "success-banner" "You have successfully created an event." }}
       {{ end }}
 

--- a/web/template/layout/notification-banner.gohtml
+++ b/web/template/layout/notification-banner.gohtml
@@ -1,0 +1,17 @@
+{{ define "notification-banner" }}
+  <div class="moj-banner moj-banner--success">
+    <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+      <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z" />
+    </svg>
+
+    <div class="moj-banner__message">
+      <span class="moj-banner__assistive">Success</span>
+      {{ if .Description }}
+        <strong>{{ .Title }}</strong>
+        <p class="govuk-body">{{ .Description }}</p>
+      {{ else }}
+        {{ .Title }}
+      {{ end }}
+    </div>
+  </div>
+{{ end }}

--- a/web/template/link_person.gohtml
+++ b/web/template/link_person.gohtml
@@ -10,6 +10,7 @@
       {{ template "error-summary" .Error }}
 
       {{ if .Success }}
+        <meta data-app-reload="page" />
         {{ template "success-banner" "You have successfully linked these records." }}
       {{ end }}
 

--- a/web/template/payments.gohtml
+++ b/web/template/payments.gohtml
@@ -9,6 +9,10 @@
                 <strong>{{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "lpa" }}LPA{{ end }} {{ .Case.UID }}</strong>
             </h1>
 
+            {{ if .FlashMessage.Title }}
+                {{ template "notification-banner" .FlashMessage }}
+            {{ end }}
+
             {{ if and (not .Payments) (not .FeeReductions)}}
                 <p class="govuk-body govuk-!-padding-top-7 govuk-!-padding-bottom-7"><strong>There is currently no fee
                         data available to display.</strong></p>

--- a/web/template/relationship.gohtml
+++ b/web/template/relationship.gohtml
@@ -10,6 +10,7 @@
       {{ template "error-summary" .Error }}
 
       {{ if .Success }}
+        <meta data-app-reload="page" />
         {{ template "success-banner" "You have successfully created a relationship." }}
       {{ end }}
 

--- a/web/template/task.gohtml
+++ b/web/template/task.gohtml
@@ -10,6 +10,7 @@
       {{ template "error-summary" .Error }}
 
       {{ if .Success }}
+        <meta data-app-reload="page" />
         {{ template "success-banner" "You have successfully created a task." }}
       {{ end }}
 

--- a/web/template/unlink_person.gohtml
+++ b/web/template/unlink_person.gohtml
@@ -7,6 +7,7 @@
         <div class="govuk-grid-column-two-thirds">
 
             {{ if .Success }}
+                <meta data-app-reload="page" />
                 {{ template "success-banner" "You have successfully unlinked the record(s)." }}
             {{ end }}
 

--- a/web/template/warning.gohtml
+++ b/web/template/warning.gohtml
@@ -8,6 +8,7 @@
       {{ template "error-summary" .Error }}
 
       {{ if .Success }}
+        <meta data-app-reload="page" />
         {{ template "success-banner" "You have successfully created a warning." }}
       {{ end }}
 


### PR DESCRIPTION
Two changes here:
- Rather than reloading the page whenever a success banner is found, look for the more explicit `data-app-reload` attribute containing the word "page". The existing forms have been updated to match, but in the future we might want to add flexibility so you can do e.g. `data-app-reload="timeline tasks"`
- In payments forms, instead of showing success messages in-place they now get saved as flash messages and the user is returned to `/payments?id=#` where they're shown

Fixes VEGA-1513 #minor