### PR TITLE
VEGA-1647-removing-details-from-edit-donor-bug

### DIFF
--- a/internal/sirius/create_contact_test.go
+++ b/internal/sirius/create_contact_test.go
@@ -30,6 +30,9 @@ func TestCreateContact(t *testing.T) {
 				Firstname:             "Pauline",
 				Middlenames:           "Suzanne",
 				Surname:               "Price",
+				DateOfBirth:           DateString("1995-07-01"),
+				PreviouslyKnownAs:     "",
+				AlsoKnownAs:           "",
 				CompanyName:           "",
 				CompanyReference:      "",
 				AddressLine1:          "278 Nicole Lock",
@@ -45,6 +48,7 @@ func TestCreateContact(t *testing.T) {
 				CorrespondenceByPost:  false,
 				CorrespondenceByEmail: true,
 				CorrespondenceByPhone: true,
+				ResearchOptOut:        false,
 			},
 			setup: func() {
 				pact.
@@ -62,8 +66,12 @@ func TestCreateContact(t *testing.T) {
 							"firstname":             "Pauline",
 							"middlenames":           "Suzanne",
 							"surname":               "Price",
+							"dob":                   "01/07/1995",
+							"previousNames":         "",
+							"otherNames":            "",
 							"addressLine1":          "278 Nicole Lock",
 							"addressLine2":          "Toby Court",
+							"addressLine3":          "",
 							"town":                  "Russellstad",
 							"county":                "Cumbria",
 							"postcode":              "HP19 9BW",
@@ -76,6 +84,9 @@ func TestCreateContact(t *testing.T) {
 							"correspondenceByEmail": true,
 							"correspondenceByPhone": true,
 							"correspondenceByWelsh": false,
+							"companyName":           "",
+							"companyReference":      "",
+							"researchOptOut":        false,
 						},
 					}).
 					WillRespondWith(dsl.Response{

--- a/internal/sirius/create_donor_test.go
+++ b/internal/sirius/create_donor_test.go
@@ -84,6 +84,8 @@ func TestCreateDonor(t *testing.T) {
 							"correspondenceByPhone": true,
 							"correspondenceByWelsh": false,
 							"researchOptOut":        true,
+							"companyName":           "",
+							"companyReference":      "",
 						},
 					}).
 					WillRespondWith(dsl.Response{

--- a/internal/sirius/edit_donor_test.go
+++ b/internal/sirius/edit_donor_test.go
@@ -83,6 +83,8 @@ func TestEditDonor(t *testing.T) {
 							"correspondenceByPhone": false,
 							"correspondenceByWelsh": true,
 							"researchOptOut":        true,
+							"companyName":           "",
+							"companyReference":      "",
 						},
 					}).
 					WillRespondWith(dsl.Response{

--- a/internal/sirius/person.go
+++ b/internal/sirius/person.go
@@ -12,16 +12,16 @@ type Person struct {
 	Firstname             string     `json:"firstname"`
 	Middlenames           string     `json:"middlenames"`
 	Surname               string     `json:"surname"`
-	DateOfBirth           DateString `json:"dob,omitempty"`
-	PreviouslyKnownAs     string     `json:"previousNames,omitempty"`
-	AlsoKnownAs           string     `json:"otherNames,omitempty"`
-	AddressLine1          string     `json:"addressLine1,omitempty"`
-	AddressLine2          string     `json:"addressLine2,omitempty"`
-	AddressLine3          string     `json:"addressLine3,omitempty"`
-	Town                  string     `json:"town,omitempty"`
-	County                string     `json:"county,omitempty"`
-	Postcode              string     `json:"postcode,omitempty"`
-	Country               string     `json:"country,omitempty"`
+	DateOfBirth           DateString `json:"dob"`
+	PreviouslyKnownAs     string     `json:"previousNames"`
+	AlsoKnownAs           string     `json:"otherNames"`
+	AddressLine1          string     `json:"addressLine1"`
+	AddressLine2          string     `json:"addressLine2"`
+	AddressLine3          string     `json:"addressLine3"`
+	Town                  string     `json:"town"`
+	County                string     `json:"county"`
+	Postcode              string     `json:"postcode"`
+	Country               string     `json:"country"`
 	IsAirmailRequired     bool       `json:"isAirmailRequired"`
 	PhoneNumber           string     `json:"phoneNumber"`
 	Email                 string     `json:"email"`
@@ -30,10 +30,10 @@ type Person struct {
 	CorrespondenceByEmail bool       `json:"correspondenceByEmail"`
 	CorrespondenceByPhone bool       `json:"correspondenceByPhone"`
 	CorrespondenceByWelsh bool       `json:"correspondenceByWelsh"`
-	ResearchOptOut        bool       `json:"researchOptOut,omitempty"`
+	ResearchOptOut        bool       `json:"researchOptOut"`
 	Children              []Person   `json:"children,omitempty"`
-	CompanyName           string     `json:"companyName,omitempty"`
-	CompanyReference      string     `json:"companyReference,omitempty"`
+	CompanyName           string     `json:"companyName"`
+	CompanyReference      string     `json:"companyReference"`
 	PersonType            string     `json:"personType,omitempty"`
 	Cases                 []*Case    `json:"cases,omitempty"`
 }


### PR DESCRIPTION
Removed `omitempty` tag from `person.go` attributes, otherwise you cannot set values to empty. Included missing data in tests
VEGA-1647 