### PR TITLE
VEGA-2028 Rename summary tab and remove extraneous components 

### DIFF
--- a/web/assets/dark.scss
+++ b/web/assets/dark.scss
@@ -126,10 +126,6 @@ $sirius-bg-color: #29292e;
     border-color: govuk-colour("white");
   }
 
-  .app-stat-block {
-    background-color: govuk-colour("dark-grey");
-  }
-
   .app-caseworker-summary,
   .app-caseworker-summary table {
     background-color: #505a5f;

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -134,20 +134,6 @@ $govuk-assets-path: "/lpa/frontend/assets/";
   background: govuk-colour("white");
 }
 
-.app-stat-block__container {
-  display: flex;
-  grid-gap: 1.375rem;
-  margin-bottom: govuk-spacing(6);
-}
-
-.app-stat-block {
-  @include govuk-font($size: 19);
-  display: block;
-  flex: 1;
-  padding: 1.375rem;
-  background-color: govuk-colour("light-grey");
-}
-
 .app-table-no-cell-borders {
   table,
   tr,

--- a/web/template/layout/mlpa-header.gohtml
+++ b/web/template/layout/mlpa-header.gohtml
@@ -25,9 +25,9 @@
                 Contents
             </h2>
             <ul class="govuk-tabs__list">
-                <li class="govuk-tabs__list-item {{ if eq .TabName "summary" }}govuk-tabs__list-item--selected{{ end }}">
+                <li class="govuk-tabs__list-item {{ if eq .TabName "application-progress" }}govuk-tabs__list-item--selected{{ end }}">
                     <a class="govuk-tabs__tab" href="{{ prefix (printf "/lpa/%s" .Lpa.UID) }}">
-                        Summary
+                        Application progress
                     </a>
                 </li>
                 <li class="govuk-tabs__list-item {{ if eq .TabName "details" }}govuk-tabs__list-item--selected{{ end }}">

--- a/web/template/lpa.gohtml
+++ b/web/template/lpa.gohtml
@@ -4,9 +4,7 @@
 
 {{ define "main" }}
 
-  {{ template "mlpa-header" (caseTabs .Lpa "summary") }}
-
-  <h2 class="govuk-heading-m">Case summary</h2>
+  {{ template "mlpa-header" (caseTabs .Lpa "application-progress") }}
 
   {{ if .FlashMessage.Title }}
       {{ template "notification-banner" .FlashMessage }}
@@ -46,29 +44,6 @@
           <dd class="govuk-summary-list__value">{{ (date .Lpa.CreatedDate "2 January 2006") }}</dd>
         </div>
       </dl>
-
-      <div class="app-stat-block__container">
-        <aside class="app-stat-block">
-          <h3 class="govuk-heading-l govuk-!-margin-bottom-2">{{ .Lpa.ObjectionCount }}</h3>
-          Objections
-        </aside>
-        <aside class="app-stat-block">
-          <h3 class="govuk-heading-l govuk-!-margin-bottom-2">{{ .Lpa.WarningCount }}</h3>
-          Warnings
-        </aside>
-        <aside class="app-stat-block">
-          <h3 class="govuk-heading-l govuk-!-margin-bottom-2">{{ .Lpa.ComplaintCount }}</h3>
-          Complaints
-        </aside>
-        <aside class="app-stat-block">
-          <h3 class="govuk-heading-l govuk-!-margin-bottom-2">{{ .Lpa.InvestigationCount }}</h3>
-          Investigations
-        </aside>
-        <aside class="app-stat-block">
-          <h3 class="govuk-heading-l govuk-!-margin-bottom-2">{{ len .TaskList }}</h3>
-          Tasks
-        </aside>
-      </div>
 
       <h2>Tasks</h2>
 


### PR DESCRIPTION
NB leaving the summary stats (number of tasks, warnings, objections etc.) in the template object in case they return to the design later.

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards
