### PR TITLE
VEGA-1781 - Allow indices to be specified for seaches

### DIFF
--- a/cypress/e2e/create-relationship.cy.js
+++ b/cypress/e2e/create-relationship.cy.js
@@ -1,6 +1,6 @@
 describe("Create a relationship", () => {
   beforeEach(() => {
-    cy.addMock("/lpa-api/v1/search/persons", "POST", {
+    cy.addMock("/lpa-api/v1/search/searchAll", "POST", {
       status: 200,
       body: {
         aggregations: {

--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -1,7 +1,7 @@
 describe("Search", () => {
   describe("Searching by name", () => {
     beforeEach(() => {
-      cy.addMock("/lpa-api/v1/search/persons", "POST", {
+      cy.addMock("/lpa-api/v1/search/searchAll", "POST", {
         status: 200,
         body: {
           aggregations: {
@@ -124,6 +124,15 @@ describe("Search", () => {
 
   describe("Search features", () => {
     beforeEach(() => {
+      cy.addMock("/lpa-api/v1/search/searchAll", "POST", {
+        status: 200,
+        body: {
+          total: {
+            count: 0,
+          },
+        },
+      });
+
       cy.visit("/search?term=abcdefg");
     });
 
@@ -152,7 +161,7 @@ describe("Search", () => {
 
   describe("Search deleted case", () => {
     beforeEach(() => {
-      cy.addMock("/lpa-api/v1/search/persons", "POST", {
+      cy.addMock("/lpa-api/v1/search/searchAll", "POST", {
         status: 200,
         body: {
           total: {

--- a/internal/server/search.go
+++ b/internal/server/search.go
@@ -11,7 +11,7 @@ import (
 )
 
 type SearchClient interface {
-	Search(ctx sirius.Context, term string, page int, personTypeFilters []string) (sirius.SearchResponse, *sirius.Pagination, error)
+	Search(ctx sirius.Context, term string, page int, personTypeFilters []string, indices []string) (sirius.SearchResponse, *sirius.Pagination, error)
 	DeletedCases(ctx sirius.Context, uid string) ([]sirius.DeletedCase, error)
 }
 
@@ -77,7 +77,7 @@ func Search(client SearchClient, tmpl template.Template) Handler {
 			Filters:    filters,
 		}
 
-		results, pagination, err := client.Search(ctx, searchTerm, getPage(r), filters.PersonType)
+		results, pagination, err := client.Search(ctx, searchTerm, getPage(r), filters.PersonType, []string{"person"})
 		if err != nil {
 			return err
 		}

--- a/internal/server/search_test.go
+++ b/internal/server/search_test.go
@@ -13,8 +13,8 @@ type mockSearchClient struct {
 	mock.Mock
 }
 
-func (m *mockSearchClient) Search(ctx sirius.Context, term string, page int, personTypeFilters []string) (sirius.SearchResponse, *sirius.Pagination, error) {
-	args := m.Called(ctx, term, page, personTypeFilters)
+func (m *mockSearchClient) Search(ctx sirius.Context, term string, page int, personTypeFilters []string, indices []string) (sirius.SearchResponse, *sirius.Pagination, error) {
+	args := m.Called(ctx, term, page, personTypeFilters, indices)
 	if v, ok := args.Get(1).(*sirius.Pagination); ok {
 		return args.Get(0).(sirius.SearchResponse), v, args.Error(2)
 	}
@@ -50,7 +50,7 @@ func TestGetSearch(t *testing.T) {
 
 	client := &mockSearchClient{}
 	client.
-		On("Search", mock.Anything, "bob", 1, noFilters).
+		On("Search", mock.Anything, "bob", 1, noFilters, []string{"person"}).
 		Return(expectedResponse, expectedPagination, nil)
 
 	template := &mockTemplate{}
@@ -101,7 +101,7 @@ func TestGetSearchFiltered(t *testing.T) {
 
 	client := &mockSearchClient{}
 	client.
-		On("Search", mock.Anything, "bob", 1, filters).
+		On("Search", mock.Anything, "bob", 1, filters, []string{"person"}).
 		Return(expectedResponse, expectedPagination, nil)
 
 	template := &mockTemplate{}
@@ -157,7 +157,7 @@ func TestGetSearchPaginationCalculations(t *testing.T) {
 
 	client := &mockSearchClient{}
 	client.
-		On("Search", mock.Anything, "bob", 2, noFilters).
+		On("Search", mock.Anything, "bob", 2, noFilters, []string{"person"}).
 		Return(expectedResponse, expectedPagination, nil)
 
 	template := &mockTemplate{}
@@ -209,7 +209,7 @@ func TestGetSearchCallsDeletedCasesOnFallback(t *testing.T) {
 
 	client := &mockSearchClient{}
 	client.
-		On("Search", mock.Anything, "7000-0000-5678", 1, noFilters).
+		On("Search", mock.Anything, "7000-0000-5678", 1, noFilters, []string{"person"}).
 		Return(expectedResponse, expectedPagination, nil).
 		On("DeletedCases", mock.Anything, "700000005678").
 		Return(expectedDeletedCases, nil)
@@ -253,7 +253,7 @@ func TestGetSearchGetDeletedCasesFailure(t *testing.T) {
 
 	client := &mockSearchClient{}
 	client.
-		On("Search", mock.Anything, "7000-0000-5678", 1, noFilters).
+		On("Search", mock.Anything, "7000-0000-5678", 1, noFilters, []string{"person"}).
 		Return(expectedResponse, expectedPagination, nil).
 		On("DeletedCases", mock.Anything, "700000005678").
 		Return([]sirius.DeletedCase{}, expectedError)
@@ -290,7 +290,7 @@ func TestGetSearchErrors(t *testing.T) {
 
 	client := &mockSearchClient{}
 	client.
-		On("Search", mock.Anything, "bob", 1, filters).
+		On("Search", mock.Anything, "bob", 1, filters, []string{"person"}).
 		Return(sirius.SearchResponse{}, &sirius.Pagination{}, expectedError)
 
 	req, _ := http.NewRequest(http.MethodGet, "/search?term=bob", nil)
@@ -322,7 +322,7 @@ func TestGetSearchTemplateErrors(t *testing.T) {
 
 	client := &mockSearchClient{}
 	client.
-		On("Search", mock.Anything, "bob", 1, noFilters).
+		On("Search", mock.Anything, "bob", 1, noFilters, []string{"person"}).
 		Return(expectedResponse, expectedPagination, nil)
 
 	template := &mockTemplate{}

--- a/internal/sirius/search.go
+++ b/internal/sirius/search.go
@@ -14,6 +14,7 @@ type searchRequest struct {
 	PersonTypes []string `json:"personTypes"`
 	Limit       int      `json:"size"`
 	From        int      `json:"from"`
+	Indices     []string `json:"indices"`
 }
 
 type Aggregations struct {
@@ -42,7 +43,7 @@ var AllPersonTypes = []string{
 	"Correspondent",
 }
 
-func (c *Client) Search(ctx Context, term string, page int, personTypeFilters []string) (SearchResponse, *Pagination, error) {
+func (c *Client) Search(ctx Context, term string, page int, personTypeFilters []string, indices []string) (SearchResponse, *Pagination, error) {
 	var v SearchResponse
 	if len(term) < 3 {
 		err := ValidationError{
@@ -59,7 +60,7 @@ func (c *Client) Search(ctx Context, term string, page int, personTypeFilters []
 		personTypeFilters = AllPersonTypes
 	}
 
-	data, err := json.Marshal(searchRequest{Term: term, PersonTypes: personTypeFilters, Limit: PageLimit, From: PageLimit * (page - 1)})
+	data, err := json.Marshal(searchRequest{Term: term, PersonTypes: personTypeFilters, Limit: PageLimit, From: PageLimit * (page - 1), Indices: indices})
 	if err != nil {
 		return v, nil, err
 	}

--- a/internal/sirius/search.go
+++ b/internal/sirius/search.go
@@ -65,7 +65,7 @@ func (c *Client) Search(ctx Context, term string, page int, personTypeFilters []
 		return v, nil, err
 	}
 
-	req, err := c.newRequest(ctx, http.MethodPost, "/lpa-api/v1/search/persons", bytes.NewReader(data))
+	req, err := c.newRequest(ctx, http.MethodPost, "/lpa-api/v1/search/searchAll", bytes.NewReader(data))
 	if err != nil {
 		return v, nil, err
 	}

--- a/internal/sirius/search_donors.go
+++ b/internal/sirius/search_donors.go
@@ -1,7 +1,7 @@
 package sirius
 
 func (c *Client) SearchDonors(ctx Context, term string) ([]Person, error) {
-	resp, _, err := c.Search(ctx, term, 1, []string{"Donor"})
+	resp, _, err := c.Search(ctx, term, 1, []string{"Donor"}, []string{"person"})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sirius/search_donors_test.go
+++ b/internal/sirius/search_donors_test.go
@@ -37,6 +37,7 @@ func TestSearchDonors(t *testing.T) {
 							"personTypes": []string{"Donor"},
 							"size":        PageLimit,
 							"from":        0,
+							"indices":     []string{"person"},
 						},
 					}).
 					WillRespondWith(dsl.Response{

--- a/internal/sirius/search_donors_test.go
+++ b/internal/sirius/search_donors_test.go
@@ -31,7 +31,7 @@ func TestSearchDonors(t *testing.T) {
 					UponReceiving("A search for donors").
 					WithRequest(dsl.Request{
 						Method: http.MethodPost,
-						Path:   dsl.String("/lpa-api/v1/search/persons"),
+						Path:   dsl.String("/lpa-api/v1/search/searchAll"),
 						Body: map[string]interface{}{
 							"term":        "7000-0000-0003",
 							"personTypes": []string{"Donor"},

--- a/internal/sirius/search_test.go
+++ b/internal/sirius/search_test.go
@@ -43,6 +43,7 @@ func TestSearch(t *testing.T) {
 							"personTypes": AllPersonTypes,
 							"size":        PageLimit,
 							"from":        0,
+							"indices":     []string{"person", "firm"},
 						},
 					}).
 					WillRespondWith(dsl.Response{
@@ -132,6 +133,7 @@ func TestSearch(t *testing.T) {
 							"personTypes": AllPersonTypes,
 							"size":        PageLimit,
 							"from":        0,
+							"indices":     []string{"person", "firm"},
 						},
 					}).
 					WillRespondWith(dsl.Response{
@@ -165,7 +167,7 @@ func TestSearch(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				results, pagination, err := client.Search(Context{Context: context.Background()}, tc.searchTerm, 1, AllPersonTypes)
+				results, pagination, err := client.Search(Context{Context: context.Background()}, tc.searchTerm, 1, AllPersonTypes, []string{"person", "firm"})
 				assert.Equal(t, tc.expectedResponse, results)
 				assert.Equal(t, tc.expectedPagination, pagination)
 				if tc.expectedError == nil {

--- a/internal/sirius/search_test.go
+++ b/internal/sirius/search_test.go
@@ -34,7 +34,7 @@ func TestSearch(t *testing.T) {
 					UponReceiving("A search request for a donor not related to a case").
 					WithRequest(dsl.Request{
 						Method: http.MethodPost,
-						Path:   dsl.String("/lpa-api/v1/search/persons"),
+						Path:   dsl.String("/lpa-api/v1/search/searchAll"),
 						Headers: dsl.MapMatcher{
 							"Content-Type": dsl.String("application/json"),
 						},
@@ -124,7 +124,7 @@ func TestSearch(t *testing.T) {
 					UponReceiving("A search request for the deleted case uid").
 					WithRequest(dsl.Request{
 						Method: http.MethodPost,
-						Path:   dsl.String("/lpa-api/v1/search/persons"),
+						Path:   dsl.String("/lpa-api/v1/search/searchAll"),
 						Headers: dsl.MapMatcher{
 							"Content-Type": dsl.String("application/json"),
 						},


### PR DESCRIPTION
The search and search donor endpoints have been updated to call searchAll on sirius API, with the relevant indices specified according to the requirements on the [ticket](https://opgtransform.atlassian.net/browse/VEGA-1781)

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards
