### PR TITLE
Reduce spacing in create document form

### DIFF
--- a/internal/server/create_document.go
+++ b/internal/server/create_document.go
@@ -129,8 +129,11 @@ func CreateDocument(client CreateDocumentClient, tmpl template.Template) Handler
 
 			hasViewedInsertPage := r.FormValue("hasViewedInserts")
 			hasNoInsertsToSelect := data.TemplateSelected.TemplateId != "" && len(data.DocumentInsertTypes) == 0
-			uniqueInserts := removeDuplicateStr(r.Form["insert"])
-			data.SelectedInserts = uniqueInserts
+
+			if r.FormValue("skipInserts") == "" {
+				uniqueInserts := removeDuplicateStr(r.Form["insert"])
+				data.SelectedInserts = uniqueInserts
+			}
 
 			if hasViewedInsertPage == "true" || hasNoInsertsToSelect {
 				data.HasViewedInsertPage = true
@@ -158,10 +161,10 @@ func CreateDocument(client CreateDocumentClient, tmpl template.Template) Handler
 				}
 
 				templateId := r.FormValue("templateId")
-				uniqueInserts := removeDuplicateStr(r.Form["insert"])
 
-				if len(uniqueInserts) == 0 {
-					uniqueInserts = []string{}
+				uniqueInserts := []string{}
+				if r.FormValue("skipInserts") == "" {
+					uniqueInserts = removeDuplicateStr(r.Form["insert"])
 				}
 
 				for _, recipientID := range selectedRecipientIDs {
@@ -214,13 +217,16 @@ func CreateDocument(client CreateDocumentClient, tmpl template.Template) Handler
 				} else {
 					data.Success = true
 					data.TemplateSelected.TemplateId = r.FormValue("templateId")
-					data.SelectedInserts = r.Form["insert"]
 					data.HasViewedInsertPage = true
 					data.Recipients, err = getRecipients(ctx, client, data.Case)
 					if err != nil {
 						return err
 					}
 					data.Recipients = append(data.Recipients, createdContact)
+
+					if r.FormValue("skipInserts") == "" {
+						data.SelectedInserts = r.Form["insert"]
+					}
 				}
 			}
 		}

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -13,6 +13,19 @@ $govuk-assets-path: "/lpa/frontend/assets/";
   display: none;
 }
 
+// When embedded, always use mobile-size wrapper spacing
+@include govuk-media-query($from: tablet) {
+    .app-\!-embedded .govuk-width-container {
+        margin-left: $govuk-gutter-half;
+        margin-right: $govuk-gutter-half;
+    }
+
+    .app-\!-embedded .govuk-main-wrapper {
+        padding-top: govuk-spacing(4);
+        padding-bottom: govuk-spacing(4);
+    }
+}
+
 .app-\!-html-class--embedded {
   font-size: 0.875em;
 }
@@ -47,18 +60,6 @@ $govuk-assets-path: "/lpa/frontend/assets/";
     border-bottom-color: govuk-colour("black") !important ;
 }
 
-.autocomplete__input {
-    z-index: 1;
-}
-
-.autocomplete__dropdown-arrow-down {
-    z-index: 0;
-}
-
-.autocomplete__wrapper {
-  font-family: $govuk-font-family;
-}
-
 .app-\!-width-fit-content {
     width: fit-content;
 }
@@ -66,6 +67,10 @@ $govuk-assets-path: "/lpa/frontend/assets/";
 .app-\!-search-results-table th,
 .app-\!-search-results-table th button {
     color: govuk-colour("blue");
+}
+
+.app-\!-float-left {
+    float: left;
 }
 
 .app-\!-float-right {
@@ -80,4 +85,29 @@ $govuk-assets-path: "/lpa/frontend/assets/";
 
 .app-\!-flex {
     display: flex;
+}
+
+.app-table--compact {
+    margin-bottom: 0;
+}
+
+.app-table--compact .govuk-table__cell {
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
+.app-tabs__panel--compact, .js-enabled .app-tabs__panel--compact {
+    padding: 0 10px;
+}
+
+.autocomplete__input {
+    z-index: 1;
+}
+
+.autocomplete__dropdown-arrow-down {
+    z-index: 0;
+}
+
+.autocomplete__wrapper {
+  font-family: $govuk-font-family;
 }

--- a/web/template/create_document.gohtml
+++ b/web/template/create_document.gohtml
@@ -181,20 +181,7 @@
 {{ end }}
 
 {{ define "select-insert" }}
-    <div class="govuk-clearfix">
-        <h1 class="govuk-heading-m app-!-float-left">Select document inserts</h1>
-        <form class="form" method="GET">
-            <input type="hidden" name="id" value="{{ .Case.ID }}"/>
-            <input type="hidden" name="case" value="{{ .Case.CaseType }}"/>
-            <input type="hidden" name="templateId" value="{{ .TemplateSelected.TemplateId }}"/>
-            <input type="hidden" name="hasViewedInserts" value="true"/>
-
-            <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0 app-!-float-right"
-                    data-module="govuk-button" type="submit">
-                Skip
-            </button>
-        </form>
-    </div>
+    <h1 class="govuk-heading-m">Select document inserts</h1>
 
     <form class="form" method="GET">
         <input type="hidden" name="id" value="{{ .Case.ID }}"/>
@@ -204,6 +191,12 @@
 
         <div class="govuk-tabs" data-module="govuk-tabs">
             <h2 class="govuk-tabs__title">Inserts</h2>
+
+            <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0 app-!-float-right"
+                    data-module="govuk-button" type="submit" name="skipInserts" value="true">
+                Skip
+            </button>
+
             <ul class="govuk-tabs__list">
                 {{ range .DocumentInsertKeys }}
                     <li class="govuk-tabs__list-item" data-module="tab-link" id="{{ . }}">

--- a/web/template/create_document.gohtml
+++ b/web/template/create_document.gohtml
@@ -26,7 +26,6 @@
                 <a href="{{ prefix .Back }}" class="govuk-back-link govuk-!-margin-top-0">Back</a>
                 {{ template "case-details" . }}
                 {{ template "select-insert" . }}
-
             {{ else }}
                 {{ template "case-details" . }}
                 {{ template "select-template" . }}
@@ -115,21 +114,23 @@
 {{ end }}
 
 {{ define "select-recipient" }}
-    <h1 class="govuk-heading-m app-!-float-left">Select a recipient</h1>
-    <form class="form" method="GET">
-        <input type="hidden" name="id" value="{{ .Case.ID }}"/>
-        <input type="hidden" name="case" value="{{ .Case.CaseType }}"/>
-        <input type="hidden" name="templateId" value="{{ .TemplateSelected.TemplateId }}"/>
-        {{ range .SelectedInserts }}
-            <input type="hidden" name="insert" value="{{ . }}"/>
-        {{ end }}
-        <input type="hidden" name="hasViewedInserts" value="true"/>
-        <input type="hidden" name="hasSelectedAddNewRecipient" value="true"/>
-        <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0 app-!-float-right"
-                data-module="govuk-button" type="submit">
-            Add new recipient
-        </button>
-    </form>
+    <div class="govuk-clearfix">
+        <h1 class="govuk-heading-m app-!-float-left">Select a recipient</h1>
+        <form class="form" method="GET">
+            <input type="hidden" name="id" value="{{ .Case.ID }}"/>
+            <input type="hidden" name="case" value="{{ .Case.CaseType }}"/>
+            <input type="hidden" name="templateId" value="{{ .TemplateSelected.TemplateId }}"/>
+            {{ range .SelectedInserts }}
+                <input type="hidden" name="insert" value="{{ . }}"/>
+            {{ end }}
+            <input type="hidden" name="hasViewedInserts" value="true"/>
+            <input type="hidden" name="hasSelectedAddNewRecipient" value="true"/>
+            <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0 app-!-float-right"
+                    data-module="govuk-button" type="submit">
+                Add new recipient
+            </button>
+        </form>
+    </div>
 
     <form class="form" method="POST">
         <input type="hidden" name="id" value="{{ .Case.ID }}"/>
@@ -180,7 +181,21 @@
 {{ end }}
 
 {{ define "select-insert" }}
-    <h1 class="govuk-heading-m">Select document inserts</h1>
+    <div class="govuk-clearfix">
+        <h1 class="govuk-heading-m app-!-float-left">Select document inserts</h1>
+        <form class="form" method="GET">
+            <input type="hidden" name="id" value="{{ .Case.ID }}"/>
+            <input type="hidden" name="case" value="{{ .Case.CaseType }}"/>
+            <input type="hidden" name="templateId" value="{{ .TemplateSelected.TemplateId }}"/>
+            <input type="hidden" name="hasViewedInserts" value="true"/>
+
+            <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0 app-!-float-right"
+                    data-module="govuk-button" type="submit">
+                Skip
+            </button>
+        </form>
+    </div>
+
     <form class="form" method="GET">
         <input type="hidden" name="id" value="{{ .Case.ID }}"/>
         <input type="hidden" name="case" value="{{ .Case.CaseType }}"/>

--- a/web/template/create_document.gohtml
+++ b/web/template/create_document.gohtml
@@ -13,22 +13,22 @@
             {{ end }}
 
             {{ if .HasSelectedAddNewRecipient }}
-                <a href="{{ prefix .Back }}" class="govuk-back-link">Back</a>
+                <a href="{{ prefix .Back }}" class="govuk-back-link govuk-!-margin-top-0">Back</a>
                 {{ template "case-details" . }}
                 {{ template "add-recipient" . }}
 
             {{ else if .HasViewedInsertPage }}
-                <a href="{{ prefix .Back }}" class="govuk-back-link">Back</a>
+                <a href="{{ prefix .Back }}" class="govuk-back-link govuk-!-margin-top-0">Back</a>
                 {{ template "case-details" . }}
                 {{ template "select-recipient" . }}
 
             {{ else if .TemplateSelected.TemplateId }}
-                <a href="{{ prefix .Back }}" class="govuk-back-link">Back</a>
+                <a href="{{ prefix .Back }}" class="govuk-back-link govuk-!-margin-top-0">Back</a>
                 {{ template "case-details" . }}
                 {{ template "select-insert" . }}
 
             {{ else }}
-                <div class="govuk-!-margin-top-8">{{ template "case-details" . }}</div>
+                {{ template "case-details" . }}
                 {{ template "select-template" . }}
             {{ end }}
         </div>
@@ -106,30 +106,30 @@
                 <div class="govuk-button-group govuk-!-padding-top-5">
                     <button class="govuk-button" data-module="govuk-button" type="submit" name="recipientControls" value="addNewRecipient">Continue</button>
                 </div>
-                <a href="{{ prefix .Back }}" class="govuk-link govuk-link--no-visited-state">Cancel</a>
+                <div class="govuk-body">
+                    <a href="{{ prefix .Back }}" class="govuk-link govuk-link--no-visited-state">Cancel</a>
+                </div>
             </div>
         </div>
     </form>
 {{ end }}
 
 {{ define "select-recipient" }}
-    <div class="govuk-grid-row">
-        <h1 class="govuk-heading-m govuk-grid-column-two-thirds">Select a recipient</h1>
-        <form class="form" method="GET">
-            <input type="hidden" name="id" value="{{ .Case.ID }}"/>
-            <input type="hidden" name="case" value="{{ .Case.CaseType }}"/>
-            <input type="hidden" name="templateId" value="{{ .TemplateSelected.TemplateId }}"/>
-            {{ range .SelectedInserts }}
-                <input type="hidden" name="insert" value="{{ . }}"/>
-            {{ end }}
-            <input type="hidden" name="hasViewedInserts" value="true"/>
-            <input type="hidden" name="hasSelectedAddNewRecipient" value="true"/>
-            <button class="govuk-button govuk-button--secondary app-!-float-right govuk-grid-column-one-third"
-                    data-module="govuk-button" type="submit">
-                Add new recipient
-            </button>
-        </form>
-    </div>
+    <h1 class="govuk-heading-m app-!-float-left">Select a recipient</h1>
+    <form class="form" method="GET">
+        <input type="hidden" name="id" value="{{ .Case.ID }}"/>
+        <input type="hidden" name="case" value="{{ .Case.CaseType }}"/>
+        <input type="hidden" name="templateId" value="{{ .TemplateSelected.TemplateId }}"/>
+        {{ range .SelectedInserts }}
+            <input type="hidden" name="insert" value="{{ . }}"/>
+        {{ end }}
+        <input type="hidden" name="hasViewedInserts" value="true"/>
+        <input type="hidden" name="hasSelectedAddNewRecipient" value="true"/>
+        <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0 app-!-float-right"
+                data-module="govuk-button" type="submit">
+            Add new recipient
+        </button>
+    </form>
 
     <form class="form" method="POST">
         <input type="hidden" name="id" value="{{ .Case.ID }}"/>
@@ -140,40 +140,42 @@
 
         <div class="govuk-form-group {{ if .Error.Field.selectRecipient }}govuk-form-group--error{{ end }}">
             {{ template "errors" .Error.Field.selectRecipient }}
-            <table class="govuk-table my-table table__no-border">
-                <tbody class="govuk-table__body">
-                {{ range .Recipients }}
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
-                            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                                <div class="govuk-checkboxes__item">
-                                    <input class="govuk-checkboxes__input" id="f-recipient-{{ .ID }}"
-                                           name="selectRecipients" type="checkbox"
-                                           value="{{ .ID }}"
-                                           data-module="recipient-checkbox"/>
-                                    <label class="govuk-label govuk-checkboxes__label"
-                                           for="f-recipient-{{ .ID }}">
-                                        {{ if .CompanyName  }}
-                                            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{{ .CompanyName }} ({{ .PersonType }})</h2>
-                                        {{ else }}
-                                            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{{ .Salutation }} {{ .Firstname }} {{ .Surname }} ({{ .PersonType }})</h2>
-                                        {{ end }}
-                                        <p class="govuk-body govuk-!-margin-bottom-0">{{ .AddressLine1 }}, {{ .AddressLine2 }}, {{ .AddressLine3 }}, {{ .Town }}, {{ .County }}, {{ .Postcode }}.</p>
-                                    </label>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                {{ end }}
-                </tbody>
-            </table>
+            <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+                <table class="govuk-table">
+                    <tbody class="govuk-table__body">
+                    {{ range .Recipients }}
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell">
+                                    <div class="govuk-checkboxes__item">
+                                        <input class="govuk-checkboxes__input" id="f-recipient-{{ .ID }}"
+                                            name="selectRecipients" type="checkbox"
+                                            value="{{ .ID }}"
+                                            data-module="recipient-checkbox"/>
+                                        <label class="govuk-label govuk-checkboxes__label"
+                                            for="f-recipient-{{ .ID }}">
+                                            {{ if .CompanyName  }}
+                                                <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{{ .CompanyName }} ({{ .PersonType }})</h2>
+                                            {{ else }}
+                                                <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{{ .Salutation }} {{ .Firstname }} {{ .Surname }} ({{ .PersonType }})</h2>
+                                            {{ end }}
+                                            <p class="govuk-body govuk-!-margin-bottom-0">{{ .AddressLine1 }}, {{ .AddressLine2 }}, {{ .AddressLine3 }}, {{ .Town }}, {{ .County }}, {{ .Postcode }}.</p>
+                                        </label>
+                                    </div>
+                            </td>
+                        </tr>
+                    {{ end }}
+                    </tbody>
+                </table>
+            </div>
         </div>
 
         <div class="govuk-button-group govuk-!-padding-top-5">
             <button class="govuk-button govuk-button--disabled" data-module="create-document-button" type="submit" name="recipientControls" value="selectRecipients">Create draft document
             </button>
         </div>
-        <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+        <div class="govuk-body">
+            <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+        </div>
     </form>
 {{ end }}
 
@@ -198,60 +200,61 @@
             </ul>
 
             {{ range $k := .DocumentInsertKeys }}
-                <div class="govuk-tabs__panel" data-module="tab-content" id="{{ $k }}">
-                    <table class="govuk-table my-table table__no-border">
-                        <tbody class="govuk-table__body app-!-td-last-child-no-border">
-                        {{ range $t := $.DocumentInsertTypes }}
-                            {{if eq $t.Key $k }}
-                                <tr class="govuk-table__row app-!-table-row__no-border">
-                                    <td class="govuk-table__cell">
-                                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                                            <div class="govuk-checkboxes__item">
-                                                <input class="govuk-checkboxes__input"
-                                                       id="f-{{ $t.Handle }}-{{$k}}"
-                                                       name="insert"
-                                                       type="checkbox" value="{{ $t.Handle }}"
-                                                       data-module="insert-checkbox"
-                                                       {{ if contains $.SelectedInserts $t.Handle }}checked{{ end }}/>
-                                                <label class="govuk-label govuk-checkboxes__label"
-                                                       for="f-{{ $t.Handle }}-{{$k}}">
-                                                    {{ $t.Handle }}: {{ $t.Label }}
-                                                </label>
+                <div class="govuk-tabs__panel app-tabs__panel--compact" data-module="tab-content" id="{{ $k }}">
+                    <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+                        <table class="govuk-table app-table--compact">
+                            <tbody class="govuk-table__body app-!-td-last-child-no-border">
+                            {{ range $t := $.DocumentInsertTypes }}
+                                {{if eq $t.Key $k }}
+                                    <tr class="govuk-table__row app-!-table-row__no-border">
+                                        <td class="govuk-table__cell">
+                                                <div class="govuk-checkboxes__item">
+                                                    <input class="govuk-checkboxes__input"
+                                                        id="f-{{ $t.Handle }}-{{$k}}"
+                                                        name="insert"
+                                                        type="checkbox" value="{{ $t.Handle }}"
+                                                        data-module="insert-checkbox"
+                                                        {{ if contains $.SelectedInserts $t.Handle }}checked{{ end }}/>
+                                                    <label class="govuk-label govuk-checkboxes__label"
+                                                        for="f-{{ $t.Handle }}-{{$k}}">
+                                                        {{ $t.Handle }}: {{ $t.Label }}
+                                                    </label>
+                                                </div>
                                             </div>
-                                        </div>
-                                    </td>
-                                </tr>
-                            {{ else if eq $k "all" }}
-                                <tr class="govuk-table__row app-!-table-row__no-border">
-                                    <td class="govuk-table__cell">
-                                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                                            <div class="govuk-checkboxes__item">
-                                                <input class="govuk-checkboxes__input"
-                                                       id="f-{{ $t.Handle }}-{{$k}}"
-                                                       name="insert"
-                                                       type="checkbox" value="{{ $t.Handle }}"
-                                                       data-module="insert-checkbox"
-                                                       {{ if contains $.SelectedInserts $t.Handle }}checked{{ end }}/>
-                                                <label class="govuk-label govuk-checkboxes__label"
-                                                       for="f-{{ $t.Handle }}-{{$k}}">
-                                                    {{ $t.Handle }}: {{ $t.Label }}
-                                                </label>
-                                            </div>
-                                        </div>
-                                    </td>
-                                </tr>
+                                        </td>
+                                    </tr>
+                                {{ else if eq $k "all" }}
+                                    <tr class="govuk-table__row app-!-table-row__no-border">
+                                        <td class="govuk-table__cell">
+                                                <div class="govuk-checkboxes__item">
+                                                    <input class="govuk-checkboxes__input"
+                                                        id="f-{{ $t.Handle }}-{{$k}}"
+                                                        name="insert"
+                                                        type="checkbox" value="{{ $t.Handle }}"
+                                                        data-module="insert-checkbox"
+                                                        {{ if contains $.SelectedInserts $t.Handle }}checked{{ end }}/>
+                                                    <label class="govuk-label govuk-checkboxes__label"
+                                                        for="f-{{ $t.Handle }}-{{$k}}">
+                                                        {{ $t.Handle }}: {{ $t.Label }}
+                                                    </label>
+                                                </div>
+                                        </td>
+                                    </tr>
+                                {{ end }}
                             {{ end }}
-                        {{ end }}
-                        </tbody>
-                    </table>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             {{ end }}
         </div>
 
-        <div class="govuk-button-group govuk-!-padding-top-5">
+        <div class="govuk-button-group">
             <button class="govuk-button" data-module="govuk-button" type="submit">Continue</button>
         </div>
-        <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+        <div class="govuk-body">
+            <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+        </div>
     </form>
 {{ end }}
 
@@ -278,6 +281,8 @@
         <div class="govuk-button-group govuk-!-padding-top-5">
             <button class="govuk-button" data-module="govuk-button" type="submit">Continue</button>
         </div>
-        <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+        <div class="govuk-body">
+            <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+        </div>
     </form>
 {{ end }}

--- a/web/template/edit_document.gohtml
+++ b/web/template/edit_document.gohtml
@@ -17,7 +17,7 @@
                    data-module="app-auto-click">Download preview document</a>
             {{ end }}
 
-            <a href="{{ prefix (printf "/create-document?id=%d&case=%s" .Case.ID .Case.CaseType) }}" class="govuk-back-link">Back</a>
+            <a href="{{ prefix (printf "/create-document?id=%d&case=%s" .Case.ID .Case.CaseType) }}" class="govuk-back-link govuk-!-margin-top-0">Back</a>
             {{ template "case-details" . }}
             <h1 class="govuk-heading-m">Edit draft document</h1>
 
@@ -76,7 +76,9 @@
                                 value="publish">Publish draft
                         </button>
                     </div>
-                    <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+                    <div class="govuk-body">
+                        <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+                    </div>
                 </form>
             {{ end }}
         </div>

--- a/web/template/payments.gohtml
+++ b/web/template/payments.gohtml
@@ -17,7 +17,7 @@
                 <p class="govuk-body govuk-!-padding-top-7 govuk-!-padding-bottom-7"><strong>There is currently no fee
                         data available to display.</strong></p>
             {{ else }}
-                <table class="govuk-table my-table table__no-border">
+                <table class="govuk-table">
                     <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
                         {{ if gt .OutstandingFee 0 }}


### PR DESCRIPTION
Use smaller checkboxes, make inserts panel/table compact, remove a few spacing classes.

When embedded at tablet width (or wider), use mobile-scale gutters for main page containers.

Fixes VEGA-1711 #minor