### PR TITLE
Fix complaint resolution conditional reveals

### DIFF
--- a/web/template/edit_complaint.gohtml
+++ b/web/template/edit_complaint.gohtml
@@ -78,7 +78,15 @@
           <div class="govuk-radios" data-module="govuk-radios">
             {{ range $k, $v := .CompensationTypes }}
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="f-compensation-type-{{ $k }}" name="compensationType" type="radio" value="{{ $v.Handle }}" data-aria-controls="conditional-compensation-{{ $k }}" {{ if or (eq $v.Handle $.Complaint.CompensationType) (and (not $.Complaint.CompensationType) (eq $v.Handle "NOT_APPLICABLE")) }}checked{{ end }}>
+                <input
+                  class="govuk-radios__input"
+                  id="f-compensation-type-{{ $k }}"
+                  name="compensationType"
+                  type="radio"
+                  value="{{ $v.Handle }}"
+                  {{ if not (eq $v.Handle "NOT_APPLICABLE") }}data-aria-controls="conditional-compensation-{{ $k }}"{{ end }}
+                  {{ if or (eq $v.Handle $.Complaint.CompensationType) (and (not $.Complaint.CompensationType) (eq $v.Handle "NOT_APPLICABLE")) }}checked{{ end }}
+                >
                 <label class="govuk-label govuk-radios__label" for="f-compensation-type-{{ $k }}">
                   {{ $v.Label }}
                 </label>


### PR DESCRIPTION
We should not set `data-aria-controls` if there's no element with that ID, otherwise govuk-frontend crashes.

Fixes VEGA-2307, introduced by VEGA-2202 #patch
