### PR TITLE
Show inserts when selecting document template

### DIFF
--- a/cypress/e2e/create-document.cy.js
+++ b/cypress/e2e/create-document.cy.js
@@ -5,14 +5,11 @@ describe("Create a document", () => {
         cy.contains("Select a document template");
         cy.get("#f-templateId").type("DD");
         cy.get(".autocomplete__menu").contains("DD: Donor deceased: Blank template").click();
-        cy.contains("button", "Continue").click();
 
         cy.contains("Select document inserts");
-        cy.contains("DD1: DD1 - Case complete");
-        cy.get("#f-DD1-all").click();
+        cy.contains("DD1: DD1 - Case complete").click();
         cy.contains("button", "Continue").click();
     });
-
 
     it("creates a document on the case by selecting a recipient", () => {
         cy.contains("Select a recipient");

--- a/internal/server/create_document_test.go
+++ b/internal/server/create_document_test.go
@@ -87,7 +87,8 @@ func TestGetCreateDocument(t *testing.T) {
 					Case:                    caseItem,
 					DocumentTemplateRefData: documentTemplates,
 					DocumentTemplates:       documentTemplateData,
-					Back:                    "/create-document?id=0&case=" + caseType,
+					ComponentDocumentData: buildComponentDocumentData(documentTemplateData, documentTemplates),
+					Back:                  "/create-document?id=0&case=" + caseType,
 				}).
 				Return(nil)
 
@@ -360,6 +361,7 @@ func TestGetCreateDocumentWhenTemplateErrors(t *testing.T) {
 			Case:                    caseItem,
 			DocumentTemplateRefData: documentTemplates,
 			DocumentTemplates:       documentTemplateData,
+			ComponentDocumentData:   buildComponentDocumentData(documentTemplateData, documentTemplates),
 			Back:                    "/create-document?id=0&case=lpa",
 		}).
 		Return(expectedError)

--- a/internal/sirius/document.go
+++ b/internal/sirius/document.go
@@ -2,6 +2,7 @@ package sirius
 
 import (
 	"fmt"
+	"sort"
 )
 
 type Document struct {
@@ -35,6 +36,10 @@ func (c *Client) Documents(ctx Context, caseType CaseType, caseId int, docType s
 	if err != nil {
 		return nil, err
 	}
+
+	sort.Slice(d, func(i, j int) bool {
+		return d[i].ID > d[j].ID
+	})
 
 	return d, err
 }

--- a/internal/sirius/document_test.go
+++ b/internal/sirius/document_test.go
@@ -94,6 +94,56 @@ func TestDocument(t *testing.T) {
 	}
 }
 
+func TestDocumentsSortedByID(t *testing.T) {
+	t.Parallel()
+
+	pact := newIgnoredPact()
+	defer pact.Teardown()
+
+	pact.
+		AddInteraction().
+		Given("I have an lpa with multiple documents, out of order").
+		UponReceiving("A request for the documents by case").
+		WithRequest(dsl.Request{
+			Method: http.MethodGet,
+			Path:   dsl.String("/lpa-api/v1/lpas/894/documents"),
+		}).
+		WillRespondWith(dsl.Response{
+			Status: http.StatusOK,
+			Body: []map[string]interface{}{
+				{
+					"id":   1,
+					"uuid": "7327f57d-e3d5-4300-95a8-67b3337c7231",
+				},
+				{
+					"id":   2,
+					"uuid": "40fa2847-27ae-4976-a93a-9f45ec0a4e98",
+				},
+			},
+			Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+		})
+
+	assert.Nil(t, pact.Verify(func() error {
+		client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
+
+		documents, err := client.Documents(Context{Context: context.Background()}, CaseTypeLpa, 894, TypeDraft)
+
+		assert.Equal(t, []Document{
+			{
+				ID:   2,
+				UUID: "40fa2847-27ae-4976-a93a-9f45ec0a4e98",
+			},
+			{
+				ID:   1,
+				UUID: "7327f57d-e3d5-4300-95a8-67b3337c7231",
+			},
+		}, documents)
+		assert.Nil(t, err)
+
+		return nil
+	}))
+}
+
 func TestDocumentByUuid(t *testing.T) {
 	t.Parallel()
 

--- a/web/assets/handle-insert-checkboxes.js
+++ b/web/assets/handle-insert-checkboxes.js
@@ -1,9 +1,9 @@
-const handleInsertCheckboxes = () => {
+const handleInsertCheckboxes = (config = {}) => {
   /*Insert checkboxes may appear twice and therefore js is needed to make sure
     that a check in one tab is displayed in the other*/
 
-  /** @type NodeList|null checkboxes */
-  const checkboxes = document.querySelectorAll(
+  /** @type {NodeListOf<HTMLInputElement>|null} checkboxes */
+  const checkboxes = (config.scope || document).querySelectorAll(
     '[data-module="insert-checkbox"]'
   );
 

--- a/web/assets/insert-selector.js
+++ b/web/assets/insert-selector.js
@@ -1,0 +1,149 @@
+import { nodeListForEach } from "@ministryofjustice/frontend";
+import { createElement as el } from "./lib/createElement";
+import { initAll as initGOVUKFrontend } from "govuk-frontend";
+import handleInsertCheckboxes from "./handle-insert-checkboxes";
+
+function InsertSelector($module) {
+  this.$module = $module;
+
+  const $dataSource = $module.querySelector('[data-id="insert-selector-data"]');
+  this.data = JSON.parse($dataSource.innerHTML);
+
+  const selectorAttribute = $module.getAttribute("data-initiator-selector");
+  this.$initiator = document.querySelector(`${selectorAttribute}-select`);
+
+  this.$containerTemplate = $module.querySelector(
+    '[data-id="insert-selector-template-container"]'
+  );
+  this.$panelTemplate = $module.querySelector(
+    '[data-id="insert-selector-template-panel"]'
+  );
+
+  this.templateId = "";
+}
+
+InsertSelector.prototype.init = function () {
+  this.$initiator.addEventListener("confirm", this.onSelectTemplate.bind(this));
+};
+
+InsertSelector.prototype.onSelectTemplate = function (e) {
+  if (this.$initiator.value === this.templateId) {
+    return;
+  }
+
+  this.templateId = this.$initiator.value;
+  const template = this.data.templates.find((x) => x.id === this.templateId);
+
+  if (template) {
+    this.buildSelector(template.inserts);
+  }
+};
+
+InsertSelector.prototype.buildSelector = function (inserts) {
+  this.resetSelector();
+
+  if (Object.keys(inserts).length) {
+    this.populateSelector(inserts);
+  }
+};
+
+InsertSelector.prototype.resetSelector = function () {
+  if (this.$container) {
+    this.$module.removeChild(this.$container);
+    this.$container = null;
+  }
+};
+
+InsertSelector.prototype.populateSelector = function (insertLists) {
+  this.$container = this.$containerTemplate.content.children[0].cloneNode(true);
+
+  this.$tabContainer = this.$container.querySelector(".govuk-tabs__list");
+  this.$panelContainer = this.$container.querySelector(
+    '[data-module="govuk-tabs"]'
+  );
+
+  if (!insertLists.all) {
+    const all = [];
+
+    Object.values(insertLists).forEach((inserts) => {
+      inserts.forEach((insert) => {
+        if (!all.includes(insert)) all.push(insert);
+      });
+    });
+
+    insertLists = { all, ...insertLists };
+  }
+
+  Object.entries(insertLists).forEach(([key, inserts]) => {
+    this.$tabContainer.appendChild(
+      el(
+        "li",
+        {
+          class: "govuk-tabs__list-item",
+        },
+        [
+          el("a", { class: "govuk-tabs__tab", href: `#panel-${key}` }, [
+            key.charAt(0).toUpperCase() + key.slice(1),
+          ]),
+        ]
+      )
+    );
+
+    const $rows = inserts.map((insert) => {
+      const label = this.data.translations[insert.onScreenSummary];
+
+      return el(
+        "tr",
+        {
+          class: "govuk-table__row app-!-table-row__no-border",
+        },
+        [
+          el("td", { class: "govuk-table__cell" }, [
+            el("div", { class: "govuk-checkboxes__item" }, [
+              el("input", {
+                class: "govuk-checkboxes__input",
+                id: `f-${insert.id}-${key}`,
+                name: "insert",
+                type: "checkbox",
+                value: insert.id,
+                "data-module": "insert-checkbox",
+              }),
+              el(
+                "label",
+                {
+                  class: "govuk-label govuk-checkboxes__label",
+                  for: `f-${insert.id}-${key}`,
+                },
+                [`${insert.id}: ${label}`]
+              ),
+            ]),
+          ]),
+        ]
+      );
+    });
+
+    const $panel = this.$panelTemplate.content.children[0].cloneNode(true);
+
+    $panel.setAttribute("id", `panel-${key}`);
+    $rows.forEach(($child) =>
+      $panel.querySelector("tbody").appendChild($child)
+    );
+
+    this.$panelContainer.appendChild($panel);
+  });
+
+  this.$module.appendChild(this.$container);
+
+  initGOVUKFrontend({ scope: this.$module });
+  handleInsertCheckboxes({ scope: this.$module });
+};
+
+export default function init($scope) {
+  const $insertSelectors = ($scope || document).querySelectorAll(
+    '[data-module="app-insert-selector"]'
+  );
+
+  nodeListForEach($insertSelectors, ($insertSelector) => {
+    new InsertSelector($insertSelector).init();
+  });
+}

--- a/web/assets/lib/createElement.js
+++ b/web/assets/lib/createElement.js
@@ -1,0 +1,23 @@
+/**
+ * @template {keyof HTMLElementTagNameMap} K
+ * @param {K} tag
+ * @param {{[name: string]: string}} attrs
+ * @returns {HTMLElementTagNameMap[K]}
+ */
+export function createElement(tag, attrs = {}, $children = []) {
+  const $element = document.createElement(tag);
+
+  Object.entries(attrs).forEach(([key, value]) => {
+    $element.setAttribute(key, value);
+  });
+
+  $children.forEach(($child) => {
+    if ($child instanceof HTMLElement) {
+      $element.appendChild($child);
+    } else if (typeof $child === "string") {
+      $element.appendChild(new Text($child));
+    }
+  });
+
+  return $element;
+}

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -13,12 +13,10 @@ import selectTab from "./select-tab";
 import handleInsertCheckboxes from "./handle-insert-checkboxes";
 import autoClick from "./auto-click";
 import handleCreateDocumentButton from "./handle-create-document-button";
+import insertSelector from "./insert-selector";
 
 // Expose jQuery on window so MOJFrontend can use it
 window.$ = $;
-
-// we aren't using the JS tabs, but they try to initialise this will stop them breaking
-GOVUKFrontend.Tabs.prototype.setup = () => {};
 
 const prefix = document.body.getAttribute("data-prefix");
 
@@ -36,6 +34,7 @@ selectTab();
 handleInsertCheckboxes();
 autoClick();
 handleCreateDocumentButton();
+insertSelector();
 
 if (window.self !== window.parent) {
   const success = document.querySelector('[data-app-reload~="page"]');

--- a/web/assets/select.js
+++ b/web/assets/select.js
@@ -19,6 +19,13 @@ function enhanceTemplateSearchElement(element) {
     accessibleAutocomplete.enhanceSelectElement({
       selectElement: element,
       showAllValues: true,
+      onConfirm: function (value) {
+        // Provide default behaviour, which is normally overridden by `onConfirm`
+        const requestedOption = [].filter.call(this.selectElement.options, option => (option.textContent || option.innerText) === value)[0]
+        if (requestedOption) { requestedOption.selected = true }
+
+        this.selectElement.dispatchEvent(new CustomEvent("confirm"));
+      },
     });
   }
 }

--- a/web/template/create_document.gohtml
+++ b/web/template/create_document.gohtml
@@ -228,36 +228,35 @@
                                 {{if eq $t.Key $k }}
                                     <tr class="govuk-table__row app-!-table-row__no-border">
                                         <td class="govuk-table__cell">
-                                                <div class="govuk-checkboxes__item">
-                                                    <input class="govuk-checkboxes__input"
-                                                        id="f-{{ $t.Handle }}-{{$k}}"
-                                                        name="insert"
-                                                        type="checkbox" value="{{ $t.Handle }}"
-                                                        data-module="insert-checkbox"
-                                                        {{ if contains $.SelectedInserts $t.Handle }}checked{{ end }}/>
-                                                    <label class="govuk-label govuk-checkboxes__label"
-                                                        for="f-{{ $t.Handle }}-{{$k}}">
-                                                        {{ $t.Handle }}: {{ $t.Label }}
-                                                    </label>
-                                                </div>
+                                            <div class="govuk-checkboxes__item">
+                                                <input class="govuk-checkboxes__input"
+                                                    id="f-{{ $t.Handle }}-{{$k}}"
+                                                    name="insert"
+                                                    type="checkbox" value="{{ $t.Handle }}"
+                                                    data-module="insert-checkbox"
+                                                    {{ if contains $.SelectedInserts $t.Handle }}checked{{ end }}/>
+                                                <label class="govuk-label govuk-checkboxes__label"
+                                                    for="f-{{ $t.Handle }}-{{$k}}">
+                                                    {{ $t.Handle }}: {{ $t.Label }}
+                                                </label>
                                             </div>
                                         </td>
                                     </tr>
                                 {{ else if eq $k "all" }}
                                     <tr class="govuk-table__row app-!-table-row__no-border">
                                         <td class="govuk-table__cell">
-                                                <div class="govuk-checkboxes__item">
-                                                    <input class="govuk-checkboxes__input"
-                                                        id="f-{{ $t.Handle }}-{{$k}}"
-                                                        name="insert"
-                                                        type="checkbox" value="{{ $t.Handle }}"
-                                                        data-module="insert-checkbox"
-                                                        {{ if contains $.SelectedInserts $t.Handle }}checked{{ end }}/>
-                                                    <label class="govuk-label govuk-checkboxes__label"
-                                                        for="f-{{ $t.Handle }}-{{$k}}">
-                                                        {{ $t.Handle }}: {{ $t.Label }}
-                                                    </label>
-                                                </div>
+                                            <div class="govuk-checkboxes__item">
+                                                <input class="govuk-checkboxes__input"
+                                                    id="f-{{ $t.Handle }}-{{$k}}"
+                                                    name="insert"
+                                                    type="checkbox" value="{{ $t.Handle }}"
+                                                    data-module="insert-checkbox"
+                                                    {{ if contains $.SelectedInserts $t.Handle }}checked{{ end }}/>
+                                                <label class="govuk-label govuk-checkboxes__label"
+                                                    for="f-{{ $t.Handle }}-{{$k}}">
+                                                    {{ $t.Handle }}: {{ $t.Label }}
+                                                </label>
+                                            </div>
                                         </td>
                                     </tr>
                                 {{ end }}
@@ -296,6 +295,39 @@
                     <option value="{{ .Handle }}" {{ if eq .Handle nil }}selected{{ end }}>{{ .Handle }}: {{ .Label }}</option>
                 {{ end }}
             </select>
+        </div>
+
+        <div data-module="app-insert-selector" data-initiator-selector="#f-templateId">
+            <script type="application/json" data-id="insert-selector-data">
+                {{ .ComponentDocumentData }}
+            </script>
+
+            <template data-id="insert-selector-template-container">
+                <div>
+                    <input type="hidden" name="hasViewedInserts" value="true" />
+
+                    <h2 class="govuk-heading-m">Select document inserts</h2>
+
+                    <button class="govuk-button govuk-!-margin-bottom-0 app-!-float-right"
+                            data-module="govuk-button" type="submit" name="skipInserts" value="true">
+                        Skip
+                    </button>
+                    <div class="govuk-tabs" data-module="govuk-tabs">
+                        <ul class="govuk-tabs__list"></ul>
+                    </div>
+                </div>
+            </template>
+
+            <template data-id="insert-selector-template-panel">
+                <div class="govuk-tabs__panel app-tabs__panel--compact" data-module="tab-content">
+                    <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+                        <table class="govuk-table app-table--compact">
+                            <tbody class="govuk-table__body app-!-td-last-child-no-border">
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </template>
         </div>
 
         <div class="govuk-button-group govuk-!-padding-top-5">


### PR DESCRIPTION
Adds a component to the template selection screen which shows the available inserts when you select a document. It has the same design and functionality of the existing insert screen but is inline.

I had to create a new data object in a structure that's useful for JavaScript. The component then generates the DOM either from templates or from directly creating each element (using a helper function called createElement).

The component contains a hidden input called `hasViewedInserts` which causes the next page to be skipped. But if the component fails to load then the input isn't added and the user is taken to the fallback page.

This also ensures the documents are sorted by newest-first on the edit screen, to ensure the newly-created document is always shown first.

Fixes VEGA-1751, VEGA-1759 #minor