### PR TITLE
Show incoming correspondence on Digital LPAs

### DIFF
--- a/cypress/mocks/common.json
+++ b/cypress/mocks/common.json
@@ -110,7 +110,7 @@
     {
       "request": {
         "method": "GET",
-        "url": "/lpa-api/v1/lpas/800/documents?type[]=Save"
+        "url": "/lpa-api/v1/lpas/800/documents?type[-][]=Draft&type[-][]=Preview"
       },
       "response": {
         "status": 200,

--- a/internal/server/edit_document.go
+++ b/internal/server/edit_document.go
@@ -11,7 +11,7 @@ import (
 )
 
 type EditDocumentClient interface {
-	Documents(ctx sirius.Context, caseType sirius.CaseType, caseId int, docType string) ([]sirius.Document, error)
+	Documents(ctx sirius.Context, caseType sirius.CaseType, caseId int, docTypes []string, notDocTypes []string) ([]sirius.Document, error)
 	Case(ctx sirius.Context, id int) (sirius.Case, error)
 	DigitalLpa(ctx sirius.Context, uid string) (sirius.DigitalLpa, error)
 	DocumentByUUID(ctx sirius.Context, uuid string) (sirius.Document, error)
@@ -78,7 +78,7 @@ func EditDocument(client EditDocumentClient, tmpl template.Template) Handler {
 			})
 
 			group.Go(func() error {
-				documents, err := client.Documents(ctx.With(groupCtx), caseType, caseID, sirius.TypeDraft)
+				documents, err := client.Documents(ctx.With(groupCtx), caseType, caseID, []string{sirius.TypeDraft}, []string{})
 				if err != nil {
 					return err
 				}
@@ -231,7 +231,7 @@ func EditDocument(client EditDocumentClient, tmpl template.Template) Handler {
 				})
 
 				group.Go(func() error {
-					documents, err := client.Documents(ctx.With(groupCtx), caseType, caseID, sirius.TypeDraft)
+					documents, err := client.Documents(ctx.With(groupCtx), caseType, caseID, []string{sirius.TypeDraft}, []string{})
 					if err != nil {
 						return err
 					}

--- a/internal/server/edit_document_test.go
+++ b/internal/server/edit_document_test.go
@@ -26,8 +26,8 @@ func (m *mockEditDocumentClient) DigitalLpa(ctx sirius.Context, uid string) (sir
 	return args.Get(0).(sirius.DigitalLpa), args.Error(1)
 }
 
-func (m *mockEditDocumentClient) Documents(ctx sirius.Context, caseType sirius.CaseType, caseId int, docType string) ([]sirius.Document, error) {
-	args := m.Called(ctx, caseType, caseId, docType)
+func (m *mockEditDocumentClient) Documents(ctx sirius.Context, caseType sirius.CaseType, caseId int, docTypes []string, notDocTypes []string) ([]sirius.Document, error) {
+	args := m.Called(ctx, caseType, caseId, docTypes, notDocTypes)
 	return args.Get(0).([]sirius.Document), args.Error(1)
 }
 
@@ -84,7 +84,7 @@ func TestGetEditDocument(t *testing.T) {
 				On("Case", mock.Anything, 123).
 				Return(caseItem, nil)
 			client.
-				On("Documents", mock.Anything, sirius.CaseType(caseType), 123, sirius.TypeDraft).
+				On("Documents", mock.Anything, sirius.CaseType(caseType), 123, []string{sirius.TypeDraft}, []string{}).
 				Return(documents, nil)
 			client.
 				On("DocumentByUUID", mock.Anything, document.UUID).
@@ -149,7 +149,7 @@ func TestPostSaveDocument(t *testing.T) {
 				On("Case", mock.Anything, 123).
 				Return(caseItem, nil)
 			client.
-				On("Documents", mock.Anything, sirius.CaseType(caseType), 123, sirius.TypeDraft).
+				On("Documents", mock.Anything, sirius.CaseType(caseType), 123, []string{sirius.TypeDraft}, []string{}).
 				Return(documents, nil)
 			client.
 				On("EditDocument", mock.Anything, document.UUID, "Edited test content").
@@ -238,7 +238,7 @@ func TestPostDeleteDocument(t *testing.T) {
 				expectedError = RedirectError("/lpa/700700/documents")
 			} else {
 				client.
-					On("Documents", mock.Anything, sirius.CaseType(caseType), 123, sirius.TypeDraft).
+					On("Documents", mock.Anything, sirius.CaseType(caseType), 123, []string{sirius.TypeDraft}, []string{}).
 					Return(documents, nil)
 				client.
 					On("DocumentByUUID", mock.Anything, document.UUID).
@@ -325,7 +325,7 @@ func TestPostPublishDocument(t *testing.T) {
 				expectedError = RedirectError("/lpa/700700/documents")
 			} else {
 				client.
-					On("Documents", mock.Anything, sirius.CaseType(caseType), 123, sirius.TypeDraft).
+					On("Documents", mock.Anything, sirius.CaseType(caseType), 123, []string{sirius.TypeDraft}, []string{}).
 					Return(documents, nil)
 				client.
 					On("DocumentTemplates", mock.Anything, sirius.CaseType(caseType)).
@@ -399,7 +399,7 @@ func TestPostPreviewDocument(t *testing.T) {
 		On("Case", mock.Anything, 123).
 		Return(caseItem, nil)
 	client.
-		On("Documents", mock.Anything, sirius.CaseType("lpa"), 123, sirius.TypeDraft).
+		On("Documents", mock.Anything, sirius.CaseType("lpa"), 123, []string{sirius.TypeDraft}, []string{}).
 		Return(documents, nil)
 	client.
 		On("DocumentTemplates", mock.Anything, sirius.CaseTypeLpa).
@@ -506,7 +506,7 @@ func TestGetEditDocumentWhenCaseErrors(t *testing.T) {
 		On("Case", mock.Anything, 123).
 		Return(sirius.Case{}, expectedError)
 	client.
-		On("Documents", mock.Anything, sirius.CaseTypeLpa, 123, sirius.TypeDraft).
+		On("Documents", mock.Anything, sirius.CaseTypeLpa, 123, []string{sirius.TypeDraft}, []string{}).
 		Return([]sirius.Document{}, nil)
 	client.
 		On("DocumentTemplates", mock.Anything, sirius.CaseTypeLpa).
@@ -529,7 +529,7 @@ func TestGetCreateDocumentWhenFailureOnDocuments(t *testing.T) {
 		On("Case", mock.Anything, 123).
 		Return(caseItem, nil)
 	client.
-		On("Documents", mock.Anything, sirius.CaseTypeLpa, 123, sirius.TypeDraft).
+		On("Documents", mock.Anything, sirius.CaseTypeLpa, 123, []string{sirius.TypeDraft}, []string{}).
 		Return([]sirius.Document{}, expectedError)
 	client.
 		On("DocumentTemplates", mock.Anything, sirius.CaseTypeLpa).
@@ -562,7 +562,7 @@ func TestGetCreateDocumentWhenFailureOnDocumentByUUID(t *testing.T) {
 		On("Case", mock.Anything, 123).
 		Return(caseItem, nil)
 	client.
-		On("Documents", mock.Anything, sirius.CaseTypeLpa, 123, sirius.TypeDraft).
+		On("Documents", mock.Anything, sirius.CaseTypeLpa, 123, []string{sirius.TypeDraft}, []string{}).
 		Return(documents, nil)
 	client.
 		On("DocumentByUUID", mock.Anything, "dfef6714-b4fe-44c2-b26e-90dfe3663e95").
@@ -598,7 +598,7 @@ func TestGetEditDocumentWhenTemplateErrors(t *testing.T) {
 		On("Case", mock.Anything, 123).
 		Return(caseItem, nil)
 	client.
-		On("Documents", mock.Anything, sirius.CaseTypeLpa, 123, sirius.TypeDraft).
+		On("Documents", mock.Anything, sirius.CaseTypeLpa, 123, []string{sirius.TypeDraft}, []string{}).
 		Return(documents, nil)
 	client.
 		On("DocumentByUUID", mock.Anything, "dfef6714-b4fe-44c2-b26e-90dfe3663e95").

--- a/internal/server/get_documents.go
+++ b/internal/server/get_documents.go
@@ -11,7 +11,7 @@ import (
 
 type GetDocumentsClient interface {
 	DigitalLpa(ctx sirius.Context, uid string) (sirius.DigitalLpa, error)
-	Documents(ctx sirius.Context, caseType sirius.CaseType, caseId int, docType string) ([]sirius.Document, error)
+	Documents(ctx sirius.Context, caseType sirius.CaseType, caseId int, docTypes []string, notDocTypes []string) ([]sirius.Document, error)
 }
 
 type getDocumentsData struct {
@@ -31,7 +31,7 @@ func GetDocuments(client GetDocumentsClient, tmpl template.Template) Handler {
 			return err
 		}
 
-		documents, err := client.Documents(ctx, "lpa", lpa.ID, sirius.TypeSave)
+		documents, err := client.Documents(ctx, "lpa", lpa.ID, []string{}, []string{sirius.TypeDraft, sirius.TypePreview})
 		if err != nil {
 			return err
 		}

--- a/internal/server/get_documents_test.go
+++ b/internal/server/get_documents_test.go
@@ -1,19 +1,20 @@
 package server
 
 import (
+	"net/http"
+	"testing"
+
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"net/http"
-	"testing"
 )
 
 type mockGetDocuments struct {
 	mock.Mock
 }
 
-func (m *mockGetDocuments) Documents(ctx sirius.Context, caseType sirius.CaseType, caseId int, docType string) ([]sirius.Document, error) {
-	args := m.Called(ctx, caseType, caseId, docType)
+func (m *mockGetDocuments) Documents(ctx sirius.Context, caseType sirius.CaseType, caseId int, docTypes []string, notDocTypes []string) ([]sirius.Document, error) {
+	args := m.Called(ctx, caseType, caseId, docTypes, notDocTypes)
 	return args.Get(0).([]sirius.Document), args.Error(1)
 }
 
@@ -43,7 +44,7 @@ func TestGetDocuments(t *testing.T) {
 		On("DigitalLpa", mock.Anything, "M-9876-9876-9876").
 		Return(digitalLpa, nil)
 	client.
-		On("Documents", mock.Anything, sirius.CaseType("lpa"), 1, sirius.TypeSave).
+		On("Documents", mock.Anything, sirius.CaseType("lpa"), 1, []string{}, []string{sirius.TypeDraft, sirius.TypePreview}).
 		Return(documents, nil)
 
 	template := &mockTemplate{}
@@ -91,7 +92,7 @@ func TestGetPaymentsWhenFailureOnGetDocuments(t *testing.T) {
 		On("DigitalLpa", mock.Anything, "M-9876-9876-9876").
 		Return(digitalLpa, nil)
 	client.
-		On("Documents", mock.Anything, sirius.CaseType("lpa"), 1, sirius.TypeSave).
+		On("Documents", mock.Anything, sirius.CaseType("lpa"), 1, []string{}, []string{sirius.TypeDraft, sirius.TypePreview}).
 		Return([]sirius.Document{}, expectedError)
 
 	server := newMockServer("/lpa/{uid}/documents", GetDocuments(client, nil))

--- a/internal/sirius/document.go
+++ b/internal/sirius/document.go
@@ -3,6 +3,7 @@ package sirius
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 type Document struct {
@@ -14,6 +15,7 @@ type Document struct {
 	Direction           string `json:"direction"`
 	MimeType            string `json:"mimeType"`
 	SystemType          string `json:"systemType"`
+	SubType             string `json:"subType"`
 	FileName            string `json:"fileName,omitempty"`
 	Content             string `json:"content,omitempty"`
 	Correspondent       Person `json:"correspondent"`
@@ -27,14 +29,24 @@ const (
 	TypeSave    string = "Save"
 )
 
-func (c *Client) Documents(ctx Context, caseType CaseType, caseId int, docType string) ([]Document, error) {
+func (c *Client) Documents(ctx Context, caseType CaseType, caseId int, docTypes []string, notDocTypes []string) ([]Document, error) {
 	var d []Document
 
 	if caseType == CaseTypeDigitalLpa {
 		caseType = CaseTypeLpa
 	}
 
-	url := fmt.Sprintf("/lpa-api/v1/%s/%d/documents?type[]=%s", caseType+"s", caseId, docType)
+	query := ""
+
+	for _, docType := range docTypes {
+		query = query + "&type[]=" + docType
+	}
+
+	for _, docType := range notDocTypes {
+		query = query + "&type[-][]=" + docType
+	}
+
+	url := fmt.Sprintf("/lpa-api/v1/%s/%d/documents?%s", caseType+"s", caseId, strings.Trim(query, "&"))
 
 	err := c.get(ctx, url, &d)
 	if err != nil {

--- a/internal/sirius/document_test.go
+++ b/internal/sirius/document_test.go
@@ -24,7 +24,7 @@ func TestDocument(t *testing.T) {
 		expectedResponse []Document
 	}{
 		{
-			name: "LPA",
+			name:     "LPA",
 			caseType: CaseTypeLpa,
 			setup: func() {
 				pact.
@@ -34,6 +34,10 @@ func TestDocument(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/lpas/800/documents"),
+						Query: dsl.MapMatcher{
+							"type[]":    dsl.EachLike("Draft", 1),
+							"type[-][]": dsl.EachLike("Preview", 1),
+						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -74,7 +78,7 @@ func TestDocument(t *testing.T) {
 			},
 		},
 		{
-			name: "Digital LPA",
+			name:     "Digital LPA",
 			caseType: CaseTypeDigitalLpa,
 			setup: func() {
 				pact.
@@ -84,6 +88,10 @@ func TestDocument(t *testing.T) {
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/lpas/800/documents"),
+						Query: dsl.MapMatcher{
+							"type[]":    dsl.EachLike("Draft", 1),
+							"type[-][]": dsl.EachLike("Preview", 1),
+						},
 					}).
 					WillRespondWith(dsl.Response{
 						Status: http.StatusOK,
@@ -132,7 +140,7 @@ func TestDocument(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				documents, err := client.Documents(Context{Context: context.Background()}, tc.caseType, 800, TypeDraft)
+				documents, err := client.Documents(Context{Context: context.Background()}, tc.caseType, 800, []string{TypeDraft}, []string{TypePreview})
 
 				assert.Equal(t, tc.expectedResponse, documents)
 				if tc.expectedError == nil {

--- a/web/template/mlpa-documents.gohtml
+++ b/web/template/mlpa-documents.gohtml
@@ -62,17 +62,28 @@
                             </div>
                         </td>
                         <td class="govuk-table__cell">
-                            {{ if eq .Direction "Incoming" }}
-                                [IN]
-                            {{ else if  eq .Direction "Outgoing" }}
-                                [OUT]
-                            {{ else }}
-                                [INT]
-                            {{ end }}
-                            {{ .Correspondent.PersonType }}, {{ .Correspondent.Firstname }} {{.Correspondent.Surname }}
-                            <br><a class="govuk-link" href="#">{{ .FriendlyDescription }}</a>
+                            <strong>
+                                {{ if eq .Direction "Incoming" }}
+                                    [IN]
+                                {{ else if eq .Direction "Outgoing" }}
+                                    [OUT] {{ .Correspondent.PersonType }}, {{ .Correspondent.Firstname }} {{.Correspondent.Surname }}
+                                {{ else }}
+                                    [INT]
+                                {{ end }}
+                            </strong>
+                            <br>
+                            <a class="govuk-link" href="{{ sirius (printf "/lpa-api/v1/documents/%s/download" .UUID) }}" target="_blank">
+                                {{ .FriendlyDescription }}
+                            </a>
                         </td>
-                        <td class="govuk-table__cell">{{ .SystemType }}</td>
+                        <td class="govuk-table__cell">
+                            {{ if eq .Direction "Incoming" }}
+                                {{ .Type }}
+                                {{ if .SubType }}<br />&ndash; {{ .SubType }}{{ end }}
+                            {{ else if eq .Direction "Outgoing" }}
+                                {{ .SystemType }}
+                            {{ end }}
+                        </td>
                         <td class="govuk-table__cell">{{ (formatDateWithTime .CreatedDate "2 January 2006") }}</td>
                     </tr>
                 {{ end }}


### PR DESCRIPTION
- Include incoming correspondence when requesting list of documents. This is done by excluding drafts and previews.
- Alter what is shown in the documents table based on document direction (e.g. showing "System Type" for outgoing docs and "type"/"subtype" for incoming)
- Add a download link to each document (previously was `#`)

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
  - N/A
- [x] I have added styling for Dark Mode
  - N/A
- [x] I have checked that my UI changes meet accessibility standards

For VEGA-2058 #minor