### PR TITLE
VEGA-1961 use Chi URL param on payments route

### DIFF
--- a/cypress/e2e/payments.cy.js
+++ b/cypress/e2e/payments.cy.js
@@ -1,7 +1,7 @@
 describe("View a payment", () => {
   describe("No payments on case", () => {
     it("displays default message when there are no payments on the case", () => {
-      cy.visit("/payments?id=801");
+      cy.visit("/payments/801");
       cy.contains("7000-0000-0001");
       cy.contains("There is currently no fee data available to display.");
     });
@@ -14,7 +14,7 @@ describe("View a payment", () => {
         },
       });
 
-      cy.visit("/payments?id=801");
+      cy.visit("/payments/801");
       cy.contains(".govuk-button", "Add payment");
       cy.contains(".govuk-button", "Apply fee reduction").should("not.exist");
     });
@@ -27,7 +27,7 @@ describe("View a payment", () => {
         },
       });
 
-      cy.visit("/payments?id=801");
+      cy.visit("/payments/801");
       cy.contains(".govuk-button", "Add payment");
       cy.contains(".govuk-button", "Apply fee reduction");
     });
@@ -35,7 +35,7 @@ describe("View a payment", () => {
 
   describe("Payments on case", () => {
     it("displays payment information if there is a payment on the case", () => {
-      cy.visit("/payments?id=800");
+      cy.visit("/payments/800");
       cy.contains("7000-0000-0000");
       cy.contains("Total paid");
       cy.contains("£41.00");
@@ -54,7 +54,7 @@ describe("View a payment", () => {
     });
 
     it("displays fee reduction information", () => {
-      cy.visit("/payments?id=802");
+      cy.visit("/payments/802");
       cy.contains("Fee reductions");
       cy.get("#f-fee-reductions-tab").click();
       cy.contains("Outstanding fee due");

--- a/internal/server/add_payment.go
+++ b/internal/server/add_payment.go
@@ -103,7 +103,7 @@ func AddPayment(client AddPaymentClient, tmpl template.Template) Handler {
 				SetFlash(w, FlashNotification{
 					Title: "Payment added",
 				})
-				return RedirectError(fmt.Sprintf("/payments?id=%d", caseID))
+				return RedirectError(fmt.Sprintf("/payments/%d", caseID))
 			}
 		}
 

--- a/internal/server/add_payment_test.go
+++ b/internal/server/add_payment_test.go
@@ -217,7 +217,7 @@ func TestPostAddPayment(t *testing.T) {
 	err := AddPayment(client, template.Func)(w, r)
 	resp := w.Result()
 
-	assert.Equal(t, RedirectError("/payments?id=123"), err)
+	assert.Equal(t, RedirectError("/payments/123"), err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	mock.AssertExpectationsForObjects(t, client, template)
 }

--- a/internal/server/apply_fee_reduction.go
+++ b/internal/server/apply_fee_reduction.go
@@ -76,7 +76,7 @@ func ApplyFeeReduction(client ApplyFeeReductionClient, tmpl template.Template) H
 				SetFlash(w, FlashNotification{
 					Title: fmt.Sprintf("%s approved", translateRefData(data.FeeReductionTypes, data.FeeReductionType)),
 				})
-				return RedirectError(fmt.Sprintf("/payments?id=%d", caseID))
+				return RedirectError(fmt.Sprintf("/payments/%d", caseID))
 			}
 		}
 

--- a/internal/server/apply_fee_reduction_test.go
+++ b/internal/server/apply_fee_reduction_test.go
@@ -212,7 +212,7 @@ func TestPostFeeReduction(t *testing.T) {
 	err := ApplyFeeReduction(client, template.Func)(w, r)
 	resp := w.Result()
 
-	assert.Equal(t, RedirectError("/payments?id=123"), err)
+	assert.Equal(t, RedirectError("/payments/123"), err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	mock.AssertExpectationsForObjects(t, client, template)
 }

--- a/internal/server/delete_payment.go
+++ b/internal/server/delete_payment.go
@@ -80,7 +80,7 @@ func DeletePayment(client DeletePaymentClient, tmpl template.Template) Handler {
 			SetFlash(w, FlashNotification{
 				Title: fmt.Sprintf("%s deleted", item),
 			})
-			return RedirectError(fmt.Sprintf("/payments?id=%d", p.Case.ID))
+			return RedirectError(fmt.Sprintf("/payments/%d", p.Case.ID))
 		}
 
 		return tmpl(w, data)

--- a/internal/server/delete_payment_test.go
+++ b/internal/server/delete_payment_test.go
@@ -264,7 +264,7 @@ func TestPostDeletePayment(t *testing.T) {
 	err := DeletePayment(client, template.Func)(w, r)
 	resp := w.Result()
 
-	assert.Equal(t, RedirectError("/payments?id=4"), err)
+	assert.Equal(t, RedirectError("/payments/4"), err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	mock.AssertExpectationsForObjects(t, client, template)
 }

--- a/internal/server/edit_fee_reduction.go
+++ b/internal/server/edit_fee_reduction.go
@@ -80,7 +80,7 @@ func EditFeeReduction(client EditFeeReductionClient, tmpl template.Template) Han
 				return err
 			} else {
 				SetFlash(w, FlashNotification{Title: "Fee reduction edited"})
-				return RedirectError(fmt.Sprintf("/payments?id=%d", data.FeeReduction.Case.ID))
+				return RedirectError(fmt.Sprintf("/payments/%d", data.FeeReduction.Case.ID))
 			}
 		}
 

--- a/internal/server/edit_fee_reduction_test.go
+++ b/internal/server/edit_fee_reduction_test.go
@@ -355,7 +355,7 @@ func TestPostEditFeeReduction(t *testing.T) {
 	err := EditFeeReduction(client, template.Func)(w, r)
 	resp := w.Result()
 
-	assert.Equal(t, RedirectError("/payments?id=4"), err)
+	assert.Equal(t, RedirectError("/payments/4"), err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	mock.AssertExpectationsForObjects(t, client, template)
 }

--- a/internal/server/edit_payment.go
+++ b/internal/server/edit_payment.go
@@ -118,7 +118,7 @@ func EditPayment(client EditPaymentClient, tmpl template.Template) Handler {
 				return err
 			} else {
 				SetFlash(w, FlashNotification{Title: "Payment saved"})
-				return RedirectError(fmt.Sprintf("/payments?id=%d", data.Case.ID))
+				return RedirectError(fmt.Sprintf("/payments/%d", data.Case.ID))
 			}
 		}
 

--- a/internal/server/edit_payment_test.go
+++ b/internal/server/edit_payment_test.go
@@ -366,7 +366,7 @@ func TestPostEditPayment(t *testing.T) {
 	err := EditPayment(client, template.Func)(w, r)
 	resp := w.Result()
 
-	assert.Equal(t, RedirectError("/payments?id=4"), err)
+	assert.Equal(t, RedirectError("/payments/4"), err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	mock.AssertExpectationsForObjects(t, client, template)
 }

--- a/internal/server/get_payments.go
+++ b/internal/server/get_payments.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/go-chi/chi/v5"
 	"golang.org/x/sync/errgroup"
 	"net/http"
 	"strconv"
@@ -36,7 +37,16 @@ type getPaymentsData struct {
 
 func GetPayments(client GetPaymentsClient, tmpl template.Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
-		caseID, err := strconv.Atoi(r.FormValue("id"))
+		var caseID int
+		var err error
+
+		caseIDChiURLParam := chi.URLParam(r, "id")
+		if caseIDChiURLParam != "" {
+			caseID, err = strconv.Atoi(caseIDChiURLParam)
+		} else {
+			caseID, err = strconv.Atoi(r.FormValue("id"))
+		}
+
 		if err != nil {
 			return err
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -118,6 +118,7 @@ func New(logger Logger, client Client, templates template.Templates, prefix, sir
 	mux.Handle("/edit-payment", wrap(EditPayment(client, templates.Get("edit_payment.gohtml"))))
 	mux.Handle("/edit-fee-reduction", wrap(EditFeeReduction(client, templates.Get("edit_fee_reduction.gohtml"))))
 	mux.Handle("/payments", wrap(GetPayments(client, templates.Get("payments.gohtml"))))
+	mux.Handle("/payments/{id}", wrap(GetPayments(client, templates.Get("payments.gohtml"))))
 	mux.Handle("/search-users", wrap(SearchUsers(client)))
 	mux.Handle("/search-persons", wrap(SearchDonors(client)))
 	mux.Handle("/search-postcode", wrap(SearchPostcode(client)))
@@ -170,7 +171,7 @@ func errorHandler(logger Logger, tmplError template.Template, prefix, siriusURL 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if err := next(w, r); err != nil {
 				if v, ok := err.(unauthorizedError); ok && v.IsUnauthorized() {
-					http.Redirect(w, r, fmt.Sprintf("%s/auth?redirect=%s", siriusURL, url.QueryEscape(prefix + r.URL.Path)), http.StatusFound)
+					http.Redirect(w, r, fmt.Sprintf("%s/auth?redirect=%s", siriusURL, url.QueryEscape(prefix+r.URL.Path)), http.StatusFound)
 					return
 				}
 

--- a/web/template/add_payment.gohtml
+++ b/web/template/add_payment.gohtml
@@ -31,7 +31,7 @@
 
                 <div class="govuk-button-group govuk-!-padding-top-6">
                     <button class="govuk-button" data-module="govuk-button" type="submit">Save</button>
-                    <a class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/payments?id=%d" .Case.ID) }}">Cancel</a>
+                    <a class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/payments/%d" .Case.ID) }}">Cancel</a>
                 </div>
             </form>
 

--- a/web/template/apply_fee_reduction.gohtml
+++ b/web/template/apply_fee_reduction.gohtml
@@ -22,7 +22,7 @@
 
                 <div class="govuk-button-group govuk-!-padding-top-6">
                     <button class="govuk-button" data-module="govuk-button" type="submit">Save</button>
-                    <a class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/payments?id=%d" .Case.ID) }}">Cancel</a>
+                    <a class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/payments/%d" .Case.ID) }}">Cancel</a>
                 </div>
             </form>
 

--- a/web/template/delete_fee_reduction.gohtml
+++ b/web/template/delete_fee_reduction.gohtml
@@ -19,7 +19,7 @@
                         Delete
                     </button>
 
-                    <a class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/payments?id=%d" .Case.ID) }}">
+                    <a class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/payments/%d" .Case.ID) }}">
                         Cancel
                     </a>
                 </div>

--- a/web/template/delete_payment.gohtml
+++ b/web/template/delete_payment.gohtml
@@ -18,7 +18,7 @@
                         Delete
                     </button>
 
-                    <a class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/payments?id=%d" .Case.ID) }}">
+                    <a class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/payments/%d" .Case.ID) }}">
                         Cancel
                     </a>
                 </div>

--- a/web/template/edit_fee_reduction.gohtml
+++ b/web/template/edit_fee_reduction.gohtml
@@ -22,7 +22,7 @@
 
                 <div class="govuk-button-group govuk-!-padding-top-6">
                     <button class="govuk-button" data-module="govuk-button" type="submit">Save</button>
-                    <a class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/payments?id=%d" .Case.ID) }}">Cancel</a>
+                    <a class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/payments/%d" .Case.ID) }}">Cancel</a>
                 </div>
             </form>
 

--- a/web/template/edit_payment.gohtml
+++ b/web/template/edit_payment.gohtml
@@ -32,7 +32,7 @@
 
                 <div class="govuk-button-group govuk-!-padding-top-6">
                     <button class="govuk-button" data-module="govuk-button" type="submit">Save</button>
-                    <a class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/payments?id=%d" .Case.ID) }}">Cancel</a>
+                    <a class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/payments/%d" .Case.ID) }}">Cancel</a>
                 </div>
             </form>
 


### PR DESCRIPTION
Created new payments route which uses chi URL param. The route goes to the same page and behaves the same as the existing `/payments?id={id}` route. 
VEGA-1961 #patch

## Checklist

~~- [ ] I have updated the end-to-end tests to work with my changes~~
~~- [ ] I have added styling for Dark Mode~~
~~- [ ] I have checked that my UI changes meet accessibility standards~~
