### PR TITLE
VEGA-2359 - Move aria-describedby to <input> tags 

### DIFF
--- a/web/template/create_draft.gohtml
+++ b/web/template/create_draft.gohtml
@@ -192,18 +192,20 @@
             </fieldset>
           </div>
 
-          <div class="govuk-form-group {{ if .Error.Field.donorPhone }}govuk-form-group--error{{ end }}" aria-describedby="f-donorPhone-hint">
+          <div class="govuk-form-group {{ if .Error.Field.donorPhone }}govuk-form-group--error{{ end }}">
             <label class="govuk-label" for="f-donorPhone">Donor’s phone number</label>
             <div class="govuk-hint" id="f-donorPhone-hint">Optional</div>
             {{ template "errors".Error.Field.donorPhone }}
-            <input class="govuk-input {{ if .Error.Field.donorPhone }}govuk-input--error{{ end }}" id="f-donorPhone" name="donorPhone" value="{{ .Form.Phone }}" />
+            <input class="govuk-input {{ if .Error.Field.donorPhone }}govuk-input--error{{ end }}" id="f-donorPhone"
+                   name="donorPhone" value="{{ .Form.Phone }}" aria-describedby="f-donorPhone-hint" />
           </div>
 
-          <div class="govuk-form-group {{ if .Error.Field.donorEmail }}govuk-form-group--error{{ end }}" aria-describedby="f-donorEmail-hint">
+          <div class="govuk-form-group {{ if .Error.Field.donorEmail }}govuk-form-group--error{{ end }}">
             <label class="govuk-label" for="f-donorEmail">Donor’s email address</label>
             <div class="govuk-hint" id="f-donorEmail-hint">Optional</div>
             {{ template "errors".Error.Field.donorEmail }}
-            <input class="govuk-input {{ if .Error.Field.donorEmail }}govuk-input--error{{ end }}" id="f-donorEmail" name="donorEmail" value="{{ .Form.Email }}" />
+            <input class="govuk-input {{ if .Error.Field.donorEmail }}govuk-input--error{{ end }}" id="f-donorEmail"
+                   name="donorEmail" value="{{ .Form.Email }}" aria-describedby="f-donorEmail-hint" />
           </div>
 
           <div class="govuk-form-group {{ if or (.Error.Field.correspondenceLargeFormat) (.Error.Field.correspondenceByWelsh) }}govuk-form-group--error{{ end }}" id="f-correspondenceOptions">

--- a/web/template/mlpa-details.gohtml
+++ b/web/template/mlpa-details.gohtml
@@ -122,7 +122,7 @@
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
             <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-              Attorneys ({{ (len (index .LpaStoreData "attorneys")) }})
+              Attorneys ({{ count "attorneys" .LpaStoreData }})
             </span>
           </h2>
         </div>
@@ -146,7 +146,7 @@
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
             <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
-              Replacement attorneys ({{ (len (index .LpaStoreData "attorneys")) }})
+              Replacement attorneys ({{ count "attorneys" .LpaStoreData }})
             </span>
           </h2>
         </div>


### PR DESCRIPTION
Move aria-describedby properties to the input tag
[VEGA-2359](https://opgtransform.atlassian.net/browse/VEGA-2359)

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-2359]: https://opgtransform.atlassian.net/browse/VEGA-2359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ