### PR TITLE
Create a document for Digital LPAs

### DIFF
--- a/cypress/e2e/create-document-digital-lpa.cy.js
+++ b/cypress/e2e/create-document-digital-lpa.cy.js
@@ -1,0 +1,57 @@
+describe("Create a document for a digital LPA", () => {
+  beforeEach(() => {
+    cy.addMock("/lpa-api/v1/digital-lpas/M-GDJ7-QK9R-4XVF", "GET", {
+      status: 200,
+      body: {
+        id: 483,
+        application: {
+          donorFirstNames: "Steven",
+          donorLastName: "Munnell",
+          donorDob: "17/06/1982",
+          donorAddress: {
+            addressLine1: "1 Scotland Street",
+            postcode: "EH6 18J",
+          },
+        },
+      },
+    });
+
+    cy.addMock("/lpa-api/v1/templates/digitallpa", "GET", {
+      status: 200,
+      body: {
+        DD: {
+          label: "DLPA Example Form",
+          inserts: {
+            all: {
+              DLPA_INSERT_01: {
+                label: "DLPA Insert 1",
+                order: 0,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    cy.addMock("/lpa-api/v1/lpas/483/documents/draft", "POST", {
+      status: 201,
+      body: {},
+    });
+
+    cy.visit("/lpa/M-GDJ7-QK9R-4XVF/documents/new");
+  });
+
+  it("creates a document on the case", () => {
+    cy.contains("Select a document template");
+    cy.get("#f-templateId").type("DLPA");
+    cy.get(".autocomplete__menu").contains("DLPA Example Form").click();
+
+    cy.contains("Select document inserts");
+    cy.contains("DLPA Insert 1").click();
+
+    cy.contains("1 Scotland Street, EH6 18J");
+    cy.contains("Steven Munnell (Donor)").click();
+
+    cy.contains("button", "Continue").click();
+  });
+});

--- a/internal/server/create_document_digital_lpa.go
+++ b/internal/server/create_document_digital_lpa.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/ministryofjustice/opg-go-common/template"
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
+)
+
+type CreateDocumentDigitalLpaClient interface {
+	DigitalLpa(ctx sirius.Context, uid string) (sirius.DigitalLpa, error)
+	DocumentTemplates(ctx sirius.Context, caseType sirius.CaseType) ([]sirius.DocumentTemplateData, error)
+	CreateDocument(ctx sirius.Context, caseID, correspondentID int, templateID string, inserts []string) (sirius.Document, error)
+	CreateContact(ctx sirius.Context, contact sirius.Person) (sirius.Person, error)
+}
+
+type createDocumentDigitalLpaData struct {
+	XSRFToken             string
+	Error                 sirius.ValidationError
+	Lpa                   sirius.DigitalLpa
+	DocumentTemplates     []sirius.DocumentTemplateData
+	ComponentDocumentData ComponentDocumentData
+	Recipients            []sirius.Person
+	SelectedTemplateId    string
+	SelectedInserts       []string
+	SelectedRecipients    []int
+}
+
+func CreateDocumentDigitalLpa(client CreateDocumentDigitalLpaClient, tmpl template.Template) Handler {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		var err error
+		if err := r.ParseForm(); err != nil {
+			return err
+		}
+		ctx := getContext(r)
+
+		uid := chi.URLParam(r, "uid")
+
+		data := createDocumentDigitalLpaData{
+			XSRFToken: ctx.XSRFToken,
+		}
+
+		group, groupCtx := errgroup.WithContext(ctx.Context)
+		group.Go(func() error {
+			data.Lpa, err = client.DigitalLpa(ctx.With(groupCtx), uid)
+
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+
+		group.Go(func() error {
+			documentTemplates, err := client.DocumentTemplates(ctx, sirius.CaseTypeDigitalLpa)
+			data.DocumentTemplates = sortDocumentData(documentTemplates)
+
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+
+		if err := group.Wait(); err != nil {
+			return err
+		}
+
+		data.ComponentDocumentData = buildComponentDocumentData(data.DocumentTemplates)
+
+		donorPlaceholder := sirius.Person{
+			ID:           -1,
+			Firstname:    data.Lpa.Application.DonorFirstNames,
+			Surname:      data.Lpa.Application.DonorLastName,
+			PersonType:   "Donor",
+			AddressLine1: data.Lpa.Application.DonorAddress.Line1,
+			AddressLine2: data.Lpa.Application.DonorAddress.Line2,
+			AddressLine3: data.Lpa.Application.DonorAddress.Line3,
+			Town:         data.Lpa.Application.DonorAddress.Town,
+			Postcode:     data.Lpa.Application.DonorAddress.Postcode,
+			Country:      data.Lpa.Application.DonorAddress.Country,
+		}
+		data.Recipients = append(data.Recipients, donorPlaceholder)
+
+		if r.Method == "POST" {
+			// set data
+			data.SelectedTemplateId = r.FormValue("templateId")
+			data.SelectedInserts = r.Form["insert"]
+
+			for _, recipientId := range r.Form["selectRecipients"] {
+				recipientIdInt, _ := strconv.Atoi(recipientId)
+				data.SelectedRecipients = append(data.SelectedRecipients, recipientIdInt)
+			}
+
+			// check data
+			fieldErrors := sirius.FieldErrors{}
+			if data.SelectedTemplateId == "" {
+				fieldErrors["templateId"] = map[string]string{"reason": "Please select a document template to continue"}
+			}
+
+			if len(data.SelectedRecipients) == 0 {
+				fieldErrors["selectRecipient"] = map[string]string{"reason": "Please select a recipient to continue"}
+			}
+
+			if len(fieldErrors) > 0 {
+				data.Error = sirius.ValidationError{
+					Field: fieldErrors,
+				}
+
+				return tmpl(w, data)
+			}
+
+			// save draft document
+			for _, recipient := range data.Recipients {
+				if !slices.Contains(data.SelectedRecipients, recipient.ID) {
+					continue
+				}
+
+				if recipient.ID == donorPlaceholder.ID {
+					recipient, err = client.CreateContact(ctx, donorPlaceholder)
+					if err != nil {
+						return err
+					}
+				}
+
+				_, err = client.CreateDocument(ctx, data.Lpa.ID, recipient.ID, data.SelectedTemplateId, data.SelectedInserts)
+				if err != nil {
+					return err
+				}
+
+				if ve, ok := err.(sirius.ValidationError); ok {
+					w.WriteHeader(http.StatusBadRequest)
+					data.Error = ve
+				} else if err != nil {
+					return err
+				} else {
+					return RedirectError(fmt.Sprintf("/edit-document?id=%d&case=%s", data.Lpa.ID, sirius.CaseTypeDigitalLpa))
+				}
+			}
+		}
+
+		return tmpl(w, data)
+	}
+}

--- a/internal/server/create_document_digital_lpa_test.go
+++ b/internal/server/create_document_digital_lpa_test.go
@@ -1,0 +1,250 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockCreateDocumentDigitalLpaClient struct {
+	mock.Mock
+}
+
+func (m *mockCreateDocumentDigitalLpaClient) DigitalLpa(ctx sirius.Context, uid string) (sirius.DigitalLpa, error) {
+	args := m.Called(ctx, uid)
+	return args.Get(0).(sirius.DigitalLpa), args.Error(1)
+}
+
+func (m *mockCreateDocumentDigitalLpaClient) DocumentTemplates(ctx sirius.Context, caseType sirius.CaseType) ([]sirius.DocumentTemplateData, error) {
+	args := m.Called(ctx, caseType)
+	return args.Get(0).([]sirius.DocumentTemplateData), args.Error(1)
+}
+
+func (m *mockCreateDocumentDigitalLpaClient) CreateContact(ctx sirius.Context, contact sirius.Person) (sirius.Person, error) {
+	args := m.Called(ctx, contact)
+	return args.Get(0).(sirius.Person), args.Error(1)
+}
+
+func (m *mockCreateDocumentDigitalLpaClient) CreateDocument(ctx sirius.Context, caseID, correspondentID int, templateID string, inserts []string) (sirius.Document, error) {
+	args := m.Called(ctx, caseID, correspondentID, templateID, inserts)
+	return args.Get(0).(sirius.Document), args.Error(1)
+}
+
+func TestGetCreateDocumentDigitalLpa(t *testing.T) {
+	digitalLpa := sirius.DigitalLpa{
+		Application: sirius.Draft{
+			DonorFirstNames: "Zackary",
+			DonorLastName:   "Lemmonds",
+			DonorAddress: sirius.Address{
+				Line1:    "9 Mount Pleasant Drive",
+				Town:     "East Harling",
+				Postcode: "NR16 2GB",
+				Country:  "UK",
+			},
+		},
+	}
+
+	templateData := []sirius.DocumentTemplateData{{TemplateId: "DL-EXAMPLE", Label: "Example DL Form"}}
+
+	client := &mockCreateDocumentDigitalLpaClient{}
+	client.
+		On("DigitalLpa", mock.Anything, "M-TWGJ-CDDJ-4NTL").
+		Return(digitalLpa, nil)
+	client.
+		On("DocumentTemplates", mock.Anything, sirius.CaseTypeDigitalLpa).
+		Return(templateData, nil)
+
+	template := &mockTemplate{}
+	template.
+		On("Func", mock.Anything, createDocumentDigitalLpaData{
+			Lpa:                   digitalLpa,
+			DocumentTemplates:     sortDocumentData(templateData),
+			ComponentDocumentData: buildComponentDocumentData(templateData),
+			Recipients: []sirius.Person{{
+				ID:           -1,
+				Firstname:    "Zackary",
+				Surname:      "Lemmonds",
+				PersonType:   "Donor",
+				AddressLine1: "9 Mount Pleasant Drive",
+				Town:         "East Harling",
+				Postcode:     "NR16 2GB",
+				Country:      "UK",
+			}},
+		}).
+		Return(nil)
+
+	server := newMockServer("/lpa/{uid}/documents/new", CreateDocumentDigitalLpa(client, template.Func))
+
+	req, _ := http.NewRequest(http.MethodGet, "/lpa/M-TWGJ-CDDJ-4NTL/documents/new", nil)
+	_, err := server.serve(req)
+
+	assert.Nil(t, err)
+	mock.AssertExpectationsForObjects(t, client, template)
+}
+
+func TestGetCreateDocumentDigitalLpaError(t *testing.T) {
+	expectedError := errors.New("expected error")
+	templateData := []sirius.DocumentTemplateData{{TemplateId: "DL-EXAMPLE", Label: "Example DL Form"}}
+
+	client := &mockCreateDocumentDigitalLpaClient{}
+	client.
+		On("DigitalLpa", mock.Anything, "M-TWGJ-CDDJ-4NTL").
+		Return(sirius.DigitalLpa{}, expectedError)
+	client.
+		On("DocumentTemplates", mock.Anything, sirius.CaseTypeDigitalLpa).
+		Return(templateData, nil)
+
+	template := &mockTemplate{}
+
+	server := newMockServer("/lpa/{uid}/documents/new", CreateDocumentDigitalLpa(client, template.Func))
+
+	req, _ := http.NewRequest(http.MethodGet, "/lpa/M-TWGJ-CDDJ-4NTL/documents/new", nil)
+	_, err := server.serve(req)
+
+	assert.Equal(t, expectedError, err)
+	mock.AssertExpectationsForObjects(t, client, template)
+}
+
+func TestPostCreateDocumentDigitalLpa(t *testing.T) {
+	digitalLpa := sirius.DigitalLpa{
+		ID: 1234,
+		Application: sirius.Draft{
+			DonorFirstNames: "Zackary",
+			DonorLastName:   "Lemmonds",
+			DonorAddress: sirius.Address{
+				Line1:    "9 Mount Pleasant Drive",
+				Town:     "East Harling",
+				Postcode: "NR16 2GB",
+				Country:  "UK",
+			},
+		},
+	}
+
+	templateData := []sirius.DocumentTemplateData{
+		{
+			TemplateId: "DL-EXAMPLE",
+			Label:      "Example DL Form",
+			Inserts: []sirius.Insert{
+				{InsertId: "DL_INS_01", Label: "Example Insert 1"},
+				{InsertId: "DL_INS_02", Label: "Example Insert 2"},
+			},
+		},
+	}
+
+	client := &mockCreateDocumentDigitalLpaClient{}
+	client.
+		On("DigitalLpa", mock.Anything, "M-TWGJ-CDDJ-4NTL").
+		Return(digitalLpa, nil)
+	client.
+		On("DocumentTemplates", mock.Anything, sirius.CaseTypeDigitalLpa).
+		Return(templateData, nil)
+	client.
+		On("CreateContact", mock.Anything, sirius.Person{
+			ID:           -1,
+			Firstname:    "Zackary",
+			Surname:      "Lemmonds",
+			PersonType:   "Donor",
+			AddressLine1: "9 Mount Pleasant Drive",
+			Town:         "East Harling",
+			Postcode:     "NR16 2GB",
+			Country:      "UK",
+		}).
+		Return(sirius.Person{ID: 4829}, nil)
+	client.
+		On("CreateDocument", mock.Anything, 1234, 4829, "DL-EXAMPLE", []string{"DL_INS_01", "DL_INS_02"}).
+		Return(sirius.Document{}, nil)
+
+	template := &mockTemplate{}
+
+	server := newMockServer("/lpa/{uid}/documents/new", CreateDocumentDigitalLpa(client, template.Func))
+
+	form := url.Values{
+		"templateId":       {"DL-EXAMPLE"},
+		"insert":           {"DL_INS_01", "DL_INS_02"},
+		"selectRecipients": {"-1"},
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, "/lpa/M-TWGJ-CDDJ-4NTL/documents/new", strings.NewReader(form.Encode()))
+	req.Header.Add("Content-Type", formUrlEncoded)
+	_, err := server.serve(req)
+
+	assert.Equal(t, RedirectError("/edit-document?id=1234&case=digital_lpa"), err)
+	mock.AssertExpectationsForObjects(t, client, template)
+}
+
+func TestPostCreateDocumentDigitalLpaInvalid(t *testing.T) {
+	digitalLpa := sirius.DigitalLpa{
+		ID: 1234,
+		Application: sirius.Draft{
+			DonorFirstNames: "Zackary",
+			DonorLastName:   "Lemmonds",
+			DonorAddress: sirius.Address{
+				Line1:    "9 Mount Pleasant Drive",
+				Town:     "East Harling",
+				Postcode: "NR16 2GB",
+				Country:  "UK",
+			},
+		},
+	}
+
+	templateData := []sirius.DocumentTemplateData{
+		{
+			TemplateId: "DL-EXAMPLE",
+			Label:      "Example DL Form",
+			Inserts: []sirius.Insert{
+				{InsertId: "DL_INS_01", Label: "Example Insert 1"},
+				{InsertId: "DL_INS_02", Label: "Example Insert 2"},
+			},
+		},
+	}
+
+	client := &mockCreateDocumentDigitalLpaClient{}
+	client.
+		On("DigitalLpa", mock.Anything, "M-TWGJ-CDDJ-4NTL").
+		Return(digitalLpa, nil)
+	client.
+		On("DocumentTemplates", mock.Anything, sirius.CaseTypeDigitalLpa).
+		Return(templateData, nil)
+
+	template := &mockTemplate{}
+	template.
+		On("Func", mock.Anything, createDocumentDigitalLpaData{
+			Lpa:                   digitalLpa,
+			DocumentTemplates:     sortDocumentData(templateData),
+			ComponentDocumentData: buildComponentDocumentData(templateData),
+			Recipients: []sirius.Person{{
+				ID:           -1,
+				Firstname:    "Zackary",
+				Surname:      "Lemmonds",
+				PersonType:   "Donor",
+				AddressLine1: "9 Mount Pleasant Drive",
+				Town:         "East Harling",
+				Postcode:     "NR16 2GB",
+				Country:      "UK",
+			}},
+			Error: sirius.ValidationError{
+				Field: sirius.FieldErrors{
+					"templateId":      {"reason": "Please select a document template to continue"},
+					"selectRecipient": {"reason": "Please select a recipient to continue"},
+				},
+			},
+		}).
+		Return(nil)
+
+	server := newMockServer("/lpa/{uid}/documents/new", CreateDocumentDigitalLpa(client, template.Func))
+
+	form := url.Values{}
+
+	req, _ := http.NewRequest(http.MethodPost, "/lpa/M-TWGJ-CDDJ-4NTL/documents/new", strings.NewReader(form.Encode()))
+	req.Header.Add("Content-Type", formUrlEncoded)
+	_, err := server.serve(req)
+
+	assert.Nil(t, err)
+	mock.AssertExpectationsForObjects(t, client, template)
+}

--- a/internal/server/create_draft.go
+++ b/internal/server/create_draft.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
@@ -145,7 +144,7 @@ func CreateDraft(client CreateDraftClient, tmpl template.Template) Handler {
 		if r.Method == "POST" {
 			err := decoder.Decode(&data.Form, r.PostForm)
 			if err != nil {
-				log.Panic(err)
+				return err
 			}
 
 			compiledDraft := sirius.Draft{

--- a/internal/server/flash.go
+++ b/internal/server/flash.go
@@ -53,7 +53,7 @@ func GetFlash(w http.ResponseWriter, r *http.Request) (FlashNotification, error)
 		return FlashNotification{}, err
 	}
 
-	dc := &http.Cookie{Name: flashCookieName, MaxAge: -1, Expires: time.Unix(1, 0), Path: "/",}
+	dc := &http.Cookie{Name: flashCookieName, MaxAge: -1, Expires: time.Unix(1, 0), Path: "/"}
 
 	http.SetCookie(w, dc)
 	return v, nil

--- a/internal/server/get_documents.go
+++ b/internal/server/get_documents.go
@@ -1,9 +1,10 @@
 package server
 
 import (
+	"net/http"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
-	"net/http"
 
 	"github.com/ministryofjustice/opg-go-common/template"
 )
@@ -16,8 +17,9 @@ type GetDocumentsClient interface {
 type getDocumentsData struct {
 	XSRFToken string
 
-	Lpa       sirius.DigitalLpa
-	Documents []sirius.Document
+	Lpa          sirius.DigitalLpa
+	Documents    []sirius.Document
+	FlashMessage FlashNotification
 }
 
 func GetDocuments(client GetDocumentsClient, tmpl template.Template) Handler {
@@ -39,6 +41,8 @@ func GetDocuments(client GetDocumentsClient, tmpl template.Template) Handler {
 			Documents: documents,
 			Lpa:       lpa,
 		}
+
+		data.FlashMessage, _ = GetFlash(w, r)
 
 		return tmpl(w, data)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -121,6 +121,7 @@ func New(logger Logger, client Client, templates template.Templates, prefix, sir
 	mux.Handle("/payments/{id}", wrap(GetPayments(client, templates.Get("payments.gohtml"))))
 	mux.Handle("/lpa/{uid}/payments", wrap(GetPayments(client, templates.Get("mlpa-payments.gohtml"))))
 	mux.Handle("/lpa/{uid}/documents", wrap(GetDocuments(client, templates.Get("mlpa-documents.gohtml"))))
+	mux.Handle("/lpa/{uid}/documents/new", wrap(CreateDocumentDigitalLpa(client, templates.Get("mlpa-create_document.gohtml"))))
 	mux.Handle("/search-users", wrap(SearchUsers(client)))
 	mux.Handle("/search-persons", wrap(SearchDonors(client)))
 	mux.Handle("/search-postcode", wrap(SearchPostcode(client)))

--- a/internal/sirius/case_type.go
+++ b/internal/sirius/case_type.go
@@ -8,8 +8,9 @@ import (
 type CaseType string
 
 const (
-	CaseTypeLpa = CaseType("lpa")
-	CaseTypeEpa = CaseType("epa")
+	CaseTypeLpa        = CaseType("lpa")
+	CaseTypeEpa        = CaseType("epa")
+	CaseTypeDigitalLpa = CaseType("digital_lpa")
 )
 
 func ParseCaseType(s string) (CaseType, error) {
@@ -18,6 +19,8 @@ func ParseCaseType(s string) (CaseType, error) {
 		return CaseTypeLpa, nil
 	case "epa":
 		return CaseTypeEpa, nil
+	case "digital_lpa":
+		return CaseTypeDigitalLpa, nil
 	}
 
 	return CaseType(""), errors.New("could not parse case type")

--- a/internal/sirius/document.go
+++ b/internal/sirius/document.go
@@ -30,6 +30,10 @@ const (
 func (c *Client) Documents(ctx Context, caseType CaseType, caseId int, docType string) ([]Document, error) {
 	var d []Document
 
+	if caseType == CaseTypeDigitalLpa {
+		caseType = CaseTypeLpa
+	}
+
 	url := fmt.Sprintf("/lpa-api/v1/%s/%d/documents?type[]=%s", caseType+"s", caseId, docType)
 
 	err := c.get(ctx, url, &d)

--- a/internal/sirius/document_templates.go
+++ b/internal/sirius/document_templates.go
@@ -103,7 +103,12 @@ func (i insertApiResponse) toInsertData() ([]Insert, error) {
 }
 
 func (c *Client) DocumentTemplates(ctx Context, caseType CaseType) ([]DocumentTemplateData, error) {
-	req, err := c.newRequest(ctx, http.MethodGet, fmt.Sprintf("/lpa-api/v1/templates/%s", caseType), nil)
+	templateSet := caseType
+	if caseType == CaseTypeDigitalLpa {
+		templateSet = "digitallpa"
+	}
+
+	req, err := c.newRequest(ctx, http.MethodGet, fmt.Sprintf("/lpa-api/v1/templates/%s", templateSet), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/templatefn/fn.go
+++ b/internal/templatefn/fn.go
@@ -127,6 +127,9 @@ func All(siriusPublicURL, prefix, staticHash string) map[string]interface{} {
 		"attr": func(s string) template.HTMLAttr {
 			return template.HTMLAttr(s) //#nosec G203 false positive
 		},
+		"join": func(s []string, joiner string) string {
+			return strings.Join(s, joiner)
+		},
 	}
 }
 

--- a/web/assets/handle-create-document-button.js
+++ b/web/assets/handle-create-document-button.js
@@ -14,7 +14,7 @@ const handleCreateDocumentButton = () => {
     '[data-module="recipient-checkbox"]',
   );
 
-  if (checkboxes && checkboxes.length > 0) {
+  if (createDocumentButton && checkboxes && checkboxes.length > 0) {
     checkboxes.forEach((el, i) => {
       el.addEventListener("change", (event) => {
         let isOneRecipientSelected = Array.from(checkboxes).some(

--- a/web/assets/insert-selector.js
+++ b/web/assets/insert-selector.js
@@ -24,6 +24,16 @@ function InsertSelector($module) {
 
 InsertSelector.prototype.init = function () {
   this.$initiator.addEventListener("confirm", this.onSelectTemplate.bind(this));
+
+  this.onSelectTemplate();
+
+  const selected = this.$module.getAttribute("data-selected");
+  if (selected && selected.length) {
+    const inserts = selected.split(",");
+    inserts.forEach((insert) => {
+      this.$module.querySelector(`input[value="${insert}"]`).checked = true;
+    });
+  }
 };
 
 InsertSelector.prototype.onSelectTemplate = function (e) {

--- a/web/template/edit_document.gohtml
+++ b/web/template/edit_document.gohtml
@@ -17,14 +17,26 @@
                    data-module="app-auto-click">Download preview document</a>
             {{ end }}
 
-            <div class="govuk-body">
-                <a href="{{ prefix (printf "/create-document?id=%d&case=%s" .Case.ID .Case.CaseType) }}" class="govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-0">Back</a>
-                <div class="app-!-float-right">
-                    {{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "hw" }}HW{{ end }} {{ .Case.UID }}
-                </div>
-            </div>
+            {{ if .Lpa.ID }}
+                {{ template "mlpa-header" (caseTabs .Lpa "documents") }}
 
-            <h1 class="govuk-heading-m">Edit draft document</h1>
+                <div class="govuk-body">
+                    <a href="{{ prefix (printf "/lpa/%s/documents" .Lpa.UID) }}" class="govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-0">
+                        Back
+                    </a>
+                </div>
+
+                <h1 class="govuk-heading-l">Edit draft document</h1>
+            {{ else }}
+                <div class="govuk-body">
+                    <a href="{{ prefix (printf "/create-document?id=%d&case=%s" .Case.ID .Case.CaseType) }}" class="govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-0">Back</a>
+                    <div class="app-!-float-right">
+                        {{ if eq .Case.SubType "pfa" }}PFA{{ else if eq .Case.SubType "hw" }}HW{{ end }} {{ .Case.UID }}
+                    </div>
+                </div>
+
+                <h1 class="govuk-heading-m">Edit draft document</h1>
+            {{ end }}
 
             {{ if not .Documents }}
                 <meta data-app-reload="saveAndExit"/>

--- a/web/template/mlpa-create_document.gohtml
+++ b/web/template/mlpa-create_document.gohtml
@@ -1,0 +1,115 @@
+{{ template "page" . }}
+
+{{ define "title" }}{{ if .Error.Any }}Error: {{ end }}Create Document{{ end }}
+
+{{ define "main" }}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ template "mlpa-header" (caseTabs .Lpa "documents") }}
+
+            {{ template "error-summary" .Error }}
+
+            <h1 class="govuk-heading-l">Create a document</h1>
+
+            <form class="form" method="POST">
+                <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
+
+                <div class="govuk-form-group {{ if .Error.Field.templateId }}govuk-form-group--error{{ end }}">
+                    <label class="govuk-label govuk-label--s" for="f-templateId">Select a document template</label>
+                    <div id="f-templateId-hint" class="govuk-hint">
+                        Select a template or enter the name of the template
+                    </div>
+                    {{ template "errors" .Error.Field.templateId }}
+                    <select class="govuk-select {{ if .Error.Field.templateId }}govuk-select--error{{ end }}"
+                            id="f-templateId" name="templateId" aria-describedby="f-templateId-hint" data-select-template>
+                        <option value="" selected></option>
+                        {{ range .DocumentTemplates }}
+                            <option value="{{ .TemplateId }}" {{ if eq .TemplateId $.SelectedTemplateId }}selected{{ end }}>{{ .TemplateId }}: {{ .Label }}</option>
+                        {{ end }}
+                    </select>
+                </div>
+
+                <div data-module="app-insert-selector" data-initiator-selector="#f-templateId" data-selected="{{ join .SelectedInserts "," }}">
+                    <script type="application/json" data-id="insert-selector-data">
+                        {{ .ComponentDocumentData }}
+                    </script>
+
+                    <template data-id="insert-selector-template-container">
+                        <div>
+                            <fieldset class="govuk-fieldset" aria-describedby="f-insert-selector-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                                    Select document inserts
+                                </legend>
+                                <div id="f-insert-selector-hint" class="govuk-hint">
+                                    Optional
+                                </div>
+
+                                <div class="govuk-tabs" data-module="govuk-tabs">
+                                    <ul class="govuk-tabs__list"></ul>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+
+                    <template data-id="insert-selector-template-panel">
+                        <div class="govuk-tabs__panel app-tabs__panel--compact" data-module="tab-content">
+                            <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+                                <table class="govuk-table app-table--compact">
+                                    <tbody class="govuk-table__body app-!-td-last-child-no-border">
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                        Select a recipient
+                    </legend>
+                    <div class="govuk-form-group {{ if .Error.Field.selectRecipient }}govuk-form-group--error{{ end }}">
+                        {{ template "errors" .Error.Field.selectRecipient }}
+                        <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+                            <table class="govuk-table">
+                                <tbody class="govuk-table__body">
+                                {{ range $recipient := .Recipients }}
+                                    <tr class="govuk-table__row">
+                                        <td class="govuk-table__cell">
+                                                <div class="govuk-checkboxes__item">
+                                                    <input class="govuk-checkboxes__input" id="f-recipient-{{ .ID }}"
+                                                        name="selectRecipients" type="checkbox"
+                                                        value="{{ .ID }}"
+                                                        data-module="recipient-checkbox"
+                                                        {{ range $selected := $.SelectedRecipients  }}
+                                                            {{ if eq $selected $recipient.ID }}checked{{ end }}
+                                                        {{ end }}
+                                                    />
+                                                    <label class="govuk-label govuk-checkboxes__label"
+                                                        for="f-recipient-{{ .ID }}">
+                                                        {{ if .CompanyName  }}
+                                                            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{{ .CompanyName }} ({{ .PersonType }})</h2>
+                                                        {{ else }}
+                                                            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">{{ .Salutation }} {{ .Firstname }} {{ .Surname }} ({{ .PersonType }})</h2>
+                                                        {{ end }}
+                                                        <p class="govuk-body govuk-!-margin-bottom-0">{{ .AddressSummary }}</p>
+                                                    </label>
+                                                </div>
+                                        </td>
+                                    </tr>
+                                {{ end }}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </fieldset>
+
+                <div class="govuk-button-group govuk-!-padding-top-5">
+                    <button class="govuk-button" data-module="govuk-button" data-module="create-document-button" type="submit">Continue</button>
+                </div>
+                <div class="govuk-body">
+                    <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/lpa/%s/documents" .Lpa.UID) }}">Cancel</a>
+                </div>
+            </form>
+        </div>
+    </div>
+{{ end }}

--- a/web/template/mlpa-documents.gohtml
+++ b/web/template/mlpa-documents.gohtml
@@ -8,6 +8,10 @@
 
             {{ template "mlpa-header" (caseTabs .Lpa "documents") }}
 
+            {{ if (or .FlashMessage.Title .FlashMessage.Description) }}
+                {{ template "notification-banner" .FlashMessage }}
+            {{ end }}
+
             <div class="moj-page-header-actions">
                 <div class="moj-page-header-actions__title">
                     <h1 class="govuk-heading-l">Documents</h1>
@@ -16,7 +20,7 @@
                 <div class="moj-page-header-actions__actions">
                     <div class="moj-button-menu">
                         <div class="moj-button-menu__wrapper">
-                            <a role="button" class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action" data-module="govuk-button" href="#">
+                            <a role="button" class="govuk-button govuk-button--secondary moj-button-menu__item moj-page-header-actions__action" data-module="govuk-button" href="{{ prefix (printf "/lpa/%s/documents/new" .Lpa.UID) }}">
                                 Create a document
                             </a>
                         </div>


### PR DESCRIPTION
Create a new route for creating the document, selecting templates, inserts and recipients. Since the donor record isn't (yet) populated, create a non-case contact to send to.

Tweak the insert-selector JS component so it can handle existing values.

Adapt the edit document form so it can support Digital LPA documents, and show their header.

Show flash messages on the Digital LPA document tab, and generate them when documents are previewed or published.

#minor

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [x] I have added styling for Dark Mode
  - N/A
- [x] I have checked that my UI changes meet accessibility standards
