### PR TITLE
Use single definition of expectedError in tests

### DIFF
--- a/internal/server/add_complaint_test.go
+++ b/internal/server/add_complaint_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -76,8 +75,6 @@ func TestGetAddComplaintBadQuery(t *testing.T) {
 }
 
 func TestGetAddComplaintWhenCaseErrors(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockAddComplaintClient{}
 	client.
 		On("Case", mock.Anything, 123).
@@ -93,8 +90,6 @@ func TestGetAddComplaintWhenCaseErrors(t *testing.T) {
 }
 
 func TestGetAddComplaintWhenTemplateErrors(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockAddComplaintClient{}
 	client.
 		On("Case", mock.Anything, 123).
@@ -210,8 +205,6 @@ func TestPostAddComplaintWhenAddComplaintValidationError(t *testing.T) {
 }
 
 func TestPostAddComplaintWhenAddComplaintOtherError(t *testing.T) {
-	expectedError := errors.New("err")
-
 	complaint := sirius.Complaint{Description: "This is a complaint"}
 
 	client := &mockAddComplaintClient{}

--- a/internal/server/add_payment_test.go
+++ b/internal/server/add_payment_test.go
@@ -1,15 +1,15 @@
 package server
 
 import (
-	"errors"
-	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type mockAddPaymentClient struct {
@@ -93,8 +93,6 @@ func TestAddPaymentNoID(t *testing.T) {
 }
 
 func TestAddPaymentWhenFailureOnGetCase(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockAddPaymentClient{}
 	client.
 		On("Case", mock.Anything, 4).
@@ -131,8 +129,6 @@ func TestAddPaymentWhenTemplateErrors(t *testing.T) {
 		On("RefDataByCategory", mock.Anything, sirius.PaymentSourceCategory).
 		Return(paymentSources, nil)
 
-	expectedError := errors.New("err")
-
 	template := &mockTemplate{}
 	template.
 		On("Func", mock.Anything, addPaymentData{
@@ -155,8 +151,6 @@ func TestAddPaymentWhenFailureOnGetPaymentSourceRefData(t *testing.T) {
 		UID:     "7000-0000-0021",
 		SubType: "pfa",
 	}
-
-	expectedError := errors.New("err")
 
 	client := &mockAddPaymentClient{}
 	client.

--- a/internal/server/allocate_cases_test.go
+++ b/internal/server/allocate_cases_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -115,8 +114,6 @@ func TestGetAllocateCasesBadQueryString(t *testing.T) {
 }
 
 func TestGetAllocateCasesWhenTeamsErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockAllocateCasesClient{}
 	client.
 		On("Teams", mock.Anything).
@@ -135,8 +132,6 @@ func TestGetAllocateCasesWhenTeamsErrors(t *testing.T) {
 }
 
 func TestGetAllocateCasesWhenCaseErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockAllocateCasesClient{}
 	client.
 		On("Teams", mock.Anything).
@@ -155,8 +150,6 @@ func TestGetAllocateCasesWhenCaseErrors(t *testing.T) {
 }
 
 func TestGetAllocateCasesWhenTemplateErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockAllocateCasesClient{}
 	client.
 		On("Teams", mock.Anything).
@@ -269,8 +262,6 @@ func TestPostAllocateCasesMultiple(t *testing.T) {
 }
 
 func TestPostAllocateCasesWhenAllocateCasesFails(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockAllocateCasesClient{}
 	client.
 		On("Teams", mock.Anything).

--- a/internal/server/apply_fee_reduction_test.go
+++ b/internal/server/apply_fee_reduction_test.go
@@ -1,15 +1,15 @@
 package server
 
 import (
-	"errors"
-	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type mockApplyFeeReductionClient struct {
@@ -92,8 +92,6 @@ func TestApplyFeeReductionNoID(t *testing.T) {
 }
 
 func TestApplyFeeReductionWhenFailureOnGetCase(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockApplyFeeReductionClient{}
 	client.
 		On("Case", mock.Anything, 4).
@@ -129,8 +127,6 @@ func TestApplyFeeReductionWhenTemplateErrors(t *testing.T) {
 		On("RefDataByCategory", mock.Anything, sirius.FeeReductionTypeCategory).
 		Return(feeReductionTypes, nil)
 
-	expectedError := errors.New("err")
-
 	template := &mockTemplate{}
 	template.
 		On("Func", mock.Anything, applyFeeReductionData{
@@ -153,8 +149,6 @@ func TestApplyFeeReductionWhenFailureOnGetFeeReductionTypesRefData(t *testing.T)
 		UID:     "7000-0000-0021",
 		SubType: "pfa",
 	}
-
-	expectedError := errors.New("err")
 
 	client := &mockApplyFeeReductionClient{}
 	client.

--- a/internal/server/assign_task_test.go
+++ b/internal/server/assign_task_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -114,8 +113,6 @@ func TestGetAssignTaskBadQueryString(t *testing.T) {
 }
 
 func TestGetAssignTaskWhenTeamsErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockAssignTaskClient{}
 	client.
 		On("Teams", mock.Anything).
@@ -134,8 +131,6 @@ func TestGetAssignTaskWhenTeamsErrors(t *testing.T) {
 }
 
 func TestGetAssignTaskWhenTaskErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockAssignTaskClient{}
 	client.
 		On("Teams", mock.Anything).
@@ -154,8 +149,6 @@ func TestGetAssignTaskWhenTaskErrors(t *testing.T) {
 }
 
 func TestGetAssignTaskWhenTemplateErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockAssignTaskClient{}
 	client.
 		On("Teams", mock.Anything).
@@ -266,8 +259,6 @@ func TestPostAssignTaskMultiple(t *testing.T) {
 }
 
 func TestPostAssignTaskWhenAssignTaskFails(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockAssignTaskClient{}
 	client.
 		On("Teams", mock.Anything).

--- a/internal/server/change_status_test.go
+++ b/internal/server/change_status_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -86,7 +85,6 @@ func TestGetChangeStatusNoID(t *testing.T) {
 }
 
 func TestGetChangeStatusWhenCaseErrors(t *testing.T) {
-	expectedError := errors.New("err")
 	caseitem := sirius.Case{CaseType: "PFA", UID: "700700"}
 
 	client := &mockChangeStatusClient{}
@@ -104,7 +102,6 @@ func TestGetChangeStatusWhenCaseErrors(t *testing.T) {
 }
 
 func TestGetChangeStatusWhenAvailableStatusesErrors(t *testing.T) {
-	expectedError := errors.New("err")
 	caseitem := sirius.Case{CaseType: "PFA", UID: "700700"}
 
 	client := &mockChangeStatusClient{}
@@ -126,7 +123,6 @@ func TestGetChangeStatusWhenAvailableStatusesErrors(t *testing.T) {
 }
 
 func TestGetChangeStatusWhenTemplateErrors(t *testing.T) {
-	expectedError := errors.New("err")
 	caseitem := sirius.Case{CaseType: "PFA", UID: "700700"}
 
 	client := &mockChangeStatusClient{}
@@ -204,7 +200,6 @@ func TestPostChangeStatus(t *testing.T) {
 }
 
 func TestPostChangeStatusWhenChangeStatusErrors(t *testing.T) {
-	expectedError := errors.New("err")
 	caseitem := sirius.Case{CaseType: "lpa", UID: "700700"}
 
 	client := &mockChangeStatusClient{}

--- a/internal/server/create_donor_test.go
+++ b/internal/server/create_donor_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -120,8 +119,6 @@ func TestPostCreateDonor(t *testing.T) {
 }
 
 func TestPostCreateDonorWhenAPIFails(t *testing.T) {
-	expectedError := errors.New("failed to create donor")
-
 	client := &mockCreateDonorClient{}
 	client.
 		On("CreateDonor", mock.Anything, sirius.Person{

--- a/internal/server/create_investigation_test.go
+++ b/internal/server/create_investigation_test.go
@@ -1,15 +1,15 @@
 package server
 
 import (
-	"errors"
-	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type mockCreateInvestigationClient struct {
@@ -75,8 +75,6 @@ func TestGetCreateInvestigationBadQuery(t *testing.T) {
 }
 
 func TestGetCreateInvestigationWhenCaseErrors(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockCreateInvestigationClient{}
 	client.
 		On("Case", mock.Anything, 123).
@@ -92,8 +90,6 @@ func TestGetCreateInvestigationWhenCaseErrors(t *testing.T) {
 }
 
 func TestGetCreateInvestigationWhenTemplateErrors(t *testing.T) {
-	expectedError := errors.New("err")
-
 	caseItem := sirius.Case{CaseType: "lpa", UID: "7000"}
 
 	client := &mockCreateInvestigationClient{}
@@ -208,8 +204,6 @@ func TestPostCreateInvestigationWhenValidationError(t *testing.T) {
 }
 
 func TestPostCreateInvestigationWhenOtherError(t *testing.T) {
-	expectedError := errors.New("err")
-
 	caseItem := sirius.Case{CaseType: "lpa", UID: "7000"}
 	investigation := sirius.Investigation{
 		Type: "Priority",

--- a/internal/server/delete_payment_test.go
+++ b/internal/server/delete_payment_test.go
@@ -1,13 +1,13 @@
 package server
 
 import (
-	"errors"
-	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type mockDeletePaymentClient struct {
@@ -89,8 +89,6 @@ func TestGetDeletePayment(t *testing.T) {
 }
 
 func TestDeletePaymentWhenFailureOnGetPaymentByID(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockDeletePaymentClient{}
 	client.
 		On("PaymentByID", mock.Anything, 123).
@@ -106,8 +104,6 @@ func TestDeletePaymentWhenFailureOnGetPaymentByID(t *testing.T) {
 }
 
 func TestDeletePaymentWhenFailureOnGetCase(t *testing.T) {
-	expectedError := errors.New("err")
-
 	payment := sirius.Payment{
 		ID:          123,
 		Amount:      8200,
@@ -146,8 +142,6 @@ func TestDeletePaymentWhenFailureOnGetFeeReductionTypes(t *testing.T) {
 		PaymentDate: sirius.DateString("2022-07-23"),
 		Case:        &sirius.Case{ID: 4},
 	}
-
-	expectedError := errors.New("err")
 
 	client := &mockDeletePaymentClient{}
 	client.
@@ -200,8 +194,6 @@ func TestDeletePaymentWhenTemplateErrors(t *testing.T) {
 	client.
 		On("RefDataByCategory", mock.Anything, sirius.FeeReductionTypeCategory).
 		Return(feeReductionTypes, nil)
-
-	expectedError := errors.New("err")
 
 	template := &mockTemplate{}
 	template.

--- a/internal/server/delete_relationship_test.go
+++ b/internal/server/delete_relationship_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -69,8 +68,6 @@ func TestGetDeleteRelationshipNoID(t *testing.T) {
 }
 
 func TestGetDeleteRelationshipWhenPersonErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockDeleteRelationshipClient{}
 	client.
 		On("Person", mock.Anything, 123).
@@ -89,8 +86,6 @@ func TestGetDeleteRelationshipWhenPersonErrors(t *testing.T) {
 }
 
 func TestGetDeleteRelationshipWhenPersonReferencesErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockDeleteRelationshipClient{}
 	client.
 		On("Person", mock.Anything, 123).
@@ -109,8 +104,6 @@ func TestGetDeleteRelationshipWhenPersonReferencesErrors(t *testing.T) {
 }
 
 func TestGetDeleteRelationshipWhenTemplateErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockDeleteRelationshipClient{}
 	client.
 		On("Person", mock.Anything, 123).
@@ -174,8 +167,6 @@ func TestPostDeleteRelationship(t *testing.T) {
 }
 
 func TestPostDeleteRelationshipWhenDeletePersonReferenceErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockDeleteRelationshipClient{}
 	client.
 		On("DeletePersonReference", mock.Anything, 1).

--- a/internal/server/edit_complaint_test.go
+++ b/internal/server/edit_complaint_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -71,8 +70,6 @@ func TestGetEditComplaintNoID(t *testing.T) {
 }
 
 func TestGetEditComplaintWhenComplaintErrors(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockEditComplaintClient{}
 	client.
 		On("Complaint", mock.Anything, 123).
@@ -88,8 +85,6 @@ func TestGetEditComplaintWhenComplaintErrors(t *testing.T) {
 }
 
 func TestGetEditComplaintWhenTemplateErrors(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockEditComplaintClient{}
 	client.
 		On("Complaint", mock.Anything, 123).
@@ -207,8 +202,6 @@ func TestPostEditComplaintWhenEditComplaintValidationError(t *testing.T) {
 }
 
 func TestPostEditComplaintWhenEditComplaintOtherError(t *testing.T) {
-	expectedError := errors.New("err")
-
 	complaint := sirius.Complaint{Description: "This is a complaint"}
 
 	client := &mockEditComplaintClient{}

--- a/internal/server/edit_dates_test.go
+++ b/internal/server/edit_dates_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -77,7 +76,6 @@ func TestGetEditDatesNoID(t *testing.T) {
 }
 
 func TestGetEditDatesWhenCaseErrors(t *testing.T) {
-	expectedError := errors.New("err")
 	caseitem := sirius.Case{CaseType: "PFA", UID: "700700"}
 
 	client := &mockEditDatesClient{}
@@ -95,7 +93,6 @@ func TestGetEditDatesWhenCaseErrors(t *testing.T) {
 }
 
 func TestGetEditDatesWhenTemplateErrors(t *testing.T) {
-	expectedError := errors.New("err")
 	caseitem := sirius.Case{CaseType: "PFA", UID: "700700"}
 
 	client := &mockEditDatesClient{}
@@ -176,8 +173,6 @@ func TestPostEditDates(t *testing.T) {
 }
 
 func TestPostEditDatesWhenEditDatesErrors(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockEditDatesClient{}
 	client.
 		On("EditDates", mock.Anything, 123, sirius.CaseTypeLpa, sirius.Dates{

--- a/internal/server/edit_donor_test.go
+++ b/internal/server/edit_donor_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -135,8 +134,6 @@ func TestPostEditDonor(t *testing.T) {
 }
 
 func TestPostEditDonorWhenAPIFails(t *testing.T) {
-	expectedError := errors.New("failed to create donor")
-
 	client := &mockEditDonorClient{}
 	client.
 		On("Person", mock.Anything, 123).

--- a/internal/server/edit_fee_reduction_test.go
+++ b/internal/server/edit_fee_reduction_test.go
@@ -1,15 +1,15 @@
 package server
 
 import (
-	"errors"
-	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type mockEditFeeReductionClient struct {
@@ -91,8 +91,6 @@ func TestGetEditFeeReduction(t *testing.T) {
 }
 
 func TestEditFeeReductionWhenFailureOnGetPaymentByID(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockEditFeeReductionClient{}
 	client.
 		On("PaymentByID", mock.Anything, 123).
@@ -108,8 +106,6 @@ func TestEditFeeReductionWhenFailureOnGetPaymentByID(t *testing.T) {
 }
 
 func TestEditFeeReductionWhenFailureOnGetCase(t *testing.T) {
-	expectedError := errors.New("err")
-
 	feeReduction := sirius.Payment{
 		ID:               123,
 		PaymentEvidence:  "Test evidence",
@@ -149,8 +145,6 @@ func TestEditFeeReductionWhenFailureOnGetPaymentSourceRefData(t *testing.T) {
 		PaymentDate:      sirius.DateString("2022-07-23"),
 		Case:             &sirius.Case{ID: 4},
 	}
-
-	expectedError := errors.New("err")
 
 	client := &mockEditFeeReductionClient{}
 	client.
@@ -200,8 +194,6 @@ func TestEditFeeReductionWhenTemplateErrors(t *testing.T) {
 		Return(caseItem, nil).
 		On("RefDataByCategory", mock.Anything, sirius.FeeReductionTypeCategory).
 		Return(feeReductionTypes, nil)
-
-	expectedError := errors.New("err")
 
 	template := &mockTemplate{}
 	template.

--- a/internal/server/edit_payment_test.go
+++ b/internal/server/edit_payment_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -96,8 +95,6 @@ func TestGetEditPayment(t *testing.T) {
 }
 
 func TestEditPaymentWhenFailureOnGetPaymentByID(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockEditPaymentClient{}
 	client.
 		On("PaymentByID", mock.Anything, 123).
@@ -113,8 +110,6 @@ func TestEditPaymentWhenFailureOnGetPaymentByID(t *testing.T) {
 }
 
 func TestEditPaymentWhenFailureOnGetCase(t *testing.T) {
-	expectedError := errors.New("err")
-
 	payment := sirius.Payment{
 		ID:          123,
 		Amount:      8200,
@@ -153,8 +148,6 @@ func TestEditPaymentWhenFailureOnGetPaymentSourceRefData(t *testing.T) {
 		PaymentDate: sirius.DateString("2022-07-23"),
 		Case:        &sirius.Case{ID: 4},
 	}
-
-	expectedError := errors.New("err")
 
 	client := &mockEditPaymentClient{}
 	client.
@@ -208,8 +201,6 @@ func TestEditPaymentWhenTemplateErrors(t *testing.T) {
 	client.
 		On("RefDataByCategory", mock.Anything, sirius.PaymentSourceCategory).
 		Return(paymentSources, nil)
-
-	expectedError := errors.New("err")
 
 	template := &mockTemplate{}
 	template.

--- a/internal/server/event_test.go
+++ b/internal/server/event_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"errors"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -132,8 +131,6 @@ func TestGetEventBadQueryString(t *testing.T) {
 }
 
 func TestGetEventWhenNoteTypeErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockEventClient{}
 	client.
 		On("NoteTypes", mock.Anything).
@@ -151,8 +148,6 @@ func TestGetEventWhenNoteTypeErrors(t *testing.T) {
 }
 
 func TestGetEventWhenTemplateErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockEventClient{}
 	client.
 		On("NoteTypes", mock.Anything).
@@ -280,8 +275,6 @@ func TestPostEventWithBadForm(t *testing.T) {
 }
 
 func TestPostEventWhenCreateNoteFails(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockEventClient{}
 	client.
 		On("NoteTypes", mock.Anything).

--- a/internal/server/get_payments_test.go
+++ b/internal/server/get_payments_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -153,8 +152,6 @@ func TestGetPaymentsNoID(t *testing.T) {
 }
 
 func TestGetPaymentsWhenFailureOnGetCase(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockGetPayments{}
 	client.
 		On("Case", mock.Anything, 4).
@@ -170,8 +167,6 @@ func TestGetPaymentsWhenFailureOnGetCase(t *testing.T) {
 }
 
 func TestGetPaymentsWhenFailureOnGetPayments(t *testing.T) {
-	expectedError := errors.New("err")
-
 	caseItem := sirius.Case{
 		UID:     "7000-0000-0021",
 		SubType: "pfa",
@@ -196,8 +191,6 @@ func TestGetPaymentsWhenFailureOnGetPayments(t *testing.T) {
 }
 
 func TestGetPaymentsWhenFailureOnGetPaymentSourceRefData(t *testing.T) {
-	expectedError := errors.New("err")
-
 	payments := []sirius.Payment{
 		{
 			ID:          2,
@@ -233,8 +226,6 @@ func TestGetPaymentsWhenFailureOnGetPaymentSourceRefData(t *testing.T) {
 }
 
 func TestGetPaymentsWhenFailureOnGetReferenceTypeRefData(t *testing.T) {
-	expectedError := errors.New("err")
-
 	payments := []sirius.Payment{
 		{
 			ID:          2,
@@ -279,8 +270,6 @@ func TestGetPaymentsWhenFailureOnGetReferenceTypeRefData(t *testing.T) {
 }
 
 func TestGetPaymentsWhenFailureOnFeeReductionTypesRefData(t *testing.T) {
-	expectedError := errors.New("err")
-
 	payments := []sirius.Payment{
 		{
 			ID:          2,
@@ -392,8 +381,6 @@ func TestGetPaymentsWhenTemplateErrors(t *testing.T) {
 	client.
 		On("GetUserDetails", mock.Anything).
 		Return(user, nil)
-
-	expectedError := errors.New("err")
 
 	template := &mockTemplate{}
 	template.

--- a/internal/server/link_person_test.go
+++ b/internal/server/link_person_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -81,8 +80,6 @@ func TestLinkPersonNoID(t *testing.T) {
 }
 
 func TestLinkPersonGetFails(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockLinkPersonClient{}
 	client.
 		On("Person", mock.Anything, 123).
@@ -103,7 +100,6 @@ func TestLinkPersonGetFails(t *testing.T) {
 
 func TestLinkPersonTemplateErrors(t *testing.T) {
 	person := sirius.Person{Firstname: "John", Surname: "Doe"}
-	expectedError := errors.New("err")
 
 	client := &mockLinkPersonClient{}
 	client.

--- a/internal/server/mi_reporting_test.go
+++ b/internal/server/mi_reporting_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -127,8 +126,6 @@ func TestGetMiReportingWhenReportTypeSelected(t *testing.T) {
 }
 
 func TestGetMiReportingWhenConfigErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockMiReportingClient{}
 	client.
 		On("MiConfig", mock.Anything).
@@ -144,8 +141,6 @@ func TestGetMiReportingWhenConfigErrors(t *testing.T) {
 }
 
 func TestGetMiReportingWhenTemplateErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	reportTypes := []sirius.MiConfigEnum{
 		{Name: "epaReport", Description: "EPA Report"},
 		{Name: "lpaReport", Description: "LPA Report"},
@@ -219,8 +214,6 @@ func TestPostMiReporting(t *testing.T) {
 }
 
 func TestPostMiReportingWhenError(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockMiReportingClient{}
 	client.
 		On("MiReport", mock.Anything, url.Values{}).

--- a/internal/server/place_investigation_on_hold_test.go
+++ b/internal/server/place_investigation_on_hold_test.go
@@ -1,15 +1,15 @@
 package server
 
 import (
-	"errors"
-	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type mockPlaceInvestigationOnHoldClient struct {
@@ -77,8 +77,6 @@ func TestGetPlaceInvestigationOnHoldBadQuery(t *testing.T) {
 }
 
 func TestGetPlaceInvestigationOnHoldWhenInvestigationErrors(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockPlaceInvestigationOnHoldClient{}
 	client.
 		On("Investigation", mock.Anything, 123).
@@ -94,8 +92,6 @@ func TestGetPlaceInvestigationOnHoldWhenInvestigationErrors(t *testing.T) {
 }
 
 func TestGetPlaceInvestigationOnHoldWhenTemplateErrors(t *testing.T) {
-	expectedError := errors.New("err")
-
 	investigation := sirius.Investigation{
 		ID:           123,
 		Title:        "Test title",
@@ -207,8 +203,6 @@ func TestPostPlaceInvestigationOnHoldWhenValidationError(t *testing.T) {
 }
 
 func TestPostPlaceInvestigationOnHoldWhenOtherError(t *testing.T) {
-	expectedError := errors.New("err")
-
 	investigation := sirius.Investigation{
 		Type: "Priority",
 	}

--- a/internal/server/relationship_test.go
+++ b/internal/server/relationship_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -72,8 +71,6 @@ func TestGetRelationshipNoID(t *testing.T) {
 }
 
 func TestGetRelationshipWhenPersonErrors(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockRelationshipClient{}
 	client.
 		On("Person", mock.Anything, 123).
@@ -95,8 +92,6 @@ func TestGetRelationshipWhenPersonErrors(t *testing.T) {
 }
 
 func TestGetRelationshipWhenTemplateErrors(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockRelationshipClient{}
 	client.
 		On("Person", mock.Anything, 123).
@@ -192,8 +187,6 @@ func TestPostRelationshipWhenCreatePersonReferenceValidationError(t *testing.T) 
 }
 
 func TestPostRelationshipWhenCreatePersonReferenceOtherError(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockRelationshipClient{}
 	client.
 		On("Person", mock.Anything, 123).

--- a/internal/server/search_donors_test.go
+++ b/internal/server/search_donors_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -46,8 +45,6 @@ func TestGetSearchDonors(t *testing.T) {
 }
 
 func TestGetSearchDonorsWhenError(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockSearchDonorsClient{}
 	client.
 		On("SearchDonors", mock.Anything, "something").

--- a/internal/server/search_users_test.go
+++ b/internal/server/search_users_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -46,8 +45,6 @@ func TestGetSearchUsers(t *testing.T) {
 }
 
 func TestGetSearchUsersWhenError(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockSearchUsersClient{}
 	client.
 		On("SearchUsers", mock.Anything, "something").

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,8 @@ import (
 )
 
 const formUrlEncoded = "application/x-www-form-urlencoded"
+
+var expectedError = errors.New("error")
 
 type mockTemplate struct {
 	mock.Mock

--- a/internal/server/task_test.go
+++ b/internal/server/task_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -87,8 +86,6 @@ func TestGetTaskBadQueryString(t *testing.T) {
 }
 
 func TestGetTaskWhenTaskTypeErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockTaskClient{}
 	client.
 		On("TaskTypes", mock.Anything).
@@ -109,8 +106,6 @@ func TestGetTaskWhenTaskTypeErrors(t *testing.T) {
 }
 
 func TestGetTaskWhenTeamsErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockTaskClient{}
 	client.
 		On("TaskTypes", mock.Anything).
@@ -131,8 +126,6 @@ func TestGetTaskWhenTeamsErrors(t *testing.T) {
 }
 
 func TestGetTaskWhenCaseErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockTaskClient{}
 	client.
 		On("TaskTypes", mock.Anything).
@@ -153,8 +146,6 @@ func TestGetTaskWhenCaseErrors(t *testing.T) {
 }
 
 func TestGetTaskWhenTemplateErrors(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockTaskClient{}
 	client.
 		On("TaskTypes", mock.Anything).
@@ -233,8 +224,6 @@ func TestPostTask(t *testing.T) {
 }
 
 func TestPostTaskWhenCreateTaskFails(t *testing.T) {
-	expectedError := errors.New("hmm")
-
 	client := &mockTaskClient{}
 	client.
 		On("TaskTypes", mock.Anything).

--- a/internal/server/unlink_person_test.go
+++ b/internal/server/unlink_person_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -89,8 +88,6 @@ func TestUnlinkPersonNoID(t *testing.T) {
 }
 
 func TestUnlinkPersonsWhenFailure(t *testing.T) {
-	expectedError := errors.New("err")
-
 	client := &mockUnlinkPerson{}
 	client.
 		On("Person", mock.Anything, 189).
@@ -107,7 +104,6 @@ func TestUnlinkPersonsWhenFailure(t *testing.T) {
 
 func TestUnlinkPersonWhenTemplateErrors(t *testing.T) {
 	person := sirius.Person{ID: 189, Firstname: "John", Surname: "Doe"}
-	expectedError := errors.New("err")
 
 	client := &mockUnlinkPerson{}
 	client.


### PR DESCRIPTION
This is a little thing we started doing in the modernising repo and makes tests slightly less annoying