### PR TITLE
Add correspondent to Create Draft recipients

### DIFF
--- a/internal/server/create_document.go
+++ b/internal/server/create_document.go
@@ -2,14 +2,15 @@ package server
 
 import (
 	"fmt"
-	"github.com/ministryofjustice/opg-go-common/template"
-	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
-	"golang.org/x/exp/slices"
-	"golang.org/x/sync/errgroup"
 	"net/http"
 	"sort"
 	"strconv"
 	"sync"
+
+	"github.com/ministryofjustice/opg-go-common/template"
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
 )
 
 type CreateDocumentClient interface {
@@ -234,6 +235,10 @@ func getRecipients(ctx sirius.Context, client CreateDocumentClient, caseItem sir
 	recipientIds = append(recipientIds, donor.ID)
 	recipientIds = append(recipientIds, getPersonIds(caseItem.TrustCorporations)...)
 	recipientIds = append(recipientIds, getPersonIds(caseItem.Attorneys)...)
+
+	if caseItem.Correspondent != nil {
+		recipientIds = append(recipientIds, caseItem.Correspondent.ID)
+	}
 
 	var recipients []sirius.Person
 	group, groupCtx := errgroup.WithContext(ctx.Context)

--- a/internal/server/create_document_test.go
+++ b/internal/server/create_document_test.go
@@ -484,6 +484,29 @@ func TestGetRecipients(t *testing.T) {
 	assert.Equal(t, 3, len(recipients))
 }
 
+func TestGetRecipientsWithCorrespondent(t *testing.T) {
+	donor := sirius.Person{ID: 1}
+	attorney := sirius.Person{ID: 3}
+	correspondent := sirius.Person{ID: 4}
+	caseItem := sirius.Case{Donor: &donor, Attorneys: []sirius.Person{attorney}, Correspondent: &correspondent}
+
+	r, _ := http.NewRequest("GET", "/", nil)
+	ctx := getContext(r)
+	client := &mockCreateDocumentClient{}
+	client.
+		On("Person", mock.Anything, 1).
+		Return(donor, nil)
+	client.
+		On("Person", mock.Anything, 3).
+		Return(attorney, nil)
+	client.
+		On("Person", mock.Anything, 4).
+		Return(correspondent, nil)
+
+	recipients, _ := getRecipients(ctx, client, caseItem)
+	assert.Equal(t, 3, len(recipients))
+}
+
 func TestSliceAtoi(t *testing.T) {
 	testSliceStr := []string{"1", "2", "3"}
 	result, err := sliceAtoi(testSliceStr)

--- a/internal/sirius/case.go
+++ b/internal/sirius/case.go
@@ -21,6 +21,7 @@ type Case struct {
 	Donor             *Person    `json:"donor,omitempty"`
 	TrustCorporations []Person   `json:"trustCorporations,omitempty"`
 	Attorneys         []Person   `json:"attorneys,omitempty"`
+	Correspondent     *Person    `json:"correspondent,omitempty"`
 }
 
 func (c Case) Summary() string {


### PR DESCRIPTION
To match behaviour of the old form, ensure that correspondents can also be selected when they exist.

Fixes VEGA-1239 #minor