### PR TITLE
VEGA-1717 order recipients in create document

### DIFF
--- a/internal/sirius/case.go
+++ b/internal/sirius/case.go
@@ -34,3 +34,24 @@ func (c *Client) Case(ctx Context, id int) (Case, error) {
 
 	return v, err
 }
+
+func (c Case) FilterInactiveAttorneys() Case {
+	var activeAttorneys []Person
+	var activeTrustCorps []Person
+
+	for _, attorney := range c.Attorneys {
+		if attorney.SystemStatus {
+			activeAttorneys = append(activeAttorneys, attorney)
+		}
+	}
+
+	for _, trustCorp := range c.TrustCorporations {
+		if trustCorp.SystemStatus {
+			activeTrustCorps = append(activeTrustCorps, trustCorp)
+		}
+	}
+
+	c.Attorneys = activeAttorneys
+	c.TrustCorporations = activeTrustCorps
+	return c
+}

--- a/internal/sirius/case_test.go
+++ b/internal/sirius/case_test.go
@@ -187,3 +187,16 @@ func TestCaseWithFeeReduction(t *testing.T) {
 		})
 	}
 }
+
+func TestCaseFiltersInactiveActors(t *testing.T) {
+	actor1 := Person{ID: 1, SystemStatus: true}
+	actor2 := Person{ID: 2, SystemStatus: true}
+	inactiveActor1 := Person{ID: 3, SystemStatus: false}
+	inactiveActor2 := Person{ID: 4, SystemStatus: false}
+
+	caseItem := Case{ID: 1, Attorneys: []Person{actor1, inactiveActor1}, TrustCorporations: []Person{actor2, inactiveActor2}}
+	filteredCase := caseItem.FilterInactiveAttorneys()
+
+	assert.Equal(t, []Person{actor1}, filteredCase.Attorneys)
+	assert.Equal(t, []Person{actor2}, filteredCase.TrustCorporations)
+}

--- a/internal/sirius/person.go
+++ b/internal/sirius/person.go
@@ -62,13 +62,3 @@ func (c *Client) Person(ctx Context, id int) (Person, error) {
 
 	return v, err
 }
-
-func FilterInactiveAttorneys(actors []Person) []Person {
-	var activeActors []Person
-	for _, actor := range actors {
-		if actor.SystemStatus {
-			activeActors = append(activeActors, actor)
-		}
-	}
-	return activeActors
-}

--- a/internal/sirius/person_test.go
+++ b/internal/sirius/person_test.go
@@ -122,16 +122,3 @@ func TestPerson(t *testing.T) {
 		})
 	}
 }
-
-func TestPersonFiltersInactiveActors(t *testing.T) {
-	actor1 := Person{ID: 1, SystemStatus: true}
-	actor2 := Person{ID: 2, SystemStatus: true}
-	inactiveActor1 := Person{ID: 3, SystemStatus: false}
-	inactiveActor2 := Person{ID: 4, SystemStatus: false}
-	persons := []Person{actor1, actor2, inactiveActor1, inactiveActor2}
-	activeActors := FilterInactiveAttorneys(persons)
-
-	assert.Equal(t, 2, len(activeActors))
-	assert.NotContains(t, activeActors, inactiveActor1)
-	assert.NotContains(t, activeActors, inactiveActor2)
-}

--- a/web/template/create_document.gohtml
+++ b/web/template/create_document.gohtml
@@ -171,7 +171,7 @@
                                             {{ else }}
                                                 <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{{ .Salutation }} {{ .Firstname }} {{ .Surname }} ({{ .PersonType }})</h2>
                                             {{ end }}
-                                            <p class="govuk-body govuk-!-margin-bottom-0">{{ .AddressLine1 }}, {{ .AddressLine2 }}, {{ .AddressLine3 }}, {{ .Town }}, {{ .County }}, {{ .Postcode }}.</p>
+                                            <p class="govuk-body govuk-!-margin-bottom-0">{{ .AddressSummary }}</p>
                                         </label>
                                     </div>
                             </td>


### PR DESCRIPTION
recipients now follow order in ticket. I have also refactored the create document code to remove unnecessary API calls to get each recipient, as they have already been fetched with the case data.
VEGA-1717 #patch