### PR TITLE
VEGA - case type parser bug

### DIFF
--- a/internal/sirius/case_type.go
+++ b/internal/sirius/case_type.go
@@ -1,6 +1,9 @@
 package sirius
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 type CaseType string
 
@@ -10,10 +13,10 @@ const (
 )
 
 func ParseCaseType(s string) (CaseType, error) {
-	switch s {
-	case "lpa", "LPA":
+	switch strings.ToLower(s) {
+	case "lpa":
 		return CaseTypeLpa, nil
-	case "epa", "EPA":
+	case "epa":
 		return CaseTypeEpa, nil
 	}
 


### PR DESCRIPTION
Case type is stored in different formats in the DB, including uppercase, lowercase and title case (first letter uppercase). We had not accounted for title case in the case type parser function which was preventing users from creating documents on cases of this type. 

To fix I have converted the input of the case type parser to lowercase to remove case sensitive matching