### PR TITLE
Lighten document user instructions in dark mode

### DIFF
--- a/web/assets/dark.scss
+++ b/web/assets/dark.scss
@@ -12,6 +12,10 @@ $sirius-bg-color: #29292e;
     color: govuk-colour("white");
   }
 
+  .govuk-body {
+    color: govuk-colour("white");
+  }
+
   h1,
   h2,
   h3,

--- a/web/assets/wysiwyg.scss
+++ b/web/assets/wysiwyg.scss
@@ -34,4 +34,10 @@ body#tinymce {
 .app-\!-html-class--dark  {
   background: #363639;
   color: #ddd;
+
+  &#tinymce {
+    .user-instruction {
+      color: lighten(govuk-colour("light-blue"), 20%);
+    }
+  }
 }


### PR DESCRIPTION
Reuse the colour we use for links, since raw `govuk-colour("light-blue")` is too dark (not AA compliant).

## Checklist

* [x] I have updated the end-to-end tests to work with my changes
  * N/A
* [x] I have added styling for Dark Mode
* [x] I have checked that my UI changes meet accessibility standards

Fixes VEGA-1794 #patch