### PR TITLE
Update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,48 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
-  "branchPrefix": "renovate-"
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:base"
+    ],
+    "branchPrefix": "renovate-",
+    "commitMessageAction": "Renovate Update",
+    "labels": [
+        "Dependencies",
+        "Renovate"
+    ],
+    "lockFileMaintenance": {
+        "enabled": true
+    },
+    "packageRules": [
+        {
+            "automerge": true,
+            "groupName": "Patch & Minor Updates",
+            "groupSlug": "all-minor-patch-updates",
+            "matchPackagePatterns": [
+                "*"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch"
+            ],
+            "prPriority": 1,
+            "stabilityDays": 3
+        }
+    ],
+    "major": {
+        "labels": [
+            "Dependencies",
+            "Renovate"
+        ],
+        "prPriority": 0
+    },
+    "vulnerabilityAlerts": {
+        "groupName": "Vulnerability Patches",
+        "dependencyDashboardApproval": false,
+        "stabilityDays": 0,
+        "rangeStrategy": "update-lockfile",
+        "commitMessagePrefix": "[SECURITY]",
+        "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
+        "prCreation": "immediate",
+        "prPriority": 2
+    }
 }


### PR DESCRIPTION
To match config used in other services. This prioritises vulnerability alerts, does lock file maintenance, and groups all minor/patch updates into one PR