### PR TITLE
Enable branchNameStrict in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
+  "branchNameStrict": true,
   "branchPrefix": "renovate-",
   "commitMessageAction": "Renovate Update",
   "labels": ["Dependencies", "Renovate"],


### PR DESCRIPTION
[branchNameStrict](https://docs.renovatebot.com/configuration-options/#branchnamestrict) should prevent renovate from creating any branches with `.` in them, which seems to be confusing github-tag-action

#patch