### PR TITLE
VEGA donor parent child bug fix

### DIFF
--- a/internal/sirius/case.go
+++ b/internal/sirius/case.go
@@ -32,8 +32,10 @@ func (c *Client) Case(ctx Context, id int) (Case, error) {
 	var v Case
 	err := c.get(ctx, fmt.Sprintf("/lpa-api/v1/cases/%d", id), &v)
 
-	if v.Donor.Parent != nil {
-		v.Donor = v.Donor.Parent
+	if v.Donor != nil {
+		if v.Donor.Parent != nil {
+			v.Donor = v.Donor.Parent
+		}
 	}
 
 	return v, err


### PR DESCRIPTION
we now check that the donor isn't nil before trying to check the donor parent which is causing the nil pointer error on live. VEGA-BUG-FIX #patch