### PR TITLE
Vega-2312 handle error gracefully #patch

### DIFF
--- a/web/template/delete_relationship.gohtml
+++ b/web/template/delete_relationship.gohtml
@@ -7,6 +7,8 @@
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-body"><strong>{{ .Entity }}</strong></p>
 
+      {{ template "error-summary" .Error }}
+
       {{ if .Success }}
         <meta data-app-reload="page" />
         {{ template "success-banner" "You have successfully deleted a relationship." }}


### PR DESCRIPTION
Error message now appears on form asking user to select a relationship to delete whenever the delete button is pressed without selecting a radio option. 

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards
