### PR TITLE
VEGA-2166 Lock tinymce in opg-sirius-lpa-frontend to version 5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,15 @@
       "matchUpdateTypes": ["minor", "patch"],
       "prPriority": 1,
       "stabilityDays": 3
+    },
+    {
+      "description": [
+        "Ignore tinymce upgrades to version 6",
+        "Tinymce version 6 doesn't support pasting in from Word documents so we must lock to version 5 for now"
+      ],
+      "matchPackagePatterns": ["tinymce"],
+      "versioning": ">5.10.7",
+      "enabled": false
     }
   ],
   "major": {


### PR DESCRIPTION
Stop updates for tinymce version above 5.10.7 VEGA-2166 #minor
## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards
