### PR TITLE
VEGA-2010 Scope flash cookie to / path #minor

### DIFF
--- a/internal/server/flash.go
+++ b/internal/server/flash.go
@@ -24,6 +24,7 @@ func SetFlash(w http.ResponseWriter, notification FlashNotification) {
 		Name:     flashCookieName,
 		Value:    base64.URLEncoding.EncodeToString(str),
 		HttpOnly: true,
+		Path:     "/",
 	}
 	http.SetCookie(w, c)
 }
@@ -52,7 +53,8 @@ func GetFlash(w http.ResponseWriter, r *http.Request) (FlashNotification, error)
 		return FlashNotification{}, err
 	}
 
-	dc := &http.Cookie{Name: flashCookieName, MaxAge: -1, Expires: time.Unix(1, 0)}
+	dc := &http.Cookie{Name: flashCookieName, MaxAge: -1, Expires: time.Unix(1, 0), Path: "/",}
+
 	http.SetCookie(w, dc)
 	return v, nil
 }

--- a/internal/server/flash_test.go
+++ b/internal/server/flash_test.go
@@ -37,7 +37,7 @@ func TestSetFlashAddsHeader(t *testing.T) {
 		Description: "description",
 	})
 
-	assert.Equal(t, "flash-lpa-frontend=eyJuYW1lIjoidGl0bGUiLCJkZXNjcmlwdGlvbiI6ImRlc2NyaXB0aW9uIn0=; HttpOnly", header.Get("Set-Cookie"))
+	assert.Equal(t, "flash-lpa-frontend=eyJuYW1lIjoidGl0bGUiLCJkZXNjcmlwdGlvbiI6ImRlc2NyaXB0aW9uIn0=; Path=/; HttpOnly", header.Get("Set-Cookie"))
 }
 
 func TestGetFlashGetsHeader(t *testing.T) {


### PR DESCRIPTION
Without the Path property, the flash message cookie is not correctly matched when attempting to remove it. This results in the flash message persisting across requests and appearing incorrectly on different cases etc.

It looks like this can't be tested against the app running locally in standalone mode, as the paths appear to be set correctly and the flash cookie *is* deleted as expected.

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards
