### PR TITLE
Fix Node to 20.2.x

### DIFF
--- a/docker/sirius-lpa-frontend/Dockerfile
+++ b/docker/sirius-lpa-frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.3.1-alpine3.17 as asset-env
+FROM node:20.2.0-alpine3.17 as asset-env
 
 WORKDIR /app
 

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,17 @@
   "labels": ["Dependencies", "Renovate"],
   "packageRules": [
     {
+      "description": [
+        "Ignore Dockerfile Node upgrades",
+        "Node 20.3.x doesn't work with our local versions of Docker so we must lock to 20.2.x for now"
+      ],
+      "matchFiles": ["docker/sirius-lpa-frontend/Dockerfile"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["node"],
+      "matchUpdateTypes": ["minor"],
+      "enabled": false
+    },
+    {
       "automerge": true,
       "groupName": "Patch & Minor Updates",
       "groupSlug": "all-minor-patch-updates",


### PR DESCRIPTION
Node 20.3.x doesn't work with our local versions of Docker so we must lock to 20.2.x for now

[Issue on nodejs/docker-node](https://github.com/nodejs/docker-node/issues/1912)

#patch
