### PR TITLE
Some create document design changes

### DIFF
--- a/web/template/create_document.gohtml
+++ b/web/template/create_document.gohtml
@@ -33,7 +33,13 @@
                 {{ template "create-document-back-and-case-details" . }}
                 {{ template "select-insert" . }}
             {{ else }}
-                {{ template "case-details" . }}
+                <div class="govuk-body">
+                    <a href="#" data-app-iframe-cancel class="govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-0">Back</a>
+                    <div class="app-!-float-right">
+                        {{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "hw" }}HW{{ end }} {{ .Case.UID }}
+                    </div>
+                </div>
+
                 {{ template "select-template" . }}
             {{ end }}
         </div>

--- a/web/template/create_document.gohtml
+++ b/web/template/create_document.gohtml
@@ -2,6 +2,15 @@
 
 {{ define "title" }}{{ if .Error.Any }}Error: {{ end }}Create Document{{ end }}
 
+{{ define "create-document-back-and-case-details" }}
+    <div class="govuk-body">
+        <a href="{{ prefix .Back }}" class="govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-0">Back</a>
+        <div class="app-!-float-right">
+            {{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "hw" }}HW{{ end }} {{ .Case.UID }}
+        </div>
+    </div>
+{{ end }}
+
 {{ define "main" }}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
@@ -13,18 +22,15 @@
             {{ end }}
 
             {{ if .HasSelectedAddNewRecipient }}
-                <a href="{{ prefix .Back }}" class="govuk-back-link govuk-!-margin-top-0">Back</a>
-                {{ template "case-details" . }}
+                {{ template "create-document-back-and-case-details" . }}
                 {{ template "add-recipient" . }}
 
             {{ else if .HasViewedInsertPage }}
-                <a href="{{ prefix .Back }}" class="govuk-back-link govuk-!-margin-top-0">Back</a>
-                {{ template "case-details" . }}
+                {{ template "create-document-back-and-case-details" . }}
                 {{ template "select-recipient" . }}
 
             {{ else if .TemplateSelected.TemplateId }}
-                <a href="{{ prefix .Back }}" class="govuk-back-link govuk-!-margin-top-0">Back</a>
-                {{ template "case-details" . }}
+                {{ template "create-document-back-and-case-details" . }}
                 {{ template "select-insert" . }}
             {{ else }}
                 {{ template "case-details" . }}
@@ -192,7 +198,7 @@
         <div class="govuk-tabs" data-module="govuk-tabs">
             <h2 class="govuk-tabs__title">Inserts</h2>
 
-            <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0 app-!-float-right"
+            <button class="govuk-button govuk-!-margin-bottom-0 app-!-float-right"
                     data-module="govuk-button" type="submit" name="skipInserts" value="true">
                 Skip
             </button>

--- a/web/template/edit_document.gohtml
+++ b/web/template/edit_document.gohtml
@@ -17,8 +17,13 @@
                    data-module="app-auto-click">Download preview document</a>
             {{ end }}
 
-            <a href="{{ prefix (printf "/create-document?id=%d&case=%s" .Case.ID .Case.CaseType) }}" class="govuk-back-link govuk-!-margin-top-0">Back</a>
-            {{ template "case-details" . }}
+            <div class="govuk-body">
+                <a href="{{ prefix (printf "/create-document?id=%d&case=%s" .Case.ID .Case.CaseType) }}" class="govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-0">Back</a>
+                <div class="app-!-float-right">
+                    {{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "hw" }}HW{{ end }} {{ .Case.UID }}
+                </div>
+            </div>
+
             <h1 class="govuk-heading-m">Edit draft document</h1>
 
             {{ if not .Documents }}
@@ -57,13 +62,11 @@
                     <div class="govuk-form-group {{ if .Error.Field.documentTextEditor }}govuk-form-group--error{{ end }} govuk-!-margin-bottom-2">
                         <textarea id="documentTextEditor" name="documentTextEditor">{{ filterContent .Document.Content }}</textarea>
                     </div>
-                    <div class="govuk-button-group govuk-!-margin-bottom-6">
+                    <div class="govuk-button-group">
                         <button class="govuk-button govuk-button--secondary" data-module="govuk-button" name="documentControls" type="submit" value="save">Save draft</button>
+                        <button class="govuk-button govuk-button--secondary" data-module="govuk-button" name="documentControls" type="submit" value="saveAndExit" id="saveAndExit">Save and exit</button>
                         <button class="govuk-button govuk-button--secondary" data-module="govuk-button" name="documentControls" type="submit" value="delete">Delete draft</button>
                         <button class="govuk-button govuk-button--secondary" data-module="govuk-button" name="documentControls" type="submit" value="preview">Preview draft</button>
-                    </div>
-                    <div class="govuk-button-group govuk-!-margin-bottom-0">
-                        <button class="govuk-button govuk-button--secondary" data-module="govuk-button" name="documentControls" type="submit" value="saveAndExit" id="saveAndExit">Save and exit</button>
                         <button class="govuk-button" data-module="govuk-button" name="documentControls" type="submit" value="publish">Publish draft</button>
                     </div>
                     <div class="govuk-body">

--- a/web/template/layout/case-details.gohtml
+++ b/web/template/layout/case-details.gohtml
@@ -1,3 +1,3 @@
 {{ define "case-details" }}
-    <p class="govuk-body"><strong>{{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "lpa" }}LPA{{ end }} {{ .Case.UID }}</strong></p>
+    <p class="govuk-body"><strong>{{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "hw" }}HW{{ end }} {{ .Case.UID }}</strong></p>
 {{ end }}

--- a/web/template/payments.gohtml
+++ b/web/template/payments.gohtml
@@ -6,7 +6,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-s govuk-!-padding-bottom-2">
-                <strong>{{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "lpa" }}LPA{{ end }} {{ .Case.UID }}</strong>
+                <strong>{{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "hw" }}HW{{ end }} {{ .Case.UID }}</strong>
             </h1>
 
             {{ if .FlashMessage.Title }}


### PR DESCRIPTION
- Move case details to site alongside back button (and remove bold text)
- Make the insert skip button primary
- Move the draft save buttons inline

I also fixed an issue where "HW" LPAs weren't getting the subtype shown in the case details.

Fixes VEGA-1724 #patch