### PR TITLE
Add Chi router

### DIFF
--- a/cypress/e2e/digital-lpa.cy.js
+++ b/cypress/e2e/digital-lpa.cy.js
@@ -1,6 +1,6 @@
 describe("Edit a payment", () => {
   beforeEach(() => {
-    cy.visit("/lpa?uid=M-1234-9876-4567");
+    cy.visit("/lpa/M-1234-9876-4567");
   });
 
   it("shows case information", () => {

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
+	github.com/go-chi/chi/v5 v5.0.10 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
+github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
+github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/internal/server/lpa.go
+++ b/internal/server/lpa.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 )
@@ -18,7 +19,7 @@ type lpaData struct {
 
 func Lpa(client LpaClient, tmpl template.Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
-		uid := r.FormValue("uid")
+		uid := chi.URLParam(r, "uid")
 		ctx := getContext(r)
 
 		lpa, err := client.DigitalLpa(ctx, uid)

--- a/internal/server/lpa_test.go
+++ b/internal/server/lpa_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
@@ -38,13 +37,12 @@ func TestGetLpa(t *testing.T) {
 		}).
 		Return(nil)
 
-	req, _ := http.NewRequest(http.MethodGet, "/lpa?uid=M-9876-9876-9876", nil)
-	w := httptest.NewRecorder()
+	server := newMockServer("/lpa/{uid}", Lpa(client, template.Func))
 
-	err := Lpa(client, template.Func)(w, req)
+	req, _ := http.NewRequest(http.MethodGet, "/lpa/M-9876-9876-9876", nil)
+	resp, err := server.serve(req)
+
 	assert.Nil(t, err)
-
-	resp := w.Result()
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.Code)
 	mock.AssertExpectationsForObjects(t, client, template)
 }

--- a/internal/server/mock_server.go
+++ b/internal/server/mock_server.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type MockServer struct {
+	mux *chi.Mux
+	err error
+}
+
+func newMockServer(route string, handler Handler) MockServer {
+	mux := chi.NewRouter()
+	server := MockServer{
+		mux: mux,
+		err: nil,
+	}
+
+	server.mux.HandleFunc(route, func(w http.ResponseWriter, r *http.Request) {
+		server.err = handler(w, r)
+	})
+
+	return server
+}
+
+func (s *MockServer) serve(req *http.Request) (*httptest.ResponseRecorder, error) {
+	resp := httptest.NewRecorder()
+	s.mux.ServeHTTP(resp, req)
+
+	return resp, s.err
+}

--- a/web/template/create-draft.gohtml
+++ b/web/template/create-draft.gohtml
@@ -22,7 +22,7 @@
             <div><strong>{{ if eq .Subtype "hw" }}Health and Welfare{{ else if eq .Subtype "pfa" }}Property and Finance{{ end }} case reference number is {{ .Uid }}</strong></div>
           {{ end }}
         </p>
-        <p><a class="govuk-link govuk-link--inverse" href="{{ prefix (printf "/lpa?uid=%s" (index .Uids 0).Uid ) }}">View donor record</a></p>
+        <p><a class="govuk-link govuk-link--inverse" href="{{ prefix (printf "/lpa/%s" (index .Uids 0).Uid ) }}">View donor record</a></p>
       </div>
     </div>
 


### PR DESCRIPTION
Our existing routes all still work with Chi.

Routes that use `chi.URLParam` need to have been served by Chi, so we must update the test harness to create a mux and then serve the request through it.

Fixes VEGA-1984 #minor