### PR TITLE
Use prerelease mode for tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,6 +263,7 @@ jobs:
           INITIAL_VERSION: 1.0.0
           DEFAULT_BRANCH: main
           DEFAULT_BUMP: minor
+          PRERELEASE: true
           PRERELEASE_SUFFIX: ${{ env.BRANCH_NAME }}
           RELEASE_BRANCHES: main
           WITH_V: true


### PR DESCRIPTION
Without being enabled, every version is treated as a real bump.