### PR TITLE
Add `make dev` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ build-all:
 up:
 	docker-compose -f docker/docker-compose.ci.yml up -d
 
+dev:
+	docker-compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml up -d
+	yarn && yarn watch
+
 scan:
 	trivy image sirius-lpa-frontend:latest
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,0 +1,6 @@
+version: "3.6"
+
+services:
+  app:
+    volumes:
+      - "../web/static/javascript:/go/bin/web/static/javascript"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build:tinymce": "cp -r node_modules/tinymce/skins web/static/javascript",
     "clean": "rm -rf web/static",
     "cypress": "cypress open",
-    "prettier": "prettier --write ."
+    "prettier": "prettier --write .",
+    "watch": "yarn build:js --watch"
   },
   "dependencies": {
     "@ministryofjustice/frontend": "1.6.6",


### PR DESCRIPTION
Starts up the app container, mounts the JS folder, and runs a watch command to constantly rebuild the JavaScript files.

For JS-focussed development work.

Part of VEGA-1812 #patch