### PR TITLE
VEGA-1576-cancelled-requests-bug

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -193,6 +195,10 @@ func errorHandler(logger Logger, tmplError template.Template, prefix, siriusURL 
 					}
 
 					return
+				}
+
+				if errors.Is(err, context.Canceled) {
+					code = 499
 				}
 
 				w.WriteHeader(code)


### PR DESCRIPTION
Changed error code to 499 for cancelled requests (commonly caused autocomplete search input fields), so that we can distinguish these separately from true 500 errors