### PR TITLE
Add help target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 export DOCKER_BUILDKIT=1
 
+help:
+	@grep --no-filename -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
 all: lint gosec unit-test build-all scan pa11y lighthouse cypress down
 
+lint: ## Lint source code
 lint: go-lint yarn-lint
 
 go-lint:
@@ -11,26 +15,28 @@ yarn-lint:
 	docker compose run --rm yarn
 	docker compose run --rm yarn lint
 
-gosec:
-	docker compose run --rm gosec
+gosec: ## Scan Go code for security flaws
+gosec: docker compose run --rm gosec
 
 test-results:
 	mkdir -p -m 0777 test-results .gocache pacts logs cypress/screenshots .trivy-cache
 
 setup-directories: test-results
 
+unit-test: ## Run Go unit tests
 unit-test: setup-directories
 	docker compose run --rm test-runner
 
 build:
 	docker compose build lpa-frontend
 
-build-all:
-	docker compose build --parallel lpa-frontend puppeteer cypress test-runner
+build-all: ## Build containers
+build-all: docker compose build --parallel lpa-frontend puppeteer cypress test-runner
 
-up:
-	docker compose up -d lpa-frontend
+up: ## Start application
+up: docker compose up -d lpa-frontend
 
+dev: ## Start application with live reload for JavaScript files
 dev:
 	docker compose -f docker-compose.yml -f docker/docker-compose.dev.yml up -d lpa-frontend
 	docker compose run --rm yarn
@@ -49,8 +55,8 @@ lighthouse: setup-directories
 cypress: setup-directories
 	docker compose run --rm cypress
 
-down:
-	docker compose down
+down: ## Stop application
+down: docker compose down
 
 run-structurizr:
 	docker pull structurizr/lite


### PR DESCRIPTION
When you run `make` without a specific target, it runs the first command in the Makefile. CodeQL does this, and it causes the verification to take ~15mins since the current first target (`all`) builds everything and runs the end-to-end tests.

This PR adds a `help` target at the top of the file so that that is what's run by CodeQL.

It's hopefully also useful.

#patch
