### PR TITLE
Fix renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,7 +34,7 @@
       "matchUpdateTypes": ["minor", "patch"],
       "prPriority": 1,
       "stabilityDays": 3,
-      "schedule": ["0 17 * * 0"]
+      "schedule": ["on sunday"]
     }
   ],
   "major": {


### PR DESCRIPTION
Renovate requires the "minutes" value of a cron schedule to be `*` (since it can't guarantee minute-precision). But that's confusing because it looks like it will run every minute.

Instead, use [later syntax](https://breejs.github.io/later/) which Renovate also supports and which is a little clearer.
