### PR TITLE
VEGA-2330 Add module to disable button after click #minor

### DIFF
--- a/web/assets/disable-after-click.js
+++ b/web/assets/disable-after-click.js
@@ -12,6 +12,10 @@ const disableAfterClick = () => {
 
           button.ariaDisabled = "true";
           button.setAttribute("disabled", "true");
+
+          if (button.type == "submit") {
+            button.form.submit();
+          }
         },
         false,
       );

--- a/web/assets/disable-after-click.js
+++ b/web/assets/disable-after-click.js
@@ -1,9 +1,13 @@
 const disableAfterClick = () => {
   document
-    .querySelectorAll('[data-disable-after-click="true"]')
+    .querySelectorAll('button[type="submit"][data-disable-after-click="true"]')
     .forEach((button) => {
-      button.addEventListener(
-        "click",
+      if (!button.form) {
+        return false;
+      }
+
+      button.form.addEventListener(
+        "submit",
         (e) => {
           if (button.hasAttribute("disabled")) {
             e.preventDefault();
@@ -12,10 +16,6 @@ const disableAfterClick = () => {
 
           button.ariaDisabled = "true";
           button.setAttribute("disabled", "true");
-
-          if (button.type == "submit") {
-            button.form.submit();
-          }
         },
         false,
       );

--- a/web/assets/disable-after-click.js
+++ b/web/assets/disable-after-click.js
@@ -1,0 +1,21 @@
+const disableAfterClick = () => {
+  document
+    .querySelectorAll('[data-disable-after-click="true"]')
+    .forEach((button) => {
+      button.addEventListener(
+        "click",
+        (e) => {
+          if (button.hasAttribute("disabled")) {
+            e.preventDefault();
+            return false;
+          }
+
+          button.ariaDisabled = "true";
+          button.setAttribute("disabled", "true");
+        },
+        false,
+      );
+    });
+};
+
+export default disableAfterClick;

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -19,6 +19,7 @@ import addressFinder from "./address-finder";
 import autoApplyFilter from "./auto-apply-filter";
 import dropdownMenu from "./dropdown-menu";
 import showHideCaseSummary from "./show-hide-case-summary";
+import disableAfterClick from "./disable-after-click";
 
 // Expose jQuery on window so MOJFrontend can use it
 window.$ = $;
@@ -44,6 +45,7 @@ addressFinder(prefix);
 autoApplyFilter();
 dropdownMenu();
 showHideCaseSummary();
+disableAfterClick();
 
 if (window.self !== window.parent) {
   const success = document.querySelector('[data-app-reload~="page"]');

--- a/web/template/create-draft.gohtml
+++ b/web/template/create-draft.gohtml
@@ -244,7 +244,7 @@
           </div>
 
           <div class="govuk-button-group">
-            <button class="govuk-button" data-module="govuk-button" type="submit">Save draft LPA</button>
+            <button class="govuk-button" data-module="govuk-button" type="submit" data-disable-after-click="true">Save draft LPA</button>
             <a class="govuk-link govuk-link--no-visited-state" href="/">Cancel</a>
           </div>
         </form>


### PR DESCRIPTION
Existing methods were not suitable, for the following reasons:

- The data-prevent-double-click module in govuk design system does not change the appearance of the button after clicking.
- Our app-loading-button module expects a message element to exist (which is populates). It also blocks the form submit.

Change to a submit input (that's what it is), and add a function which will not block the submit of the form.

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards
