### PR TITLE
VEGA-1239 document form fixes

### DIFF
--- a/cypress/e2e/create-document.cy.js
+++ b/cypress/e2e/create-document.cy.js
@@ -20,6 +20,17 @@ describe("Create a document", () => {
         cy.contains("button", "Create draft document").click();
     });
 
+    it("create document button is disabled if recipient is not selected", () => {
+        cy.contains("Select a recipient");
+        cy.contains("button", "Create draft document")
+            .invoke("attr", "class")
+            .should("contain", "govuk-button--disabled");
+        cy.get("#f-189").click();
+        cy.contains("button", "Create draft document")
+            .invoke("attr", "class")
+            .should("contain", "govuk-button");
+    });
+
     it("creates a new recipient via new recipient form", () => {
         cy.contains("Select a recipient");
         cy.contains("button", "Add new recipient").click();

--- a/cypress/e2e/create-document.cy.js
+++ b/cypress/e2e/create-document.cy.js
@@ -16,7 +16,7 @@ describe("Create a document", () => {
 
     it("creates a document on the case by selecting a recipient", () => {
         cy.contains("Select a recipient");
-        cy.get("#f-189").click();
+        cy.get("#f-recipient-189").click();
         cy.contains("button", "Create draft document").click();
     });
 
@@ -25,7 +25,7 @@ describe("Create a document", () => {
         cy.contains("button", "Create draft document")
             .invoke("attr", "class")
             .should("contain", "govuk-button--disabled");
-        cy.get("#f-189").click();
+        cy.get("#f-recipient-189").click();
         cy.contains("button", "Create draft document")
             .invoke("attr", "class")
             .should("contain", "govuk-button");

--- a/internal/server/create_document_test.go
+++ b/internal/server/create_document_test.go
@@ -123,7 +123,7 @@ func TestPostCreateDocument(t *testing.T) {
 				"case":              {caseType},
 				"templateId":        {"DD"},
 				"selectRecipients":  {"1"},
-				"recipientControls": {"select"},
+				"recipientControls": {"selectRecipients"},
 				"insert":            {"DDINSERT"},
 			}
 
@@ -197,7 +197,7 @@ func TestPostCreateDocumentGenerateNewRecipient(t *testing.T) {
 				"id":                {"123"},
 				"case":              {caseType},
 				"templateId":        {"DD"},
-				"recipientControls": {"generate"},
+				"recipientControls": {"addNewRecipient"},
 				"insert":            {"DDINSERT"},
 				"companyName":       {"Test Company Name"},
 				"companyReference":  {"Test Company Reference"},

--- a/internal/server/edit_document.go
+++ b/internal/server/edit_document.go
@@ -148,6 +148,8 @@ func EditDocument(client EditDocumentClient, tmpl template.Template) Handler {
 				if err != nil {
 					return err
 				}
+				data.Success = true
+
 			case "saveAndExit":
 				_, err := client.EditDocument(ctx, documentUUID, content)
 				if err != nil {

--- a/internal/server/edit_document_test.go
+++ b/internal/server/edit_document_test.go
@@ -263,6 +263,7 @@ func TestPostPublishDocument(t *testing.T) {
 			Case:      caseItem,
 			Documents: documents,
 			Document:  document,
+			Success:   true,
 		}).
 		Return(nil)
 

--- a/internal/templatefn/fn.go
+++ b/internal/templatefn/fn.go
@@ -94,6 +94,10 @@ func All(siriusPublicURL, prefix, staticHash string) map[string]interface{} {
 			}
 			return "", nil
 		},
+		"filterContent": func(content string) string {
+			//Fixes extra newline appearing in text editor due to newline present between the doctype and html tags
+			return strings.Replace(content, "<!DOCTYPE html>\n<html lang=\"en\">", "<!DOCTYPE html><html lang=\"en\">", -1)
+		},
 	}
 }
 

--- a/web/assets/auto-click.js
+++ b/web/assets/auto-click.js
@@ -1,12 +1,14 @@
 const autoClick = () => {
   /** @type HTMLAnchorElement|null autoClickLink */
-  const autoClickLinks = document.querySelectorAll('[data-module~="app-auto-click"]');
+  const autoClickLinks = document.querySelectorAll(
+    '[data-module~="app-auto-click"]'
+  );
 
   if (autoClickLinks) {
-      autoClickLinks.forEach($link => {
-          $link.click();
-          $link.hidden = true;
-      })
+    autoClickLinks.forEach(($link) => {
+      $link.click();
+      $link.hidden = true;
+    });
   }
 };
 

--- a/web/assets/handle-create-document-button.js
+++ b/web/assets/handle-create-document-button.js
@@ -1,0 +1,33 @@
+const handleCreateDocumentButton = () => {
+    /*  After creating a non case contact recipient, if a user clicks the create document button without selecting a
+        recipient, the recipient they just created will be lost (as non case contacts are not retrieved as part of the
+        call to get recipients). So JS is required to disable the button and enable it if at least one recipient has
+        been selected */
+
+  /** @type HTMLButtonElement|null createDocumentButton */
+  const createDocumentButton = document.querySelector(
+    '[data-module="create-document-button"]'
+  );
+
+    /** @type NodeList|null checkboxes */
+    const checkboxes = document.querySelectorAll(
+        '[data-module="recipient-checkbox"]'
+    );
+
+    if (checkboxes && checkboxes.length > 0) {
+        checkboxes.forEach((el, i) => {
+            el.addEventListener("change", (event) => {
+                let isOneRecipientSelected = Array.prototype.slice.call(checkboxes).some(x => x.checked);
+                if(isOneRecipientSelected) {
+                    createDocumentButton.ariaDisabled = "false";
+                    createDocumentButton.classList.remove("govuk-button--disabled");
+                } else {
+                    createDocumentButton.ariaDisabled = "true";
+                    createDocumentButton.classList.add("govuk-button--disabled");
+                }
+            });
+        })
+    }
+};
+
+export default handleCreateDocumentButton;

--- a/web/assets/handle-create-document-button.js
+++ b/web/assets/handle-create-document-button.js
@@ -1,5 +1,5 @@
 const handleCreateDocumentButton = () => {
-    /*  After creating a non case contact recipient, if a user clicks the create document button without selecting a
+  /*  After creating a non case contact recipient, if a user clicks the create document button without selecting a
         recipient, the recipient they just created will be lost (as non case contacts are not retrieved as part of the
         call to get recipients). So JS is required to disable the button and enable it if at least one recipient has
         been selected */
@@ -9,25 +9,27 @@ const handleCreateDocumentButton = () => {
     '[data-module="create-document-button"]'
   );
 
-    /** @type NodeList|null checkboxes */
-    const checkboxes = document.querySelectorAll(
-        '[data-module="recipient-checkbox"]'
-    );
+  /** @type NodeList|null checkboxes */
+  const checkboxes = document.querySelectorAll(
+    '[data-module="recipient-checkbox"]'
+  );
 
-    if (checkboxes && checkboxes.length > 0) {
-        checkboxes.forEach((el, i) => {
-            el.addEventListener("change", (event) => {
-                let isOneRecipientSelected = Array.prototype.slice.call(checkboxes).some(x => x.checked);
-                if(isOneRecipientSelected) {
-                    createDocumentButton.ariaDisabled = "false";
-                    createDocumentButton.classList.remove("govuk-button--disabled");
-                } else {
-                    createDocumentButton.ariaDisabled = "true";
-                    createDocumentButton.classList.add("govuk-button--disabled");
-                }
-            });
-        })
-    }
+  if (checkboxes && checkboxes.length > 0) {
+    checkboxes.forEach((el, i) => {
+      el.addEventListener("change", (event) => {
+        let isOneRecipientSelected = Array.from(checkboxes).some(
+          (x) => x.checked
+        );
+        if (isOneRecipientSelected) {
+          createDocumentButton.disabled = "false";
+          createDocumentButton.classList.remove("govuk-button--disabled");
+        } else {
+          createDocumentButton.disabled = "true";
+          createDocumentButton.classList.add("govuk-button--disabled");
+        }
+      });
+    });
+  }
 };
 
 export default handleCreateDocumentButton;

--- a/web/assets/handle-create-document-button.js
+++ b/web/assets/handle-create-document-button.js
@@ -21,10 +21,10 @@ const handleCreateDocumentButton = () => {
           (x) => x.checked
         );
         if (isOneRecipientSelected) {
-          createDocumentButton.disabled = "false";
+          createDocumentButton.removeAttribute("disabled")
           createDocumentButton.classList.remove("govuk-button--disabled");
         } else {
-          createDocumentButton.disabled = "true";
+          createDocumentButton.setAttribute("disabled", "true")
           createDocumentButton.classList.add("govuk-button--disabled");
         }
       });

--- a/web/assets/handle-insert-checkboxes.js
+++ b/web/assets/handle-insert-checkboxes.js
@@ -1,23 +1,25 @@
 const handleInsertCheckboxes = () => {
-    /*Insert checkboxes may appear twice and therefore js is needed to make sure
+  /*Insert checkboxes may appear twice and therefore js is needed to make sure
     that a check in one tab is displayed in the other*/
 
-    /** @type NodeList|null checkboxes */
-    const checkboxes = document.querySelectorAll(
-        '[data-module="insert-checkbox"]'
-    );
+  /** @type NodeList|null checkboxes */
+  const checkboxes = document.querySelectorAll(
+    '[data-module="insert-checkbox"]'
+  );
 
-    if (checkboxes && checkboxes.length > 0) {
-        checkboxes.forEach((el, i) => {
-            el.addEventListener("change", (event) => {
-                checkboxes.forEach((otherEl) => {
-                    if (otherEl.value === el.value) {
-                        el.checked ? otherEl.setAttribute("checked", "checked") : otherEl.removeAttribute("checked");
-                    }
-                })
-            });
-        })
-    }
+  if (checkboxes && checkboxes.length > 0) {
+    checkboxes.forEach((el, i) => {
+      el.addEventListener("change", (event) => {
+        checkboxes.forEach((otherEl) => {
+          if (otherEl.value === el.value) {
+            el.checked
+              ? otherEl.setAttribute("checked", "checked")
+              : otherEl.removeAttribute("checked");
+          }
+        });
+      });
+    });
+  }
 };
 
 export default handleInsertCheckboxes;

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -38,7 +38,7 @@ autoClick();
 handleCreateDocumentButton();
 
 if (window.self !== window.parent) {
-  const success = document.querySelector("[data-app-reload~=\"page\"]");
+  const success = document.querySelector('[data-app-reload~="page"]');
   if (success) {
     window.parent.postMessage(
       "form-done",
@@ -56,19 +56,23 @@ if (window.self !== window.parent) {
     });
   });
 
-  const saveAndExit = document.querySelector("[data-app-reload~=\"saveAndExit\"]");
+  const saveAndExit = document.querySelector(
+    '[data-app-reload~="saveAndExit"]'
+  );
   if (saveAndExit) {
     window.parent.postMessage(
-        "form-cancel",
-        `${window.location.protocol}//${window.location.host}`
+      "form-cancel",
+      `${window.location.protocol}//${window.location.host}`
     );
   }
 
-  const reloadTimeline = document.querySelector("[data-app-reload~=\"reload-timeline\"]");
+  const reloadTimeline = document.querySelector(
+    '[data-app-reload~="reload-timeline"]'
+  );
   if (reloadTimeline) {
     window.parent.postMessage(
-        "reload-timeline",
-        `${window.location.protocol}//${window.location.host}`
+      "reload-timeline",
+      `${window.location.protocol}//${window.location.host}`
     );
   }
 }

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -63,4 +63,12 @@ if (window.self !== window.parent) {
         `${window.location.protocol}//${window.location.host}`
     );
   }
+
+  const reloadTimeline = document.querySelector("[data-app-reload~=\"reload-timeline\"]");
+  if (reloadTimeline) {
+    window.parent.postMessage(
+        "reload-timeline",
+        `${window.location.protocol}//${window.location.host}`
+    );
+  }
 }

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -12,6 +12,7 @@ import textEditor from "./text-editor";
 import selectTab from "./select-tab";
 import handleInsertCheckboxes from "./handle-insert-checkboxes";
 import autoClick from "./auto-click";
+import handleCreateDocumentButton from "./handle-create-document-button";
 
 // Expose jQuery on window so MOJFrontend can use it
 window.$ = $;
@@ -34,6 +35,7 @@ textEditor();
 selectTab();
 handleInsertCheckboxes();
 autoClick();
+handleCreateDocumentButton();
 
 if (window.self !== window.parent) {
   const success = document.querySelector("[data-app-reload~=\"page\"]");

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -6,6 +6,7 @@ $moj-page-width: 1220px;
 @import "node_modules/@ministryofjustice/frontend/moj/all";
 @import "node_modules/accessible-autocomplete/src/autocomplete";
 @import "./dark.scss";
+@import "./wysiwyg.scss";
 
 .app-\!-embedded .app-\!-embedded-hide {
   display: none;

--- a/web/assets/select-tab.js
+++ b/web/assets/select-tab.js
@@ -1,37 +1,36 @@
 const selectTab = () => {
-    /** @type NodeList|null tabs */
-    const tabs = document.querySelectorAll(
-        '[data-module="tab-link"]'
-    );
+  /** @type NodeList|null tabs */
+  const tabs = document.querySelectorAll('[data-module="tab-link"]');
 
-    /** @type NodeList|null tabSections */
-    const tabSections = document.querySelectorAll(
-        '[data-module="tab-content"]'
-    );
+  /** @type NodeList|null tabSections */
+  const tabSections = document.querySelectorAll('[data-module="tab-content"]');
 
-    if (tabs && tabs.length > 0) {
-        const defaultSelectedTab = tabs[0]
-        defaultSelectedTab.classList.add("govuk-tabs__list-item--selected")
+  if (tabs && tabs.length > 0) {
+    const defaultSelectedTab = tabs[0];
+    defaultSelectedTab.classList.add("govuk-tabs__list-item--selected");
 
-        tabSections.forEach((section) => {
-            if(section.id !== defaultSelectedTab.id){
-                section.classList.add("govuk-tabs__panel--hidden")
-            }
+    tabSections.forEach((section) => {
+      if (section.id !== defaultSelectedTab.id) {
+        section.classList.add("govuk-tabs__panel--hidden");
+      }
+    });
+
+    tabs.forEach((el, i) => {
+      el.addEventListener("click", (event) => {
+        tabs.forEach((otherEl) => {
+          el.id === otherEl.id
+            ? el.classList.add("govuk-tabs__list-item--selected")
+            : otherEl.classList.remove("govuk-tabs__list-item--selected");
         });
 
-        tabs.forEach((el, i) => {
-            el.addEventListener("click", (event) => {
-                tabs.forEach((otherEl) => {
-                    el.id === otherEl.id ? el.classList.add("govuk-tabs__list-item--selected") : otherEl.classList.remove("govuk-tabs__list-item--selected");
-                })
-
-                tabSections.forEach((section) => {
-                    section.id !== el.id ? section.classList.add("govuk-tabs__panel--hidden") : section.classList.remove("govuk-tabs__panel--hidden");
-                });
-            });
-        })
-    }
+        tabSections.forEach((section) => {
+          section.id !== el.id
+            ? section.classList.add("govuk-tabs__panel--hidden")
+            : section.classList.remove("govuk-tabs__panel--hidden");
+        });
+      });
+    });
+  }
 };
 
 export default selectTab;
-

--- a/web/assets/text-editor.js
+++ b/web/assets/text-editor.js
@@ -17,6 +17,7 @@ const textEditor = () => {
         gecko_spellcheck: true,
         height: 300,
         cache_suffix: '?v=5.10.7',
+        content_css: '../stylesheets/all.css',
     });
 }
 

--- a/web/assets/text-editor.js
+++ b/web/assets/text-editor.js
@@ -17,9 +17,12 @@ const textEditor = () => {
         gecko_spellcheck: true,
         height: 300,
         cache_suffix: '?v=5.10.7',
-        content_css: '../stylesheets/all.css',
+        content_css: getContentCSSPath(),
     });
 }
 
 export default textEditor;
 
+function getContentCSSPath() {
+    return window.self !== window.parent ?  '../frontend/stylesheets/all.css' : '../stylesheets/all.css';
+}

--- a/web/assets/text-editor.js
+++ b/web/assets/text-editor.js
@@ -5,24 +5,26 @@ import "tinymce/plugins/paste";
 import "tinymce/plugins/lists";
 
 const textEditor = () => {
-    tinymce.init({
-        selector: '#documentTextEditor',
-        menubar: false,
-        statusbar: false,
-        toolbar: 'bold italic | bullist numlist',
-        plugins: 'paste lists',
-        paste_as_text: true,
-        paste_word_valid_elements: 'h1,h2,h3,strong,em,b,i',
-        browser_spellcheck: true,
-        gecko_spellcheck: true,
-        height: 300,
-        cache_suffix: '?v=5.10.7',
-        content_css: getContentCSSPath(),
-    });
-}
+  tinymce.init({
+    selector: "#documentTextEditor",
+    menubar: false,
+    statusbar: false,
+    toolbar: "bold italic | bullist numlist",
+    plugins: "paste lists",
+    paste_as_text: true,
+    paste_word_valid_elements: "h1,h2,h3,strong,em,b,i",
+    browser_spellcheck: true,
+    gecko_spellcheck: true,
+    height: 300,
+    cache_suffix: "?v=5.10.7",
+    content_css: getContentCSSPath(),
+  });
+};
 
 export default textEditor;
 
 function getContentCSSPath() {
-    return window.self !== window.parent ?  '../frontend/stylesheets/all.css' : '../stylesheets/all.css';
+  return window.self !== window.parent
+    ? "../frontend/stylesheets/all.css"
+    : "../stylesheets/all.css";
 }

--- a/web/assets/wysiwyg.scss
+++ b/web/assets/wysiwyg.scss
@@ -3,30 +3,30 @@
 // ----------------------------------------------------------------
 
 body#tinymce {
-    min-width: 0;
-    font-family: Verdana, Arial, Helvetica, sans-serif;
-    font-size: .9em;
-    margin: 15px;
+  min-width: 0;
+  font-family: Verdana, Arial, Helvetica, sans-serif;
+  font-size: 0.9em;
+  margin: 15px;
 
-    ul {
-        padding-left: 40px;
+  ul {
+    padding-left: 40px;
 
-        li {
-            list-style: disc;
-        }
+    li {
+      list-style: disc;
     }
+  }
 
-    ol li {
-        list-style: decimal;
-    }
+  ol li {
+    list-style: decimal;
+  }
 
-    .user-instruction {
-        color: blue;
-    }
+  .user-instruction {
+    color: blue;
+  }
 }
 
 .tox-tbtn {
-    min-width: 10px;
-    margin-left: 0;
-    background: none;
+  min-width: 10px;
+  margin-left: 0;
+  background: none;
 }

--- a/web/assets/wysiwyg.scss
+++ b/web/assets/wysiwyg.scss
@@ -1,0 +1,32 @@
+// ----------------------------------------------------------------
+// Styling for the inline WYSIWYG editor on create document
+// ----------------------------------------------------------------
+
+body#tinymce {
+    min-width: 0;
+    font-family: Verdana, Arial, Helvetica, sans-serif;
+    font-size: .9em;
+    margin: 15px;
+
+    ul {
+        padding-left: 40px;
+
+        li {
+            list-style: disc;
+        }
+    }
+
+    ol li {
+        list-style: decimal;
+    }
+
+    .user-instruction {
+        color: blue;
+    }
+}
+
+.tox-tbtn {
+    min-width: 10px;
+    margin-left: 0;
+    background: none;
+}

--- a/web/template/create_document.gohtml
+++ b/web/template/create_document.gohtml
@@ -4,7 +4,7 @@
 
 {{ define "main" }}
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-full">
             {{ template "error-summary" .Error }}
 
             {{ if .Success }}
@@ -119,7 +119,7 @@
                     </fieldset>
                 </div>
                 <div class="govuk-button-group govuk-!-padding-top-5">
-                    <button class="govuk-button" data-module="govuk-button" type="submit">Continue</button>
+                    <button class="govuk-button" data-module="govuk-button" type="submit" name="recipientControls" value="addNewRecipient">Continue</button>
                 </div>
                 <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
             </div>
@@ -164,7 +164,8 @@
                                 <div class="govuk-checkboxes__item">
                                     <input class="govuk-checkboxes__input" id="f-{{ .ID }}"
                                            name="selectRecipients" type="checkbox"
-                                           value="{{ .ID }}"/>
+                                           value="{{ .ID }}"
+                                           data-module="recipient-checkbox"/>
                                     <label class="govuk-label govuk-checkboxes__label"
                                            for="f-{{ .ID }}">
                                         {{ if .CompanyName  }}
@@ -184,7 +185,7 @@
         </div>
 
         <div class="govuk-button-group govuk-!-padding-top-5">
-            <button class="govuk-button" data-module="govuk-button" type="submit">Create draft document
+            <button class="govuk-button govuk-button--disabled" data-module="create-document-button" type="submit" name="recipientControls" value="selectRecipients">Create draft document
             </button>
         </div>
         <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>

--- a/web/template/create_document.gohtml
+++ b/web/template/create_document.gohtml
@@ -162,12 +162,12 @@
                         <td class="govuk-table__cell">
                             <div class="govuk-checkboxes" data-module="govuk-checkboxes">
                                 <div class="govuk-checkboxes__item">
-                                    <input class="govuk-checkboxes__input" id="f-{{ .ID }}"
+                                    <input class="govuk-checkboxes__input" id="f-recipient-{{ .ID }}"
                                            name="selectRecipients" type="checkbox"
                                            value="{{ .ID }}"
                                            data-module="recipient-checkbox"/>
                                     <label class="govuk-label govuk-checkboxes__label"
-                                           for="f-{{ .ID }}">
+                                           for="f-recipient-{{ .ID }}">
                                         {{ if .CompanyName  }}
                                             <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{{ .CompanyName }} ({{ .PersonType }})</h2>
                                         {{ else }}

--- a/web/template/edit_document.gohtml
+++ b/web/template/edit_document.gohtml
@@ -52,7 +52,7 @@
                     <input type="hidden" name="documentUUID" value="{{ .Document.UUID }}"/>
 
                     <div class="govuk-form-group {{ if .Error.Field.documentTextEditor }}govuk-form-group--error{{ end }} govuk-!-margin-bottom-2">
-                        <textarea id="documentTextEditor" name="documentTextEditor">{{ .Document.Content }}</textarea>
+                        <textarea id="documentTextEditor" name="documentTextEditor">{{ filterContent .Document.Content }}</textarea>
                     </div>
                     <div class="govuk-button-group govuk-!-margin-bottom-6">
                         <button class="govuk-button govuk-button--secondary" data-module="govuk-button"

--- a/web/template/edit_document.gohtml
+++ b/web/template/edit_document.gohtml
@@ -4,7 +4,7 @@
 
 {{ define "main" }}
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-full">
             {{ template "error-summary" .Error }}
 
             {{ if .Success }}

--- a/web/template/edit_document.gohtml
+++ b/web/template/edit_document.gohtml
@@ -8,11 +8,9 @@
             {{ template "error-summary" .Error }}
 
             {{ if .Success }}
-                <meta data-app-reload="page"/>
-                {{ template "success-banner" "You have successfully published a document." }}
+                <meta data-app-reload="reload-timeline"/>
             {{ else if .SaveAndExit }}
                 <meta data-app-reload="saveAndExit"/>
-                {{ template "success-banner" "You have successfully saved the document." }}
             {{ else if .PreviewDraft }}
                 <a href="{{ sirius (printf "/lpa-api/v1/documents/%s/download" .DownloadUUID) }}" target="_blank"
                    data-module="app-auto-click">Download preview document</a>
@@ -21,6 +19,7 @@
             <h1 class="govuk-heading-m">Edit draft document</h1>
 
             {{ if not .Documents }}
+                <meta data-app-reload="saveAndExit"/>
                 <p class="govuk-body govuk-!-padding-top-7 govuk-!-padding-bottom-7"><strong>There is currently no document
                         data available to display.</strong></p>
             {{ else }}
@@ -28,7 +27,7 @@
                     <input type="hidden" name="id" value="{{ .Case.ID }}"/>
                     <input type="hidden" name="case" value="{{ .Case.CaseType }}"/>
 
-                    <div class="govuk-form-group {{ if .Error.Field.document }}govuk-form-group--error{{ end }}">
+                    <div class="govuk-form-group {{ if .Error.Field.document }}govuk-form-group--error{{ end }} govuk-!-margin-bottom-0">
                         <label class="govuk-label" for="f-document">
                             Select a draft to edit
                         </label>


### PR DESCRIPTION
Fixes to issues discovered when manually testing create/edit document forms

Now
- disables create draft document button when no recipients are selected (instead of a validation error message)
- reloads timeline when a document published 
- adds text-editor content styling
- fixes header and layout issues (e.g. uses full width of widget as the document widget is wider than other widgets)
- fixes new line appearing in text editor due to new line between doctype and html tags