### PR TITLE
Respond appropriately to bad search requests

### DIFF
--- a/internal/sirius/search.go
+++ b/internal/sirius/search.go
@@ -3,7 +3,6 @@ package sirius
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"math"
 	"net/http"
 )
@@ -46,7 +45,14 @@ var AllPersonTypes = []string{
 func (c *Client) Search(ctx Context, term string, page int, personTypeFilters []string) (SearchResponse, *Pagination, error) {
 	var v SearchResponse
 	if len(term) < 3 {
-		return v, nil, fmt.Errorf("Search term must be at least three characters")
+		err := ValidationError{
+			Detail: "Search term must be at least three characters",
+			Field: FieldErrors{
+				"term": {"reason": "Search term must be at least three characters"},
+			},
+		}
+
+		return v, nil, err
 	}
 
 	if len(personTypeFilters) == 0 {

--- a/internal/sirius/search_donors_test.go
+++ b/internal/sirius/search_donors_test.go
@@ -114,7 +114,14 @@ func TestSearchDonors(t *testing.T) {
 func TestSearchDonorsTooShort(t *testing.T) {
 	client := NewClient(http.DefaultClient, "")
 
+	expectedErr := ValidationError{
+		Detail: "Search term must be at least three characters",
+		Field: FieldErrors{
+			"term": {"reason": "Search term must be at least three characters"},
+		},
+	}
+
 	donors, err := client.SearchDonors(Context{Context: context.Background()}, "ad")
 	assert.Nil(t, donors)
-	assert.Equal(t, fmt.Errorf("Search term must be at least three characters"), err)
+	assert.Equal(t, expectedErr, err)
 }

--- a/internal/sirius/search_users.go
+++ b/internal/sirius/search_users.go
@@ -23,7 +23,14 @@ type User struct {
 
 func (c *Client) SearchUsers(ctx Context, term string) ([]User, error) {
 	if len(term) < 3 {
-		return nil, fmt.Errorf("Search term must be at least three characters")
+		err := ValidationError{
+			Detail: "Search term must be at least three characters",
+			Field: FieldErrors{
+				"term": {"reason": "Search term must be at least three characters"},
+			},
+		}
+
+		return nil, err
 	}
 
 	var v []apiUser

--- a/internal/sirius/search_users_test.go
+++ b/internal/sirius/search_users_test.go
@@ -77,7 +77,14 @@ func TestSearchUsers(t *testing.T) {
 func TestSearchUsersTooShort(t *testing.T) {
 	client := NewClient(http.DefaultClient, "")
 
+	expectedErr := ValidationError{
+		Detail: "Search term must be at least three characters",
+		Field: FieldErrors{
+			"term": {"reason": "Search term must be at least three characters"},
+		},
+	}
+
 	users, err := client.SearchUsers(Context{Context: context.Background()}, "ad")
 	assert.Nil(t, users)
-	assert.Equal(t, fmt.Errorf("Search term must be at least three characters"), err)
+	assert.Equal(t, expectedErr, err)
 }

--- a/web/assets/dark.scss
+++ b/web/assets/dark.scss
@@ -51,6 +51,7 @@ $sirius-bg-color: #29292e;
   }
 
   .govuk-label,
+  .govuk-fieldset__legend,
   .govuk-file-upload,
   .govuk-summary-list__key,
   .govuk-summary-list__value,

--- a/web/assets/select.js
+++ b/web/assets/select.js
@@ -10,11 +10,11 @@ export default function select(prefix) {
     fetchPerson(prefix)
   );
   enhanceTemplateSearchElement(
-      document.querySelector('[data-select-template]')
+    document.querySelector("[data-select-template]")
   );
 }
 
-function enhanceTemplateSearchElement(element){
+function enhanceTemplateSearchElement(element) {
   if (element) {
     accessibleAutocomplete.enhanceSelectElement({
       selectElement: element,
@@ -47,7 +47,11 @@ function enhanceUserPersonSearchElement(element, source) {
 
 function fetchForAutocomplete(url, mapFunction) {
   let controller = { abort: () => {} };
-  const fetchOptions = {};
+  const fetchOptions = {
+    headers: {
+      Accept: "application/json",
+    },
+  };
 
   return (query, callback) => {
     controller.abort();


### PR DESCRIPTION
Two main changes here:
- Respond to bad search requests with a ValidationError, not a plain text error
- If the request accepts JSON, return a RFC7807 error page rather than an HTML page

I also added coverage for fieldset labels in dark mode

#patch