### PR TITLE
Sort inserts by sent order

### DIFF
--- a/internal/server/create_document.go
+++ b/internal/server/create_document.go
@@ -320,10 +320,6 @@ func translateInsertData(selectedTemplateInserts []sirius.Insert, documentTempla
 		}
 	}
 
-	sort.Slice(documentTemplateInserts, func(i, j int) bool {
-		return documentTemplateInserts[i].Handle < documentTemplateInserts[j].Handle
-	})
-
 	return documentTemplateInserts
 }
 

--- a/internal/sirius/document_templates.go
+++ b/internal/sirius/document_templates.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 )
 
 type documentTemplateApiResponse map[string]json.RawMessage
@@ -13,6 +14,7 @@ type insertApiResponse map[string]json.RawMessage
 type UniversalTemplateData struct {
 	Location        string `json:"location"`
 	OnScreenSummary string `json:"onScreenSummary"`
+	Order           int    `json:"order"`
 }
 
 type documentTemplateApiData struct {
@@ -26,6 +28,7 @@ type Insert struct {
 	InsertId        string
 	Location        string `json:"location"`
 	OnScreenSummary string `json:"onScreenSummary"`
+	Order           int    `json:"order"`
 }
 
 type DocumentTemplateData struct {
@@ -81,6 +84,7 @@ func (i insertApiResponse) toInsertData() ([]Insert, error) {
 				insert.InsertId = insertId
 				insert.Location = insertData.Location
 				insert.OnScreenSummary = insertData.OnScreenSummary
+				insert.Order = insertData.Order
 				inserts = append(inserts, insert)
 			}
 			continue
@@ -88,6 +92,15 @@ func (i insertApiResponse) toInsertData() ([]Insert, error) {
 
 		return nil, errors.New("could not format insert data")
 	}
+
+	sort.Slice(inserts, func(i, j int) bool {
+		if inserts[i].Key != inserts[j].Key {
+			return inserts[i].Key < inserts[j].Key
+		}
+
+		return inserts[i].Order < inserts[j].Order
+	})
+
 	return inserts, nil
 }
 

--- a/internal/sirius/document_templates_test.go
+++ b/internal/sirius/document_templates_test.go
@@ -44,6 +44,7 @@ func TestDocumentTypes(t *testing.T) {
 										"DD1": dsl.Like(map[string]interface{}{
 											"onScreenSummary": dsl.Like("DD1LPAINSERTONSCREENSUMMARY"),
 											"location":        dsl.Like(`lpa\/inserts\/DD1.html.twig`),
+											"order":           dsl.Like(0),
 										}),
 									}),
 								}),
@@ -60,6 +61,7 @@ func TestDocumentTypes(t *testing.T) {
 							InsertId:        "DD1",
 							Location:        `lpa\/inserts\/DD1.html.twig`,
 							OnScreenSummary: "DD1LPAINSERTONSCREENSUMMARY",
+							Order:           0,
 						},
 					},
 					Location:        `lpa\/DD.html.twig`,


### PR DESCRIPTION
Use the new `order` property to sort inserts, and do this when retrieving from the DB to reduce complexity of server code.

Fixes VEGA-1716 #patch