### PR TITLE
VEGA-2007 display linked digital lpas

### DIFF
--- a/internal/server/lpa.go
+++ b/internal/server/lpa.go
@@ -1,11 +1,10 @@
 package server
 
 import (
-	"net/http"
-
 	"github.com/go-chi/chi/v5"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"net/http"
 )
 
 type LpaClient interface {
@@ -14,7 +13,7 @@ type LpaClient interface {
 }
 
 type lpaData struct {
-	Lpa sirius.DigitalLpa
+	Lpa      sirius.DigitalLpa
 	TaskList []sirius.Task
 }
 
@@ -36,7 +35,7 @@ func Lpa(client LpaClient, tmpl template.Template) Handler {
 		}
 
 		data := lpaData{
-			Lpa: lpa,
+			Lpa:      lpa,
 			TaskList: tasks,
 		}
 

--- a/internal/sirius/digital_lpa.go
+++ b/internal/sirius/digital_lpa.go
@@ -5,17 +5,18 @@ import (
 )
 
 type DigitalLpa struct {
-	ID                 int        `json:"id"`
-	UID                string     `json:"uId"`
-	Application        Draft      `json:"application"`
-	Subtype            string     `json:"caseSubtype"`
-	CreatedDate        DateString `json:"createdDate"`
-	Status             string     `json:"status"`
-	ComplaintCount     int        `json:"complaintCount"`
-	InvestigationCount int        `json:"investigationCount"`
-	TaskCount          int        `json:"taskCount"`
-	WarningCount       int        `json:"warningCount"`
-	ObjectionCount     int        `json:"objectionCount"`
+	ID                 int          `json:"id"`
+	UID                string       `json:"uId"`
+	Application        Draft        `json:"application"`
+	Subtype            string       `json:"caseSubtype"`
+	CreatedDate        DateString   `json:"createdDate"`
+	Status             string       `json:"status"`
+	ComplaintCount     int          `json:"complaintCount"`
+	InvestigationCount int          `json:"investigationCount"`
+	TaskCount          int          `json:"taskCount"`
+	WarningCount       int          `json:"warningCount"`
+	ObjectionCount     int          `json:"objectionCount"`
+	LinkedCases        []DigitalLpa `json:"linkedDigitalLpas"`
 }
 
 func (c *Client) DigitalLpa(ctx Context, uid string) (DigitalLpa, error) {

--- a/internal/templatefn/fn.go
+++ b/internal/templatefn/fn.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -97,7 +98,7 @@ func All(siriusPublicURL, prefix, staticHash string) map[string]interface{} {
 				return "turquoise"
 			case "pending":
 				return "blue"
-			case "payment pending", "reduced fees pending":
+			case "payment pending", "reduced fees pending", "draft":
 				return "purple"
 			case "cancelled", "rejected", "revoked", "withdrawn", "return - unpaid", "deleted":
 				return "red"
@@ -134,14 +135,32 @@ func All(siriusPublicURL, prefix, staticHash string) map[string]interface{} {
 }
 
 type CaseTabData struct {
-	Lpa     sirius.DigitalLpa
-	TabName string
+	Lpa               sirius.DigitalLpa
+	SortedLinkedCases []linkedCase
+	TabName           string
+}
+
+type linkedCase struct {
+	UID     string
+	Subtype string
 }
 
 func caseTab(lpa sirius.DigitalLpa, tabName string) CaseTabData {
+	var linkedCases []linkedCase
+	linkedCases = append(linkedCases, linkedCase{lpa.UID, lpa.Subtype})
+
+	for _, linkedLpa := range lpa.LinkedCases {
+		linkedCases = append(linkedCases, linkedCase{linkedLpa.UID, linkedLpa.Subtype})
+	}
+
+	sort.Slice(linkedCases, func(i, j int) bool {
+		return linkedCases[i].UID < linkedCases[j].UID
+	})
+
 	return CaseTabData{
-		Lpa:     lpa,
-		TabName: tabName,
+		Lpa:               lpa,
+		SortedLinkedCases: linkedCases,
+		TabName:           tabName,
 	}
 }
 

--- a/internal/templatefn/fn.go
+++ b/internal/templatefn/fn.go
@@ -141,20 +141,24 @@ type CaseTabData struct {
 }
 
 type linkedCase struct {
-	UID     string
-	Subtype string
+	UID         string
+	Subtype     string
+	CreatedDate sirius.DateString
 }
 
 func caseTab(lpa sirius.DigitalLpa, tabName string) CaseTabData {
 	var linkedCases []linkedCase
-	linkedCases = append(linkedCases, linkedCase{lpa.UID, lpa.Subtype})
+	linkedCases = append(linkedCases, linkedCase{lpa.UID, lpa.Subtype, lpa.CreatedDate})
 
 	for _, linkedLpa := range lpa.LinkedCases {
-		linkedCases = append(linkedCases, linkedCase{linkedLpa.UID, linkedLpa.Subtype})
+		linkedCases = append(linkedCases, linkedCase{linkedLpa.UID, linkedLpa.Subtype, linkedLpa.CreatedDate})
 	}
 
 	sort.Slice(linkedCases, func(i, j int) bool {
-		return linkedCases[i].UID < linkedCases[j].UID
+		if linkedCases[i].CreatedDate == linkedCases[j].CreatedDate {
+			return linkedCases[i].UID < linkedCases[j].UID
+		}
+		return linkedCases[i].CreatedDate < linkedCases[j].CreatedDate
 	})
 
 	return CaseTabData{

--- a/web/assets/dark.scss
+++ b/web/assets/dark.scss
@@ -71,7 +71,8 @@ $sirius-bg-color: #29292e;
   .govuk-tabs__tab:link,
   .govuk-tabs__tab:visited,
   .govuk-tabs__tab,
-  .moj-banner__message {
+  .moj-banner__message,
+  .moj-sub-navigation__link {
     color: govuk-colour("white");
   }
 

--- a/web/template/layout/mlpa-header.gohtml
+++ b/web/template/layout/mlpa-header.gohtml
@@ -20,44 +20,43 @@
         <h2 class="govuk-heading-m govuk-!-margin-top-3">
             {{ template "status-tag" (ToLower $.Lpa.Status) }} {{ if (eq .Lpa.Subtype "hw") }}Health and welfare{{ else }}Property and finance{{ end }}, {{ .Lpa.UID }}
         </h2>
-
-        <div class="govuk-tabs">
-            <h2 class="govuk-tabs__title">
-                Contents
-            </h2>
-            <ul class="govuk-tabs__list">
-                <li class="govuk-tabs__list-item {{ if eq .TabName "summary" }}govuk-tabs__list-item--selected{{ end }}">
-                    <a class="govuk-tabs__tab" href="{{ prefix (printf "/lpa/%s" .Lpa.UID) }}">
-                        Summary
-                    </a>
-                </li>
-                <li class="govuk-tabs__list-item {{ if eq .TabName "details" }}govuk-tabs__list-item--selected{{ end }}">
-                    <a class="govuk-tabs__tab" href="#lpa-details">
-                        LPA details
-                    </a>
-                </li>
-                <li class="govuk-tabs__list-item {{ if eq .TabName "issues" }}govuk-tabs__list-item--selected{{ end }}">
-                    <a class="govuk-tabs__tab"  href="#issues">
-                        Issues
-                    </a>
-                </li>
-                <li class="govuk-tabs__list-item {{ if eq .TabName "fees" }}govuk-tabs__list-item--selected{{ end }}">
-                    <a class="govuk-tabs__tab" href="{{ prefix (printf "/lpa/%s/payments" .Lpa.UID) }}">
-                        Fees
-                    </a>
-                </li>
-                <li class="govuk-tabs__list-item {{ if eq .TabName "documents" }}govuk-tabs__list-item--selected{{ end }}">
-                    <a class="govuk-tabs__tab" href="{{ prefix (printf "/lpa/%s/documents" .Lpa.UID) }}">
-                        Documents
-                    </a>
-                </li>
-                <li class="govuk-tabs__list-item {{ if eq .TabName "history" }}govuk-tabs__list-item--selected{{ end }}">
-                    <a class="govuk-tabs__tab" href="#history">
-                        History
-                    </a>
-                </li>
-            </ul>
-        </div>
-
     </nav>
+
+    <div class="govuk-tabs">
+        <h2 class="govuk-tabs__title">
+            Contents
+        </h2>
+        <ul class="govuk-tabs__list">
+            <li class="govuk-tabs__list-item {{ if eq .TabName "summary" }}govuk-tabs__list-item--selected{{ end }}">
+                <a class="govuk-tabs__tab" href="{{ prefix (printf "/lpa/%s" .Lpa.UID) }}">
+                    Summary
+                </a>
+            </li>
+            <li class="govuk-tabs__list-item {{ if eq .TabName "details" }}govuk-tabs__list-item--selected{{ end }}">
+                <a class="govuk-tabs__tab" href="#lpa-details">
+                    LPA details
+                </a>
+            </li>
+            <li class="govuk-tabs__list-item {{ if eq .TabName "issues" }}govuk-tabs__list-item--selected{{ end }}">
+                <a class="govuk-tabs__tab"  href="#issues">
+                    Issues
+                </a>
+            </li>
+            <li class="govuk-tabs__list-item {{ if eq .TabName "fees" }}govuk-tabs__list-item--selected{{ end }}">
+                <a class="govuk-tabs__tab" href="{{ prefix (printf "/lpa/%s/payments" .Lpa.UID) }}">
+                    Fees
+                </a>
+            </li>
+            <li class="govuk-tabs__list-item {{ if eq .TabName "documents" }}govuk-tabs__list-item--selected{{ end }}">
+                <a class="govuk-tabs__tab" href="{{ prefix (printf "/lpa/%s/documents" .Lpa.UID) }}">
+                    Documents
+                </a>
+            </li>
+            <li class="govuk-tabs__list-item {{ if eq .TabName "history" }}govuk-tabs__list-item--selected{{ end }}">
+                <a class="govuk-tabs__tab" href="#history">
+                    History
+                </a>
+            </li>
+        </ul>
+    </div>
 {{ end }}

--- a/web/template/layout/mlpa-header.gohtml
+++ b/web/template/layout/mlpa-header.gohtml
@@ -5,41 +5,59 @@
     </span>
     <h1 class="govuk-heading-xl">{{ .Lpa.Application.DonorFirstNames }} {{ .Lpa.Application.DonorLastName }}</h1>
 
-    <div class="govuk-tabs">
-        <h2 class="govuk-tabs__title">
-            Contents
-        </h2>
-        <ul class="govuk-tabs__list">
-            <li class="govuk-tabs__list-item {{ if eq .TabName "summary" }}govuk-tabs__list-item--selected{{ end }}">
-                <a class="govuk-tabs__tab" href="{{ prefix (printf "/lpa/%s" .Lpa.UID) }}">
-                    Summary
-                </a>
-            </li>
-            <li class="govuk-tabs__list-item {{ if eq .TabName "details" }}govuk-tabs__list-item--selected{{ end }}">
-                <a class="govuk-tabs__tab" href="#lpa-details">
-                    LPA details
-                </a>
-            </li>
-            <li class="govuk-tabs__list-item {{ if eq .TabName "issues" }}govuk-tabs__list-item--selected{{ end }}">
-                <a class="govuk-tabs__tab"  href="#issues">
-                    Issues
-                </a>
-            </li>
-            <li class="govuk-tabs__list-item {{ if eq .TabName "fees" }}govuk-tabs__list-item--selected{{ end }}">
-                <a class="govuk-tabs__tab" href="{{ prefix (printf "/lpa/%s/payments" .Lpa.UID) }}">
-                    Fees
-                </a>
-            </li>
-            <li class="govuk-tabs__list-item {{ if eq .TabName "documents" }}govuk-tabs__list-item--selected{{ end }}">
-                <a class="govuk-tabs__tab" href="{{ prefix (printf "/lpa/%s/documents" .Lpa.UID) }}">
-                    Documents
-                </a>
-            </li>
-            <li class="govuk-tabs__list-item {{ if eq .TabName "history" }}govuk-tabs__list-item--selected{{ end }}">
-                <a class="govuk-tabs__tab" href="#history">
-                    History
-                </a>
-            </li>
+    <nav class="moj-sub-navigation" aria-label="linked cases">
+
+        <ul class="moj-sub-navigation__list">
+            {{ range .SortedLinkedCases }}
+                <li class="moj-sub-navigation__item">
+                    <a class="moj-sub-navigation__link" {{ if eq $.Lpa.UID .UID }}aria-current="page"{{ end }} href="{{ prefix (printf "/lpa/%s" .UID ) }}">
+                        {{ template "status-tag" (ToLower $.Lpa.Status) }} {{ ToUpper .Subtype }} {{ .UID }}
+                    </a>
+                </li>
+            {{ end }}
         </ul>
-    </div>
+
+        <h2 class="govuk-heading-m govuk-!-margin-top-3">
+            {{ template "status-tag" (ToLower $.Lpa.Status) }} {{ if (eq .Lpa.Subtype "hw") }}Health and welfare{{ else }}Property and finance{{ end }}, {{ .Lpa.UID }}
+        </h2>
+
+        <div class="govuk-tabs">
+            <h2 class="govuk-tabs__title">
+                Contents
+            </h2>
+            <ul class="govuk-tabs__list">
+                <li class="govuk-tabs__list-item {{ if eq .TabName "summary" }}govuk-tabs__list-item--selected{{ end }}">
+                    <a class="govuk-tabs__tab" href="{{ prefix (printf "/lpa/%s" .Lpa.UID) }}">
+                        Summary
+                    </a>
+                </li>
+                <li class="govuk-tabs__list-item {{ if eq .TabName "details" }}govuk-tabs__list-item--selected{{ end }}">
+                    <a class="govuk-tabs__tab" href="#lpa-details">
+                        LPA details
+                    </a>
+                </li>
+                <li class="govuk-tabs__list-item {{ if eq .TabName "issues" }}govuk-tabs__list-item--selected{{ end }}">
+                    <a class="govuk-tabs__tab"  href="#issues">
+                        Issues
+                    </a>
+                </li>
+                <li class="govuk-tabs__list-item {{ if eq .TabName "fees" }}govuk-tabs__list-item--selected{{ end }}">
+                    <a class="govuk-tabs__tab" href="{{ prefix (printf "/lpa/%s/payments" .Lpa.UID) }}">
+                        Fees
+                    </a>
+                </li>
+                <li class="govuk-tabs__list-item {{ if eq .TabName "documents" }}govuk-tabs__list-item--selected{{ end }}">
+                    <a class="govuk-tabs__tab" href="{{ prefix (printf "/lpa/%s/documents" .Lpa.UID) }}">
+                        Documents
+                    </a>
+                </li>
+                <li class="govuk-tabs__list-item {{ if eq .TabName "history" }}govuk-tabs__list-item--selected{{ end }}">
+                    <a class="govuk-tabs__tab" href="#history">
+                        History
+                    </a>
+                </li>
+            </ul>
+        </div>
+
+    </nav>
 {{ end }}

--- a/web/template/lpa.gohtml
+++ b/web/template/lpa.gohtml
@@ -66,11 +66,11 @@
       </aside>
     </div>
 
-    <h2 class="govuk-heading-m">Tasks</h2>
+    <h2>Tasks</h2>
 
     <ul data-role="tasks-list">
       {{ range .TaskList }}
-        <li class="govuk-body">{{ .Name }} ({{ .Assignee.DisplayName }})</li>
+        <li>{{ .Name }} ({{ .Assignee.DisplayName }})</li>
       {{ end }}
     </ul>
 

--- a/web/template/lpa.gohtml
+++ b/web/template/lpa.gohtml
@@ -66,11 +66,11 @@
       </aside>
     </div>
 
-    <h2>Tasks</h2>
+    <h2 class="govuk-heading-m">Tasks</h2>
 
     <ul data-role="tasks-list">
       {{ range .TaskList }}
-        <li>{{ .Name }} ({{ .Assignee.DisplayName }})</li>
+        <li class="govuk-body">{{ .Name }} ({{ .Assignee.DisplayName }})</li>
       {{ end }}
     </ul>
 


### PR DESCRIPTION
added linked cases tabs to digital lpa case page. The cases are sorted so that their order remains the same when switching between case tabs. 

VEGA-2007 #patch

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes - N/A
- [x] I have added styling for Dark Mode
- [x] I have checked that my UI changes meet accessibility standards
