### PR TITLE
VEGA-1613 enable dark mode on non-embedded pages

### DIFF
--- a/web/assets/dark.scss
+++ b/web/assets/dark.scss
@@ -5,6 +5,7 @@ $sirius-bg-color: #29292e;
   color: govuk-colour("white");
   color-scheme: dark;
 
+  footer,
   body.govuk-template__body,
   .govuk-template {
     background-color: $sirius-bg-color;
@@ -23,6 +24,7 @@ $sirius-bg-color: #29292e;
   .govuk-heading-s,
   .govuk-heading-xs,
   p,
+  legend,
   .govuk-list {
     color: govuk-colour("white");
   }
@@ -60,9 +62,22 @@ $sirius-bg-color: #29292e;
   .govuk-textarea,
   .govuk-select,
   .govuk-table,
+  .moj-filter,
+  .moj-filter__selected,
   .autocomplete__input {
     background-color: $sirius-bg-color;
     color: govuk-colour("white");
+  }
+
+  .moj-pagination__link::before,
+  .moj-pagination__link::after {
+    filter: invert(100%);
+  }
+
+  .moj-pagination__link,
+  #search-results-table th,
+  #search-results-table th button {
+      color: govuk-colour("light-blue");
   }
 
   .govuk-notification-banner__content {

--- a/web/assets/dark.scss
+++ b/web/assets/dark.scss
@@ -5,7 +5,7 @@ $sirius-bg-color: #29292e;
   color: govuk-colour("white");
   color-scheme: dark;
 
-  footer,
+  .govuk-footer,
   body.govuk-template__body,
   .govuk-template {
     background-color: $sirius-bg-color;
@@ -75,9 +75,9 @@ $sirius-bg-color: #29292e;
   }
 
   .moj-pagination__link,
-  #search-results-table th,
-  #search-results-table th button {
-      color: govuk-colour("light-blue");
+  .app-\!-search-results-table th,
+  .app-\!-search-results-table th button {
+    color: govuk-colour("light-blue");
   }
 
   .govuk-notification-banner__content {

--- a/web/assets/load-classes.js
+++ b/web/assets/load-classes.js
@@ -5,11 +5,11 @@ document.body.className = document.body.className
 if (window.self !== window.parent) {
   document.documentElement.className += " app-!-html-class--embedded";
   document.body.className += " app-!-embedded";
+}
 
-  if (
-    document.cookie.indexOf("siriusTheme=dark") > -1 ||
-    document.cookie.indexOf("siriusTheme=accessible-dark") > -1
-  ) {
-    document.documentElement.className += " app-!-html-class--dark";
-  }
+if (
+  document.cookie.indexOf("siriusTheme=dark") > -1 ||
+  document.cookie.indexOf("siriusTheme=accessible-dark") > -1
+) {
+  document.documentElement.className += " app-!-html-class--dark";
 }

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -61,7 +61,7 @@ $moj-page-width: 1220px;
     width: fit-content;
 }
 
-#search-results-table th,
-#search-results-table th button {
+.app-\!-search-results-table th,
+.app-\!-search-results-table th button {
     color: govuk-colour("blue");
 }

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -41,10 +41,6 @@ $moj-page-width: 1220px;
    color: govuk-colour("red") !important;
 }
 
-.app-\!-colour-text-blue {
-   color: govuk-colour("blue") !important;
-}
-
 .app-\!-pre-wrap {
     white-space: pre-wrap;
 }
@@ -63,4 +59,9 @@ $moj-page-width: 1220px;
 
 .moj-filter-layout__filter {
     width: fit-content;
+}
+
+#search-results-table th,
+#search-results-table th button {
+    color: govuk-colour("blue");
 }

--- a/web/template/layout/deleted_cases.gohtml
+++ b/web/template/layout/deleted_cases.gohtml
@@ -1,7 +1,7 @@
 {{ define "deleted-cases" }}
     <table class="govuk-table">
         <thead class="govuk-table__head">
-        <tr class="govuk-table__row" id="search-results-table">
+        <tr class="govuk-table__row app-!-search-results-table">
             <th scope="col" class="govuk-table__header">Case number</th>
             <th scope="col" class="govuk-table__header">Type</th>
             <th scope="col" class="govuk-table__header">Online LPA ID</th>

--- a/web/template/layout/deleted_cases.gohtml
+++ b/web/template/layout/deleted_cases.gohtml
@@ -1,14 +1,14 @@
 {{ define "deleted-cases" }}
     <table class="govuk-table">
         <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header app-!-colour-text-blue">Case number</th>
-            <th scope="col" class="govuk-table__header app-!-colour-text-blue">Type</th>
-            <th scope="col" class="govuk-table__header app-!-colour-text-blue">Online LPA ID</th>
-            <th scope="col" class="govuk-table__header app-!-colour-text-blue">Status prior to deletion</th>
-            <th scope="col" class="govuk-table__header app-!-colour-text-blue">Reason for deletion</th>
-            <th scope="col" class="govuk-table__header app-!-colour-text-blue">Date deleted</th>
-            <th scope="col" class="govuk-table__header app-!-colour-text-blue">Status</th>
+        <tr class="govuk-table__row" id="search-results-table">
+            <th scope="col" class="govuk-table__header">Case number</th>
+            <th scope="col" class="govuk-table__header">Type</th>
+            <th scope="col" class="govuk-table__header">Online LPA ID</th>
+            <th scope="col" class="govuk-table__header">Status prior to deletion</th>
+            <th scope="col" class="govuk-table__header">Reason for deletion</th>
+            <th scope="col" class="govuk-table__header">Date deleted</th>
+            <th scope="col" class="govuk-table__header">Status</th>
         </tr>
         </thead>
         <tbody class="govuk-table__body">

--- a/web/template/search.gohtml
+++ b/web/template/search.gohtml
@@ -40,11 +40,11 @@
                 {{ if eq 0 (len .DeletedCases) }}
                     <table class="govuk-table" data-module="moj-sortable-table">
                         <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
+                        <tr class="govuk-table__row" id="search-results-table">
                             <th scope="col" class="govuk-table__header" aria-sort="none">Case number</th>
                             <th scope="col" class="govuk-table__header" aria-sort="none">Name/Role</th>
                             <th scope="col" class="govuk-table__header" aria-sort="none">Date of birth</th>
-                            <th scope="col" class="govuk-table__header govuk-!-width-one-third app-!-colour-text-blue">Address</th>
+                            <th scope="col" class="govuk-table__header govuk-!-width-one-third">Address</th>
                             <th scope="col" class="govuk-table__header" aria-sort="none">Type</th>
                             <th scope="col" class="govuk-table__header" aria-sort="none">Status</th>
                         </tr>

--- a/web/template/search.gohtml
+++ b/web/template/search.gohtml
@@ -40,7 +40,7 @@
                 {{ if eq 0 (len .DeletedCases) }}
                     <table class="govuk-table" data-module="moj-sortable-table">
                         <thead class="govuk-table__head">
-                        <tr class="govuk-table__row" id="search-results-table">
+                        <tr class="govuk-table__row app-!-search-results-table">
                             <th scope="col" class="govuk-table__header" aria-sort="none">Case number</th>
                             <th scope="col" class="govuk-table__header" aria-sort="none">Name/Role</th>
                             <th scope="col" class="govuk-table__header" aria-sort="none">Date of birth</th>


### PR DESCRIPTION
This is required as the new search results page is not embedded, and instead redirects the user to the lpa frontend url. I have applied styling to achieve desired dark mode appearance on search results page