### PR TITLE
Remove Compare Pacts step from pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,15 +100,6 @@ jobs:
             --broker-base-url https://pact-broker.api.opg.service.justice.gov.uk \
             --broker-username admin \
             --broker-password ${{ secrets.PACT_BROKER_PASSWORD }}
-      - name: Compare pacts
-        env:
-          PACT_DIR: ./pacts
-          PACT_BROKER_URL: https://pact-broker.api.opg.service.justice.gov.uk
-        run: |
-          git fetch origin main
-          LATEST_MAIN_COMMIT=$(git rev-parse --verify origin/main)
-          curl ${PACT_BROKER_URL}/pacts/provider/sirius/consumer/sirius-lpa-frontend/version/$LATEST_MAIN_COMMIT > /tmp/latest-pact.json
-          (diff <(jq --sort-keys '.interactions|=sort_by(.description)' ${PACT_DIR}/sirius-lpa-frontend-sirius.json) <(jq --sort-keys '.interactions|=sort_by(.description)' /tmp/latest-pact.json) || true) | (! grep '<')
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
It's no longer needed since Renovate can publish and verify any changed Pacts. In its current state, it stops us making any changes to the API contract.

## Checklist

* [X] I have updated the end-to-end tests to work with my changes
  * N/A
* [x] I have added styling for Dark Mode
  * N/A
* [x] I have checked that my UI changes meet accessibility standards
  * N/A

#patch