### PR TITLE
VEGA-1239 display documents in alphabetical order

### DIFF
--- a/internal/server/create_document.go
+++ b/internal/server/create_document.go
@@ -283,6 +283,10 @@ func translateDocumentData(documentTemplateData []sirius.DocumentTemplateData, d
 		}
 	}
 
+	sort.Slice(documentTemplateTypes, func(i, j int) bool {
+		return documentTemplateTypes[i].Handle < documentTemplateTypes[j].Handle
+	})
+
 	return documentTemplateTypes
 }
 


### PR DESCRIPTION
Fixes alphabetical display of document templates