### PR TITLE
Use API's label property for documents and inserts

### DIFF
--- a/cypress/e2e/create-document.cy.js
+++ b/cypress/e2e/create-document.cy.js
@@ -4,12 +4,12 @@ describe("Create a document", () => {
       status: 200,
       body: {
         DD: {
-          onScreenSummary: "DDONSCREENSUMMARY",
+          label: "Donor deceased: Blank template",
           location: "lpa/DD.html.twig",
           inserts: {
             all: {
               DD1: {
-                onScreenSummary: "DD1LPAINSERTONSCREENSUMMARY",
+                label: "DD1 - Case complete",
                 location: "lpa/inserts/DD1.html.twig",
                 order: 0,
               },

--- a/cypress/mocks/common.json
+++ b/cypress/mocks/common.json
@@ -55,17 +55,6 @@
     {
       "request": {
         "method": "GET",
-        "url": "/lpa-api/v1/reference-data/documentTemplateId"
-      },
-      "response": {
-        "status": 200,
-        "headers": { "Content-Type": "application/json" },
-        "body": "[{\"handle\":\"DDONSCREENSUMMARY\",\"label\":\"Donor deceased: Blank template\"},{\"handle\":\"DD1LPAINSERTONSCREENSUMMARY\",\"label\":\"DD1 - Case complete\"}]"
-      }
-    },
-    {
-      "request": {
-        "method": "GET",
         "url": "/lpa-api/v1/reference-data/complainantCategory"
       },
       "response": {

--- a/cypress/mocks/migrated-from-pact.json
+++ b/cypress/mocks/migrated-from-pact.json
@@ -586,24 +586,6 @@
       }
     },
     {
-      "name": "A request for document templates",
-      "request": { "method": "GET", "url": "/lpa-api/v1/templates/lpa" },
-      "response": {
-        "status": 200,
-        "headers": { "Content-Type": "application/json" },
-        "body": "{\"DD\":{\"inserts\":{\"all\":{\"DD1\":{\"location\":\"lpa\\\\/inserts\\\\/DD1.html.twig\",\"onScreenSummary\":\"DD1LPAINSERTONSCREENSUMMARY\",\"order\":0}}},\"location\":\"lpa\\\\/DD.html.twig\",\"onScreenSummary\":\"DDONSCREENSUMMARY\"}}"
-      }
-    },
-    {
-      "name": "A request for document templates (no inserts)",
-      "request": { "method": "GET", "url": "/lpa-api/v1/templates/lpa" },
-      "response": {
-        "status": 200,
-        "headers": { "Content-Type": "application/json" },
-        "body": "{\"CT-bb\":{\"inserts\":[],\"location\":\"complaints/CT-bb.html.twig\",\"onScreenSummary\":\"CTBBONSCREENSUMMARY\"}}"
-      }
-    },
-    {
       "name": "A request to link two people",
       "request": { "method": "POST", "url": "/lpa-api/v1/person-links" },
       "response": { "status": 204, "headers": {} }

--- a/internal/server/create_document.go
+++ b/internal/server/create_document.go
@@ -46,7 +46,6 @@ type InsertDisplayData struct {
 
 type ComponentTemplateInsertData struct {
 	InsertId        string `json:"id"`
-	OnScreenSummary string `json:"onScreenSummary"`
 	Label           string `json:"label"`
 }
 
@@ -352,7 +351,6 @@ func buildComponentDocumentData(templates []sirius.DocumentTemplateData) Compone
 		for _, insert := range template.Inserts {
 			formedInsert := ComponentTemplateInsertData{
 				InsertId:        insert.InsertId,
-				OnScreenSummary: insert.OnScreenSummary,
 				Label:           insert.Label,
 			}
 

--- a/internal/server/create_document_test.go
+++ b/internal/server/create_document_test.go
@@ -435,19 +435,16 @@ func TestGetSortedInsertKeys(t *testing.T) {
 			Key:             "all",
 			InsertId:        "DDINSERT",
 			Location:        `lpa\/DD.html.twig`,
-			OnScreenSummary: "DDINSERTONSCREENSUMMARY",
 		},
 		{
 			Key:             "imperfect",
 			InsertId:        "IM1INSERT",
 			Location:        `lpa\/IM1.html.twig`,
-			OnScreenSummary: "IM1INSERTONSCREENSUMMARY",
 		},
 		{
 			Key:             "perfect",
 			InsertId:        "P1INSERT",
 			Location:        `lpa\/P1.html.twig`,
-			OnScreenSummary: "P1INSERTONSCREENSUMMARY",
 		},
 	}
 
@@ -456,13 +453,11 @@ func TestGetSortedInsertKeys(t *testing.T) {
 			Key:             "imperfect",
 			InsertId:        "IM1INSERT",
 			Location:        `lpa\/IM1.html.twig`,
-			OnScreenSummary: "IM1INSERTONSCREENSUMMARY",
 		},
 		{
 			Key:             "perfect",
 			InsertId:        "P1INSERT",
 			Location:        `lpa\/P1.html.twig`,
-			OnScreenSummary: "P1INSERTONSCREENSUMMARY",
 		},
 	}
 

--- a/internal/server/create_document_test.go
+++ b/internal/server/create_document_test.go
@@ -16,14 +16,6 @@ type mockCreateDocumentClient struct {
 	mock.Mock
 }
 
-func (m *mockCreateDocumentClient) RefDataByCategory(ctx sirius.Context, category string) ([]sirius.RefDataItem, error) {
-	args := m.Called(ctx, category)
-	if args.Get(0) != nil {
-		return args.Get(0).([]sirius.RefDataItem), args.Error(1)
-	}
-	return nil, args.Error(1)
-}
-
 func (m *mockCreateDocumentClient) Case(ctx sirius.Context, id int) (sirius.Case, error) {
 	args := m.Called(ctx, id)
 	return args.Get(0).(sirius.Case), args.Error(1)
@@ -54,19 +46,12 @@ func TestGetCreateDocument(t *testing.T) {
 		t.Run(caseType, func(t *testing.T) {
 			caseItem := sirius.Case{CaseType: caseType, UID: "7000"}
 
-			documentTemplates := []sirius.RefDataItem{
-				{
-					Handle: "DD",
-					Label:  "DD Template Label",
-				},
-			}
-
 			documentTemplateData := []sirius.DocumentTemplateData{
 				{
-					Inserts:         nil,
-					TemplateId:      "DD",
-					Location:        "DD.html.twig",
-					OnScreenSummary: "DDONSCREENSUMMARY",
+					Inserts:    nil,
+					TemplateId: "DD",
+					Location:   "DD.html.twig",
+					Label:      "DD Template Label",
 				},
 			}
 
@@ -75,20 +60,16 @@ func TestGetCreateDocument(t *testing.T) {
 				On("Case", mock.Anything, 123).
 				Return(caseItem, nil)
 			client.
-				On("RefDataByCategory", mock.Anything, sirius.DocumentTemplateIdCategory).
-				Return(documentTemplates, nil)
-			client.
 				On("DocumentTemplates", mock.Anything, sirius.CaseType(caseType)).
 				Return(documentTemplateData, nil)
 
 			template := &mockTemplate{}
 			template.
 				On("Func", mock.Anything, createDocumentData{
-					Case:                    caseItem,
-					DocumentTemplateRefData: documentTemplates,
-					DocumentTemplates:       documentTemplateData,
-					ComponentDocumentData:   buildComponentDocumentData(documentTemplateData, documentTemplates),
-					Back:                    "/create-document?id=0&case=" + caseType,
+					Case:                  caseItem,
+					DocumentTemplates:     documentTemplateData,
+					ComponentDocumentData: buildComponentDocumentData(documentTemplateData),
+					Back:                  "/create-document?id=0&case=" + caseType,
 				}).
 				Return(nil)
 
@@ -298,55 +279,13 @@ func TestGetCreateDocumentWhenCaseErrors(t *testing.T) {
 	mock.AssertExpectationsForObjects(t, client)
 }
 
-func TestGetCreateDocumentWhenFailureOnGetDocumentRefData(t *testing.T) {
-	caseItem := sirius.Case{CaseType: "lpa", UID: "7000"}
-
-	documentTemplateData := []sirius.DocumentTemplateData{
-		{
-			Inserts:         nil,
-			TemplateId:      "DD",
-			Location:        `lpa\/DD.html.twig`,
-			OnScreenSummary: "DDONSCREENSUMMARY",
-		},
-	}
-
-	client := &mockCreateDocumentClient{}
-	client.
-		On("Case", mock.Anything, 123).
-		Return(caseItem, nil)
-	client.
-		On("DocumentTemplates", mock.Anything, sirius.CaseTypeLpa).
-		Return(documentTemplateData, nil)
-	client.
-		On("RefDataByCategory", mock.Anything, sirius.DocumentTemplateIdCategory).
-		Return([]sirius.RefDataItem{}, expectedError)
-
-	r, _ := http.NewRequest(http.MethodGet, "/?id=123&case=lpa", nil)
-	w := httptest.NewRecorder()
-
-	err := CreateDocument(client, nil)(w, r)
-
-	assert.Equal(t, expectedError, err)
-	mock.AssertExpectationsForObjects(t, client)
-}
-
 func TestGetCreateDocumentWhenFailureOnGetDocumentTemplates(t *testing.T) {
 	caseItem := sirius.Case{CaseType: "lpa", UID: "7000"}
 
-	documentTemplates := []sirius.RefDataItem{
-		{
-			Handle: "DD",
-			Label:  "Donor deceased: Blank template",
-		},
-	}
-
 	client := &mockCreateDocumentClient{}
 	client.
 		On("Case", mock.Anything, 123).
 		Return(caseItem, nil)
-	client.
-		On("RefDataByCategory", mock.Anything, sirius.DocumentTemplateIdCategory).
-		Return(documentTemplates, nil)
 	client.
 		On("DocumentTemplates", mock.Anything, sirius.CaseTypeLpa).
 		Return([]sirius.DocumentTemplateData{}, expectedError)
@@ -363,19 +302,12 @@ func TestGetCreateDocumentWhenFailureOnGetDocumentTemplates(t *testing.T) {
 func TestGetCreateDocumentWhenTemplateErrors(t *testing.T) {
 	caseItem := sirius.Case{CaseType: "lpa", UID: "7000"}
 
-	documentTemplates := []sirius.RefDataItem{
-		{
-			Handle: "DD",
-			Label:  "Donor deceased: Blank template",
-		},
-	}
-
 	documentTemplateData := []sirius.DocumentTemplateData{
 		{
-			Inserts:         nil,
-			TemplateId:      "DD",
-			Location:        `lpa\/DD.html.twig`,
-			OnScreenSummary: "DDONSCREENSUMMARY",
+			Inserts:    nil,
+			TemplateId: "DD",
+			Location:   `lpa\/DD.html.twig`,
+			Label:      "Donor deceased: Blank template",
 		},
 	}
 
@@ -384,20 +316,16 @@ func TestGetCreateDocumentWhenTemplateErrors(t *testing.T) {
 		On("Case", mock.Anything, 123).
 		Return(caseItem, nil)
 	client.
-		On("RefDataByCategory", mock.Anything, sirius.DocumentTemplateIdCategory).
-		Return(documentTemplates, nil)
-	client.
 		On("DocumentTemplates", mock.Anything, sirius.CaseTypeLpa).
 		Return(documentTemplateData, nil)
 
 	template := &mockTemplate{}
 	template.
 		On("Func", mock.Anything, createDocumentData{
-			Case:                    caseItem,
-			DocumentTemplateRefData: documentTemplates,
-			DocumentTemplates:       documentTemplateData,
-			ComponentDocumentData:   buildComponentDocumentData(documentTemplateData, documentTemplates),
-			Back:                    "/create-document?id=0&case=lpa",
+			Case:                  caseItem,
+			DocumentTemplates:     documentTemplateData,
+			ComponentDocumentData: buildComponentDocumentData(documentTemplateData),
+			Back:                  "/create-document?id=0&case=lpa",
 		}).
 		Return(expectedError)
 
@@ -410,47 +338,36 @@ func TestGetCreateDocumentWhenTemplateErrors(t *testing.T) {
 	mock.AssertExpectationsForObjects(t, client, template)
 }
 
-func TestTranslateDocumentData(t *testing.T) {
-	documentTemplateRefData := []sirius.RefDataItem{
-		{
-			Handle: "DDONSCREENSUMMARY",
-			Label:  "DD Template Label",
-		},
-	}
-
+func TestSortDocumentData(t *testing.T) {
 	documentTemplateData := []sirius.DocumentTemplateData{
 		{
-			Inserts:         nil,
-			TemplateId:      "DD",
-			Location:        `DD.html.twig`,
-			OnScreenSummary: "DDONSCREENSUMMARY",
+			TemplateId: "DD",
+		},
+		{
+			TemplateId: "AA",
+		},
+		{
+			TemplateId: "ZZ",
 		},
 	}
 
-	documentTemplateTypes := translateDocumentData(documentTemplateData, documentTemplateRefData)
-	assert.Equal(t, "DD Template Label", documentTemplateTypes[0].Label)
-	assert.Equal(t, "DD", documentTemplateTypes[0].Handle)
-	assert.Equal(t, false, documentTemplateTypes[0].UserSelectable)
+	sortedDocumentData := sortDocumentData(documentTemplateData)
+	assert.Equal(t, "AA", sortedDocumentData[0].TemplateId)
+	assert.Equal(t, "DD", sortedDocumentData[1].TemplateId)
+	assert.Equal(t, "ZZ", sortedDocumentData[2].TemplateId)
 }
 
 func TestTranslateInsertData(t *testing.T) {
-	documentTemplateRefData := []sirius.RefDataItem{
-		{
-			Handle: "DDINSERTONSCREENSUMMARY",
-			Label:  "DD Insert label",
-		},
-	}
-
 	selectedTemplateInserts := []sirius.Insert{
 		{
-			Key:             "All",
-			InsertId:        "DDINSERT",
-			Location:        `lpa\/DD.html.twig`,
-			OnScreenSummary: "DDINSERTONSCREENSUMMARY",
+			Key:      "All",
+			InsertId: "DDINSERT",
+			Location: `lpa\/DD.html.twig`,
+			Label:    "DD Insert label",
 		},
 	}
 
-	translatedInsert := translateInsertData(selectedTemplateInserts, documentTemplateRefData)
+	translatedInsert := translateInsertData(selectedTemplateInserts)
 	assert.Equal(t, "DD Insert label", translatedInsert[0].Label)
 	assert.Equal(t, "DDINSERT", translatedInsert[0].Handle)
 	assert.Equal(t, "All", translatedInsert[0].Key)

--- a/internal/sirius/document_templates.go
+++ b/internal/sirius/document_templates.go
@@ -13,7 +13,6 @@ type insertApiResponse map[string]json.RawMessage
 
 type UniversalTemplateData struct {
 	Location        string `json:"location"`
-	OnScreenSummary string `json:"onScreenSummary"`
 	Label           string `json:"label"`
 	Order           int    `json:"order"`
 }
@@ -21,7 +20,6 @@ type UniversalTemplateData struct {
 type documentTemplateApiData struct {
 	Inserts         insertApiResponse `json:"inserts"`
 	Location        string            `json:"location"`
-	OnScreenSummary string            `json:"onScreenSummary"`
 	Label           string            `json:"label"`
 }
 
@@ -29,7 +27,6 @@ type Insert struct {
 	Key             string
 	InsertId        string
 	Location        string `json:"location"`
-	OnScreenSummary string `json:"onScreenSummary"`
 	Label           string `json:"label"`
 	Order           int    `json:"order"`
 }
@@ -38,7 +35,6 @@ type DocumentTemplateData struct {
 	Inserts         []Insert
 	TemplateId      string
 	Location        string `json:"location"`
-	OnScreenSummary string `json:"onScreenSummary"`
 	Label           string `json:"label"`
 }
 
@@ -56,7 +52,6 @@ func (d documentTemplateApiResponse) toDocumentData() ([]DocumentTemplateData, e
 				return nil, err
 			}
 			asDocumentTemplateData.Location = asDocumentTemplateApiData.Location
-			asDocumentTemplateData.OnScreenSummary = asDocumentTemplateApiData.OnScreenSummary
 			asDocumentTemplateData.Label = asDocumentTemplateApiData.Label
 			asDocumentTemplateData.Inserts = inserts
 			s = append(s, asDocumentTemplateData)
@@ -66,7 +61,6 @@ func (d documentTemplateApiResponse) toDocumentData() ([]DocumentTemplateData, e
 			var universalTemplateData UniversalTemplateData
 			if err := json.Unmarshal(v, &universalTemplateData); err == nil {
 				asDocumentTemplateData.Location = universalTemplateData.Location
-				asDocumentTemplateData.OnScreenSummary = universalTemplateData.OnScreenSummary
 				asDocumentTemplateData.Label = universalTemplateData.Label
 				s = append(s, asDocumentTemplateData)
 				continue
@@ -89,7 +83,6 @@ func (i insertApiResponse) toInsertData() ([]Insert, error) {
 			for insertId, insertData := range asInsertKeyApiResponse {
 				insert.InsertId = insertId
 				insert.Location = insertData.Location
-				insert.OnScreenSummary = insertData.OnScreenSummary
 				insert.Label = insertData.Label
 				insert.Order = insertData.Order
 				inserts = append(inserts, insert)

--- a/internal/sirius/document_templates.go
+++ b/internal/sirius/document_templates.go
@@ -14,6 +14,7 @@ type insertApiResponse map[string]json.RawMessage
 type UniversalTemplateData struct {
 	Location        string `json:"location"`
 	OnScreenSummary string `json:"onScreenSummary"`
+	Label           string `json:"label"`
 	Order           int    `json:"order"`
 }
 
@@ -21,6 +22,7 @@ type documentTemplateApiData struct {
 	Inserts         insertApiResponse `json:"inserts"`
 	Location        string            `json:"location"`
 	OnScreenSummary string            `json:"onScreenSummary"`
+	Label           string            `json:"label"`
 }
 
 type Insert struct {
@@ -28,6 +30,7 @@ type Insert struct {
 	InsertId        string
 	Location        string `json:"location"`
 	OnScreenSummary string `json:"onScreenSummary"`
+	Label           string `json:"label"`
 	Order           int    `json:"order"`
 }
 
@@ -36,6 +39,7 @@ type DocumentTemplateData struct {
 	TemplateId      string
 	Location        string `json:"location"`
 	OnScreenSummary string `json:"onScreenSummary"`
+	Label           string `json:"label"`
 }
 
 func (d documentTemplateApiResponse) toDocumentData() ([]DocumentTemplateData, error) {
@@ -53,6 +57,7 @@ func (d documentTemplateApiResponse) toDocumentData() ([]DocumentTemplateData, e
 			}
 			asDocumentTemplateData.Location = asDocumentTemplateApiData.Location
 			asDocumentTemplateData.OnScreenSummary = asDocumentTemplateApiData.OnScreenSummary
+			asDocumentTemplateData.Label = asDocumentTemplateApiData.Label
 			asDocumentTemplateData.Inserts = inserts
 			s = append(s, asDocumentTemplateData)
 			continue
@@ -62,6 +67,7 @@ func (d documentTemplateApiResponse) toDocumentData() ([]DocumentTemplateData, e
 			if err := json.Unmarshal(v, &universalTemplateData); err == nil {
 				asDocumentTemplateData.Location = universalTemplateData.Location
 				asDocumentTemplateData.OnScreenSummary = universalTemplateData.OnScreenSummary
+				asDocumentTemplateData.Label = universalTemplateData.Label
 				s = append(s, asDocumentTemplateData)
 				continue
 			}
@@ -84,6 +90,7 @@ func (i insertApiResponse) toInsertData() ([]Insert, error) {
 				insert.InsertId = insertId
 				insert.Location = insertData.Location
 				insert.OnScreenSummary = insertData.OnScreenSummary
+				insert.Label = insertData.Label
 				insert.Order = insertData.Order
 				inserts = append(inserts, insert)
 			}

--- a/internal/sirius/document_templates_test.go
+++ b/internal/sirius/document_templates_test.go
@@ -27,7 +27,6 @@ func TestDocumentTypes(t *testing.T) {
 			setup: func() {
 				pact.
 					AddInteraction().
-					Given("Some document templates exist").
 					UponReceiving("A request for document templates").
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
@@ -37,14 +36,14 @@ func TestDocumentTypes(t *testing.T) {
 						Status: http.StatusOK,
 						Body: dsl.Like(map[string]interface{}{
 							"DD": dsl.Like(map[string]interface{}{
-								"onScreenSummary": dsl.Like("DDONSCREENSUMMARY"),
-								"location":        dsl.Like(`lpa\/DD.html.twig`),
+								"location": dsl.Like(`lpa\/DD.html.twig`),
+								"label":    dsl.Like("Donor deceased: Blank template"),
 								"inserts": dsl.Like(map[string]interface{}{
 									"all": dsl.Like(map[string]interface{}{
 										"DD1": dsl.Like(map[string]interface{}{
-											"onScreenSummary": dsl.Like("DD1LPAINSERTONSCREENSUMMARY"),
-											"location":        dsl.Like(`lpa\/inserts\/DD1.html.twig`),
-											"order":           dsl.Like(0),
+											"location": dsl.Like(`lpa\/inserts\/DD1.html.twig`),
+											"label":    dsl.Like("DD1 - Case complete"),
+											"order":    dsl.Like(0),
 										}),
 									}),
 								}),
@@ -57,48 +56,16 @@ func TestDocumentTypes(t *testing.T) {
 				{
 					Inserts: []Insert{
 						{
-							Key:             "all",
-							InsertId:        "DD1",
-							Location:        `lpa\/inserts\/DD1.html.twig`,
-							OnScreenSummary: "DD1LPAINSERTONSCREENSUMMARY",
-							Order:           0,
+							Key:      "all",
+							InsertId: "DD1",
+							Label:    "DD1 - Case complete",
+							Location: `lpa\/inserts\/DD1.html.twig`,
+							Order:    0,
 						},
 					},
-					Location:        `lpa\/DD.html.twig`,
-					OnScreenSummary: "DDONSCREENSUMMARY",
-					TemplateId:      "DD",
-				},
-			},
-		},
-		{
-			name: "OK - template with no inserts",
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("Some document templates exist").
-					UponReceiving("A request for document templates (no inserts)").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String("/lpa-api/v1/templates/lpa"),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusOK,
-						Body: dsl.Like(map[string]interface{}{
-							"CT-bb": dsl.Like(map[string]interface{}{
-								"onScreenSummary": dsl.Like("CTBBONSCREENSUMMARY"),
-								"location":        dsl.Like(`complaints/CT-bb.html.twig`),
-								"inserts":         dsl.Like([]interface{}{}),
-							}),
-						}),
-						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
-					})
-			},
-			expectedResponse: []DocumentTemplateData{
-				{
-					Inserts:         []Insert(nil),
-					Location:        `complaints/CT-bb.html.twig`,
-					OnScreenSummary: "CTBBONSCREENSUMMARY",
-					TemplateId:      "CT-bb",
+					Location:   `lpa\/DD.html.twig`,
+					TemplateId: "DD",
+					Label:      "Donor deceased: Blank template",
 				},
 			},
 		},

--- a/internal/sirius/ref_data_test.go
+++ b/internal/sirius/ref_data_test.go
@@ -134,33 +134,6 @@ func TestRefDataByCategory(t *testing.T) {
 			},
 		},
 		{
-			name:     "Document template IDs",
-			category: DocumentTemplateIdCategory,
-			setup: func() {
-				pact.
-					AddInteraction().
-					UponReceiving("A request for document template id ref data").
-					WithRequest(dsl.Request{
-						Method: http.MethodGet,
-						Path:   dsl.String(fmt.Sprintf("/lpa-api/v1/reference-data/%s", DocumentTemplateIdCategory)),
-					}).
-					WillRespondWith(dsl.Response{
-						Status: http.StatusOK,
-						Body: dsl.EachLike(map[string]interface{}{
-							"handle": dsl.String("DDONSCREENSUMMARY"),
-							"label":  dsl.String("Donor deceased: Blank template"),
-						}, 1),
-						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
-					})
-			},
-			expectedResponse: []RefDataItem{
-				{
-					Handle: "DDONSCREENSUMMARY",
-					Label:  "Donor deceased: Blank template",
-				},
-			},
-		},
-		{
 			name:     "Complainant category",
 			category: ComplainantCategory,
 			setup: func() {

--- a/web/assets/insert-selector.js
+++ b/web/assets/insert-selector.js
@@ -90,8 +90,6 @@ InsertSelector.prototype.populateSelector = function (insertLists) {
     );
 
     const $rows = inserts.map((insert) => {
-      const label = this.data.translations[insert.onScreenSummary];
-
       return el(
         "tr",
         {
@@ -114,7 +112,7 @@ InsertSelector.prototype.populateSelector = function (insertLists) {
                   class: "govuk-label govuk-checkboxes__label",
                   for: `f-${insert.id}-${key}`,
                 },
-                [`${insert.id}: ${label}`]
+                [`${insert.id}: ${insert.label}`]
               ),
             ]),
           ]),

--- a/web/template/create_document.gohtml
+++ b/web/template/create_document.gohtml
@@ -288,8 +288,8 @@
             <select class="govuk-select {{ if .Error.Field.templateId }}govuk-select--error{{ end }}"
                     id="f-templateId" name="templateId" data-select-template>
                 <option value="" selected></option>
-                {{ range .DocumentTemplateTypes }}
-                    <option value="{{ .Handle }}" {{ if eq .Handle nil }}selected{{ end }}>{{ .Handle }}: {{ .Label }}</option>
+                {{ range .DocumentTemplates }}
+                    <option value="{{ .TemplateId }}" {{ if eq .TemplateId nil }}selected{{ end }}>{{ .TemplateId }}: {{ .Label }}</option>
                 {{ end }}
             </select>
         </div>


### PR DESCRIPTION
Rather than using the template ID refdata.

In doing so we also remove the call to RefDataByCategory. We can also remove `DocumentTemplateRefData` because it's no longer used, and merge `DocumentTemplateTypes` into `DocumentTemplates` because it's just a sorted version of that.

We can also remove the `onScreenSummary` property, including taking it out of the API contract.

#patch