### PR TITLE
[VEGA-1723] Apply search filters automatically

### DIFF
--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -58,8 +58,9 @@ describe("Search", () => {
 
         it("it shows/hides filter panel", () => {
             cy.contains(".govuk-button", "Hide filters").click();
-            cy.contains("Apply filters").should("not.be.visible");
+            cy.get('.moj-filter-layout__filter').should("not.be.visible");
             cy.contains(".govuk-button", "Show filters").click();
+            cy.get('.moj-filter-layout__filter').should("be.visible");
             cy.contains("Apply filters").should("be.visible");
         });
 

--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -61,7 +61,6 @@ describe("Search", () => {
             cy.get('.moj-filter-layout__filter').should("not.be.visible");
             cy.contains(".govuk-button", "Show filters").click();
             cy.get('.moj-filter-layout__filter').should("be.visible");
-            cy.contains("Apply filters").should("be.visible");
         });
 
         it("can apply and remove filters", () => {

--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -66,7 +66,6 @@ describe("Search", () => {
         it("can apply and remove filters", () => {
             cy.contains(".govuk-checkboxes__item", "Attorney").find("input").check();
             cy.contains(".govuk-checkboxes__item", "Trust corporation").find("input").check();
-            cy.get("button[type=submit]").click();
             cy.contains(".moj-filter__tag", "Attorney");
             cy.contains(".moj-filter__tag", "Trust Corporation");
             cy.contains(".moj-filter__selected-heading", "Clear filters").find("a").click();

--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -64,6 +64,8 @@ describe("Search", () => {
         });
 
         it("can apply and remove filters", () => {
+            // Checks the button is hidden because js is enabled
+            cy.contains("Apply filters").should("not.be.visible");
             cy.contains(".govuk-checkboxes__item", "Attorney").find("input").check();
             cy.contains(".govuk-checkboxes__item", "Trust corporation").find("input").check();
             cy.contains(".moj-filter__tag", "Attorney");

--- a/web/assets/auto-apply-filter.js
+++ b/web/assets/auto-apply-filter.js
@@ -12,7 +12,7 @@ export default function autoApplyFilter() {
 
             timeout = setTimeout(() => {
                 filter.closest("form").submit();
-            }, 500)
+            }, 1000)
         })
     })
 }

--- a/web/assets/auto-apply-filter.js
+++ b/web/assets/auto-apply-filter.js
@@ -1,6 +1,8 @@
 export default function autoApplyFilter() {
     if (document.body.className.includes('js-enabled')) {
-        document.querySelector('.moj-filter form button').classList.add("govuk-!-display-none");
+        if (document.querySelector('.moj-filter')) {
+            document.querySelector('.moj-filter form button').classList.add("govuk-!-display-none");
+        }
     }
 
     const filters = document.querySelectorAll('[data-module="app-auto-apply-filter"]');

--- a/web/assets/auto-apply-filter.js
+++ b/web/assets/auto-apply-filter.js
@@ -1,0 +1,11 @@
+export default function autoApplyFilter() {
+    const filters = document.querySelectorAll("input.govuk-checkboxes__input");
+
+    filters.forEach((filter) => {
+        filter.addEventListener('click', () => {
+            setTimeout(() => {
+                document.forms["search-filters"].submit();
+            }, 500)
+        })
+    })
+}

--- a/web/assets/auto-apply-filter.js
+++ b/web/assets/auto-apply-filter.js
@@ -1,9 +1,12 @@
 export default function autoApplyFilter() {
     const filters = document.querySelectorAll("input.govuk-checkboxes__input");
+    let timeout = null;
 
     filters.forEach((filter) => {
         filter.addEventListener('click', () => {
-            setTimeout(() => {
+            if (timeout !== null) clearTimeout(timeout);
+
+            timeout = setTimeout(() => {
                 document.forms["search-filters"].submit();
             }, 500)
         })

--- a/web/assets/auto-apply-filter.js
+++ b/web/assets/auto-apply-filter.js
@@ -1,5 +1,9 @@
 export default function autoApplyFilter() {
-    const filters = document.querySelectorAll("input.govuk-checkboxes__input");
+    if (document.body.className.includes('js-enabled')) {
+        document.querySelector('.moj-filter form button').classList.add("govuk-!-display-none");
+    }
+
+    const filters = document.querySelectorAll('[data-module="app-auto-apply-filter"]');
     let timeout = null;
 
     filters.forEach((filter) => {
@@ -7,7 +11,7 @@ export default function autoApplyFilter() {
             if (timeout !== null) clearTimeout(timeout);
 
             timeout = setTimeout(() => {
-                document.forms["search-filters"].submit();
+                filter.closest("form").submit();
             }, 500)
         })
     })

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -15,6 +15,7 @@ import autoClick from "./auto-click";
 import handleCreateDocumentButton from "./handle-create-document-button";
 import insertSelector from "./insert-selector";
 import addressFinder from "./address-finder";
+import autoApplyFilter from "./auto-apply-filter";
 
 // Expose jQuery on window so MOJFrontend can use it
 window.$ = $;
@@ -37,6 +38,7 @@ autoClick();
 handleCreateDocumentButton();
 insertSelector();
 addressFinder(prefix);
+autoApplyFilter();
 
 if (window.self !== window.parent) {
   const success = document.querySelector('[data-app-reload~="page"]');

--- a/web/template/layout/search_filter.gohtml
+++ b/web/template/layout/search_filter.gohtml
@@ -32,6 +32,9 @@
                 <div class="moj-filter__options">
                     <form class="form" method="get" id="search-filters">
                         <input type="hidden" name="term" value="{{ .SearchTerm }}"/>
+                        <button class="govuk-button" data-module="govuk-button" type="submit">
+                            Apply filters
+                        </button>
 
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
@@ -39,55 +42,55 @@
                                 <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
                                     {{ $personType := .Aggregations.PersonType }}
                                     <div class="govuk-checkboxes__item">
-                                        <input class="govuk-checkboxes__input" id="f-person-type-donor" name="person-type" type="checkbox" value="Donor" {{ if contains .Filters.PersonType "Donor" }}checked{{ end }}>
+                                        <input class="govuk-checkboxes__input" id="f-person-type-donor" name="person-type" type="checkbox" value="Donor" data-module="app-auto-apply-filter" {{ if contains .Filters.PersonType "Donor" }}checked{{ end }}>
                                         <label class="govuk-label govuk-checkboxes__label" for="f-person-type-donor">
                                             Donor ({{ with $personType.Donor }}{{ . }}{{ else }}0{{ end }})
                                         </label>
                                     </div>
                                     <div class="govuk-checkboxes__item">
-                                        <input class="govuk-checkboxes__input" id="f-person-type-client" name="person-type" type="checkbox" value="Client" {{ if contains .Filters.PersonType "Client"  }}checked{{ end }}>
+                                        <input class="govuk-checkboxes__input" id="f-person-type-client" name="person-type" type="checkbox" value="Client" data-module="app-auto-apply-filter" {{ if contains .Filters.PersonType "Client"  }}checked{{ end }}>
                                         <label class="govuk-label govuk-checkboxes__label" for="f-person-type-client">
                                             Client ({{ with $personType.Client }}{{ . }}{{ else }}0{{ end }})
                                         </label>
                                     </div>
                                     <div class="govuk-checkboxes__item">
-                                        <input class="govuk-checkboxes__input" id="f-person-type-deputy" name="person-type" type="checkbox" value="Deputy" {{ if contains .Filters.PersonType "Deputy"  }}checked{{ end }}>
+                                        <input class="govuk-checkboxes__input" id="f-person-type-deputy" name="person-type" type="checkbox" value="Deputy" data-module="app-auto-apply-filter" {{ if contains .Filters.PersonType "Deputy"  }}checked{{ end }}>
                                         <label class="govuk-label govuk-checkboxes__label" for="f-person-type-deputy">
                                             Deputy ({{ with $personType.Deputy }}{{ . }}{{ else }}0{{ end }})
                                         </label>
                                     </div>
                                     <div class="govuk-checkboxes__item">
-                                        <input class="govuk-checkboxes__input" id="f-person-type-attorney" name="person-type" type="checkbox" value="Attorney" {{ if contains .Filters.PersonType "Attorney"  }}checked{{ end }}>
+                                        <input class="govuk-checkboxes__input" id="f-person-type-attorney" name="person-type" type="checkbox" value="Attorney" data-module="app-auto-apply-filter" {{ if contains .Filters.PersonType "Attorney"  }}checked{{ end }}>
                                         <label class="govuk-label govuk-checkboxes__label" for="f-person-type-attorney">
                                             Attorney ({{ with $personType.Attorney }}{{ . }}{{ else }}0{{ end }})
                                         </label>
                                     </div>
                                     <div class="govuk-checkboxes__item">
-                                        <input class="govuk-checkboxes__input" id="f-person-type-replacement-attorney" name="person-type" type="checkbox" value="Replacement Attorney" {{ if contains .Filters.PersonType "Replacement Attorney"  }}checked{{ end }}>
+                                        <input class="govuk-checkboxes__input" id="f-person-type-replacement-attorney" name="person-type" type="checkbox" value="Replacement Attorney" data-module="app-auto-apply-filter" {{ if contains .Filters.PersonType "Replacement Attorney"  }}checked{{ end }}>
                                         <label class="govuk-label govuk-checkboxes__label" for="f-person-type-replacement-attorney">
                                             Replacement attorney ({{ with (index $personType "Replacement Attorney") }}{{ . }}{{ else }}0{{ end }})
                                         </label>
                                     </div>
                                     <div class="govuk-checkboxes__item">
-                                        <input class="govuk-checkboxes__input" id="f-person-type-trust-corporation" name="person-type" type="checkbox" value="Trust Corporation" {{ if contains .Filters.PersonType "Trust Corporation"  }}checked{{ end }}>
+                                        <input class="govuk-checkboxes__input" id="f-person-type-trust-corporation" name="person-type" type="checkbox" value="Trust Corporation" data-module="app-auto-apply-filter" {{ if contains .Filters.PersonType "Trust Corporation"  }}checked{{ end }}>
                                         <label class="govuk-label govuk-checkboxes__label" for="f-person-type-trust-corporation">
                                            Trust corporation ({{ with (index $personType "Trust Corporation") }}{{ . }}{{ else }}0{{ end }})
                                         </label>
                                     </div>
                                     <div class="govuk-checkboxes__item">
-                                        <input class="govuk-checkboxes__input" id="f-person-type-notified-person" name="person-type" type="checkbox" value="Notified Person" {{ if contains .Filters.PersonType "Notified Person"  }}checked{{ end }}>
+                                        <input class="govuk-checkboxes__input" id="f-person-type-notified-person" name="person-type" type="checkbox" value="Notified Person" data-module="app-auto-apply-filter" {{ if contains .Filters.PersonType "Notified Person"  }}checked{{ end }}>
                                         <label class="govuk-label govuk-checkboxes__label" for="f-person-type-notified-person">
                                             Notified person ({{ with (index $personType "Notified Person") }}{{ . }}{{ else }}0{{ end }})
                                         </label>
                                     </div>
                                     <div class="govuk-checkboxes__item">
-                                        <input class="govuk-checkboxes__input" id="f-person-type-certificate-provider" name="person-type" type="checkbox" value="Certificate Provider" {{ if contains .Filters.PersonType "Certificate Provider"  }}checked{{ end }}>
+                                        <input class="govuk-checkboxes__input" id="f-person-type-certificate-provider" name="person-type" type="checkbox" value="Certificate Provider" data-module="app-auto-apply-filter" {{ if contains .Filters.PersonType "Certificate Provider"  }}checked{{ end }}>
                                         <label class="govuk-label govuk-checkboxes__label" for="f-person-type-certificate-provider">
                                             Certificate provider ({{ with (index $personType "Certificate Provider") }}{{ . }}{{ else }}0{{ end }})
                                         </label>
                                     </div>
                                     <div class="govuk-checkboxes__item">
-                                        <input class="govuk-checkboxes__input" id="f-person-type-correspondent" name="person-type" type="checkbox" value="Correspondent" {{ if contains .Filters.PersonType "Correspondent"  }}checked{{ end }}>
+                                        <input class="govuk-checkboxes__input" id="f-person-type-correspondent" name="person-type" type="checkbox" value="Correspondent" data-module="app-auto-apply-filter" {{ if contains .Filters.PersonType "Correspondent"  }}checked{{ end }}>
                                         <label class="govuk-label govuk-checkboxes__label" for="f-person-type-correspondent">
                                             Correspondent ({{ with $personType.Correspondent }}{{ . }}{{ else }}0{{ end }})
                                         </label>

--- a/web/template/layout/search_filter.gohtml
+++ b/web/template/layout/search_filter.gohtml
@@ -32,9 +32,6 @@
                 <div class="moj-filter__options">
                     <form class="form" method="get" id="search-filters">
                         <input type="hidden" name="term" value="{{ .SearchTerm }}"/>
-                        <button class="govuk-button" data-module="govuk-button" type="submit">
-                            Apply filters
-                        </button>
 
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">


### PR DESCRIPTION
[VEGA-1723](https://opgtransform.atlassian.net/browse/VEGA-1723) - apply search filters without needing a manual click to reapply. 

Note re accessibility - The auto-applying search filters is a compromise on accessibility because the user would not expect a page refresh, to counter this we could have a partial page reload (the filtered results) that has aria live region, which informs the user that a portion of the page has updated, so the screen reader doesn't read out everything again (article below).
Ref: https://technology.blog.gov.uk/2014/08/14/improving-accessibility-on-gov-uk-search/

## Checklist

* [x] I have updated the end-to-end tests to work with my changes
* [ ] I have added styling for Dark Mode
* [x] I have checked that my UI changes meet accessibility standards

[VEGA-1723]: https://opgtransform.atlassian.net/browse/VEGA-1723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ