### PR TITLE
VEGA-1669 remove unrequired payload failed validation message

### DIFF
--- a/web/template/layout/error-summary.gohtml
+++ b/web/template/layout/error-summary.gohtml
@@ -6,7 +6,7 @@
       </h2>
       <div class="govuk-error-summary__body">
         <ul class="govuk-list govuk-error-summary__list">
-          {{ if .Detail }}
+          {{ if (and .Detail (ne .Detail "Payload failed validation") )}}
             <li>{{ .Detail }}</li>
           {{ end }}
           {{ range $k, $v := .Field }}


### PR DESCRIPTION
Removes payload failed validation message that appears on validation messages as it is not necessary for users