### PR TITLE
Load a donor's cases from a specific endpoint

### DIFF
--- a/cypress/e2e/create-warning.cy.js
+++ b/cypress/e2e/create-warning.cy.js
@@ -1,13 +1,9 @@
 describe("Create a warning", () => {
   beforeEach(() => {
-    cy.addMock("/lpa-api/v1/persons/189", "GET", {
+    cy.addMock("/lpa-api/v1/persons/189/cases", "GET", {
       status: 200,
       body: {
-        dob: "05/05/1970",
-        firstname: "John",
-        id: 189,
-        surname: "Doe",
-        uId: "7000-0000-0007",
+        cases: [],
       },
     });
     cy.visit("/create-warning?id=189");
@@ -34,27 +30,18 @@ describe("Create a warning", () => {
 
 describe("Create a warning on multiple cases", () => {
   beforeEach(() => {
-    cy.addMock("/lpa-api/v1/persons/400", "GET", {
+    cy.addMock("/lpa-api/v1/persons/400/cases", "GET", {
       status: 200,
       body: {
-        dob: "05/05/1970",
-        firstname: "John",
-        id: 400,
-        surname: "Doe",
-        uId: "7000-0000-0007",
         cases: [
           {
             caseSubtype: "pfa",
-            caseType: "LPA",
             id: 405,
-            status: "Perfect",
             uId: "7000-5382-4438",
           },
           {
             caseSubtype: "hw",
-            caseType: "LPA",
             id: 406,
-            status: "Pending",
             uId: "7000-5382-8764",
           },
         ],

--- a/cypress/mocks/migrated-from-pact.json
+++ b/cypress/mocks/migrated-from-pact.json
@@ -379,6 +379,15 @@
       }
     },
     {
+      "name": "A request for a person's cases",
+      "request": { "method": "GET", "url": "/lpa-api/v1/persons/189/cases" },
+      "response": {
+        "status": 200,
+        "headers": { "Content-Type": "application/json" },
+        "body": "{\"cases\":[{\"id\":822,\"uId\":\"7000-3039-2919\",\"caseSubtype\":\"hw\"}]}"
+      }
+    },
+    {
       "name": "A request for the person by UID",
       "request": {
         "method": "GET",

--- a/internal/sirius/cases_by_donor.go
+++ b/internal/sirius/cases_by_donor.go
@@ -1,0 +1,15 @@
+package sirius
+
+import (
+	"fmt"
+)
+
+func (c *Client) CasesByDonor(ctx Context, id int) ([]Case, error) {
+	var v struct {
+		Cases []Case `json:"cases"`
+	}
+
+	err := c.get(ctx, fmt.Sprintf("/lpa-api/v1/persons/%d/cases", id), &v)
+
+	return v.Cases, err
+}

--- a/internal/sirius/cases_by_donor_test.go
+++ b/internal/sirius/cases_by_donor_test.go
@@ -1,0 +1,89 @@
+package sirius
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/pact-foundation/pact-go/dsl"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCasesByDonor(t *testing.T) {
+	t.Parallel()
+
+	pact := newPact()
+	defer pact.Teardown()
+
+	testCases := []struct {
+		name             string
+		setup            func()
+		expectedResponse []Case
+		expectedError    func(int) error
+	}{
+		{
+			name: "OK",
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("A donor exists with more than 1 case").
+					UponReceiving("A request for the donor's cases").
+					WithRequest(dsl.Request{
+						Method: http.MethodGet,
+						Path:   dsl.String("/lpa-api/v1/persons/400/cases"),
+					}).
+					WillRespondWith(dsl.Response{
+						Status: http.StatusOK,
+						Body: dsl.Like(map[string]interface{}{
+							"cases": []map[string]interface{}{
+								{
+									"id":          dsl.Like(405),
+									"uId":         dsl.Term("7000-5382-4438", `\d{4}-\d{4}-\d{4}`),
+									"caseSubtype": dsl.Term("pfa", "hw|pfa"),
+								},
+								{
+									"id":          dsl.Like(406),
+									"uId":         dsl.Term("7000-5382-8764", `\d{4}-\d{4}-\d{4}`),
+									"caseSubtype": dsl.Term("hw", "hw|pfa"),
+								},
+							},
+						}),
+						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+					})
+			},
+			expectedResponse: []Case{
+				{
+					ID:       405,
+					UID:      "7000-5382-4438",
+					SubType:  "pfa",
+				},
+				{
+					ID:       406,
+					UID:      "7000-5382-8764",
+					SubType:  "hw",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+
+			assert.Nil(t, pact.Verify(func() error {
+				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
+
+				caseitem, err := client.CasesByDonor(Context{Context: context.Background()}, 400)
+
+				assert.Equal(t, tc.expectedResponse, caseitem)
+				if tc.expectedError == nil {
+					assert.Nil(t, err)
+				} else {
+					assert.Equal(t, tc.expectedError(pact.Server.Port), err)
+				}
+				return nil
+			}))
+		})
+	}
+}

--- a/web/template/warning.gohtml
+++ b/web/template/warning.gohtml
@@ -17,12 +17,12 @@
       <form class="form" method="POST">
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
 
-        {{ if gt (len .Donor.Cases) 1 }}
+        {{ if gt (len .Cases) 1 }}
           <div class="govuk-form-group">
             <fieldset class="govuk-fieldset">
               <legend class="govuk-fieldset__legend">What case is the warning for?</legend>
               <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                {{ range $i, $c := .Donor.Cases }}
+                {{ range $i, $c := .Cases }}
                   <div class="govuk-checkboxes__item">
                     <input class="govuk-checkboxes__input" id="case-id-{{ $i }}" name="case-id" type="checkbox" value="{{ $c.ID }}">
                     <label class="govuk-label govuk-checkboxes__label" for="case-id-{{ $i }}">{{ ToUpper $c.SubType }} {{ $c.UID }}</label>


### PR DESCRIPTION
The `/donors/:id` doesn't contain any child donor cases, making it impossible to create warnings for them.

`/persons/:id/cases` contains all of the parent and children's cases.

Fixes VEGA-1926 #patch
