### PR TITLE
Ignore gosec false positives

### DIFF
--- a/internal/sirius/add_complaint.go
+++ b/internal/sirius/add_complaint.go
@@ -22,7 +22,7 @@ func (c *Client) AddComplaint(ctx Context, caseID int, caseType CaseType, compla
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/add_document.go
+++ b/internal/sirius/add_document.go
@@ -38,7 +38,7 @@ func (c *Client) AddDocument(ctx Context, caseID int, document Document, docType
 	if err != nil {
 		return Document{}, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/add_payment.go
+++ b/internal/sirius/add_payment.go
@@ -31,7 +31,7 @@ func (c *Client) AddPayment(ctx Context, caseID int, amount int, source string, 
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/allocate_cases.go
+++ b/internal/sirius/allocate_cases.go
@@ -37,7 +37,7 @@ func (c *Client) AllocateCases(ctx Context, assigneeID int, allocations []CaseAl
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/apply_fee_reduction.go
+++ b/internal/sirius/apply_fee_reduction.go
@@ -35,7 +35,7 @@ func (c *Client) ApplyFeeReduction(ctx Context, caseID int, feeReductionType str
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/assign_tasks.go
+++ b/internal/sirius/assign_tasks.go
@@ -23,7 +23,7 @@ func (c *Client) AssignTasks(ctx Context, assigneeID int, taskIDs []int) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/client.go
+++ b/internal/sirius/client.go
@@ -65,7 +65,7 @@ func (c *Client) get(ctx Context, path string, v interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode != http.StatusOK {
 		return newStatusError(resp)

--- a/internal/sirius/create_contact.go
+++ b/internal/sirius/create_contact.go
@@ -21,7 +21,7 @@ func (c *Client) CreateContact(ctx Context, contact Person) (Person, error) {
 	if err != nil {
 		return Person{}, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/create_document.go
+++ b/internal/sirius/create_document.go
@@ -33,7 +33,7 @@ func (c *Client) CreateDocument(ctx Context, caseID, correspondentID int, templa
 	if err != nil {
 		return d, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/create_donor.go
+++ b/internal/sirius/create_donor.go
@@ -21,7 +21,7 @@ func (c *Client) CreateDonor(ctx Context, person Person) (Person, error) {
 	if err != nil {
 		return Person{}, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/create_investigation.go
+++ b/internal/sirius/create_investigation.go
@@ -22,7 +22,7 @@ func (c *Client) CreateInvestigation(ctx Context, caseID int, caseType CaseType,
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/create_note.go
+++ b/internal/sirius/create_note.go
@@ -40,7 +40,7 @@ func (c *Client) CreateNote(ctx Context, entityID int, entityType EntityType, no
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	defer res.Body.Close() //#nosec G307 false positive
 
 	if res.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/create_person_reference.go
+++ b/internal/sirius/create_person_reference.go
@@ -31,7 +31,7 @@ func (c *Client) CreatePersonReference(ctx Context, personID int, referencedUID,
 		return err
 	}
 
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/create_task.go
+++ b/internal/sirius/create_task.go
@@ -30,7 +30,7 @@ func (c *Client) CreateTask(ctx Context, caseID int, task TaskRequest) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/create_warning.go
+++ b/internal/sirius/create_warning.go
@@ -36,7 +36,7 @@ func (c *Client) CreateWarning(ctx Context, personId int, warningType string, wa
 		return err
 	}
 
-	defer res.Body.Close()
+	defer res.Body.Close() //#nosec G307 false positive
 
 	if res.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/delete_document.go
+++ b/internal/sirius/delete_document.go
@@ -15,7 +15,7 @@ func (c *Client) DeleteDocument(ctx Context, uuid string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode != http.StatusNoContent {
 		return newStatusError(resp)

--- a/internal/sirius/delete_payment.go
+++ b/internal/sirius/delete_payment.go
@@ -15,7 +15,7 @@ func (c *Client) DeletePayment(ctx Context, paymentID int) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode != http.StatusNoContent {
 		return newStatusError(resp)

--- a/internal/sirius/delete_person_reference.go
+++ b/internal/sirius/delete_person_reference.go
@@ -15,7 +15,7 @@ func (c *Client) DeletePersonReference(ctx Context, referenceID int) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode != http.StatusNoContent {
 		return newStatusError(resp)

--- a/internal/sirius/document_templates.go
+++ b/internal/sirius/document_templates.go
@@ -101,7 +101,7 @@ func (c *Client) DocumentTemplates(ctx Context, caseType CaseType) ([]DocumentTe
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	var v documentTemplateApiResponse
 	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {

--- a/internal/sirius/edit_case.go
+++ b/internal/sirius/edit_case.go
@@ -23,7 +23,7 @@ func (c *Client) EditCase(ctx Context, caseID int, caseType CaseType, caseDetail
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/edit_complaint.go
+++ b/internal/sirius/edit_complaint.go
@@ -22,7 +22,7 @@ func (c *Client) EditComplaint(ctx Context, id int, complaint Complaint) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/edit_dates.go
+++ b/internal/sirius/edit_dates.go
@@ -33,7 +33,7 @@ func (c *Client) EditDates(ctx Context, caseID int, caseType CaseType, dates Dat
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/edit_document.go
+++ b/internal/sirius/edit_document.go
@@ -26,7 +26,7 @@ func (c *Client) EditDocument(ctx Context, uuid string, content string) (Documen
 	if err != nil {
 		return Document{}, err
 	}
-	defer res.Body.Close()
+	defer res.Body.Close() //#nosec G307 false positive
 
 	if res.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/edit_donor.go
+++ b/internal/sirius/edit_donor.go
@@ -22,7 +22,7 @@ func (c *Client) EditDonor(ctx Context, personID int, person Person) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/edit_investigation.go
+++ b/internal/sirius/edit_investigation.go
@@ -22,7 +22,7 @@ func (c *Client) EditInvestigation(ctx Context, investigationID int, investigati
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v struct {

--- a/internal/sirius/edit_payment.go
+++ b/internal/sirius/edit_payment.go
@@ -22,7 +22,7 @@ func (c *Client) EditPayment(ctx Context, paymentID int, payment Payment) error 
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/link_people.go
+++ b/internal/sirius/link_people.go
@@ -35,7 +35,7 @@ func (c *Client) LinkPeople(ctx Context, parentId int, childId int) error {
 		return err
 	}
 
-	defer res.Body.Close()
+	defer res.Body.Close() //#nosec G307 false positive
 
 	if res.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/mi_report.go
+++ b/internal/sirius/mi_report.go
@@ -31,7 +31,7 @@ func (c *Client) MiReport(ctx Context, params url.Values) (*MiReportResponse, er
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v miReportError

--- a/internal/sirius/place_investigation_on_hold.go
+++ b/internal/sirius/place_investigation_on_hold.go
@@ -26,7 +26,7 @@ func (c *Client) PlaceInvestigationOnHold(ctx Context, investigationID int, reas
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/search.go
+++ b/internal/sirius/search.go
@@ -73,7 +73,7 @@ func (c *Client) Search(ctx Context, term string, page int, personTypeFilters []
 	if err != nil {
 		return v, nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode != http.StatusOK {
 		return v, nil, newStatusError(resp)

--- a/internal/sirius/take_investigation_off_hold.go
+++ b/internal/sirius/take_investigation_off_hold.go
@@ -16,7 +16,7 @@ func (c *Client) TakeInvestigationOffHold(ctx Context, holdPeriodId int) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError

--- a/internal/sirius/unlink_person.go
+++ b/internal/sirius/unlink_person.go
@@ -27,7 +27,7 @@ func (c *Client) UnlinkPerson(ctx Context, parentId int, childId int) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //#nosec G307 false positive
 
 	if resp.StatusCode == http.StatusBadRequest {
 		var v ValidationError


### PR DESCRIPTION
We don't care about errors when closing the body of an API request

Fixes VEGA-1706 #patch