### PR TITLE
Use pact-ruby-standalone install script

### DIFF
--- a/docker/test-runner/Dockerfile
+++ b/docker/test-runner/Dockerfile
@@ -2,6 +2,6 @@ FROM golang:1.22-bookworm
 
 RUN go install gotest.tools/gotestsum@latest
 
-ADD https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.88.82/pact-1.88.82-linux-x86_64.tar.gz /usr/bin
-RUN cd /usr/bin; tar xzf pact-1.88.82-linux-x86_64.tar.gz
-ENV PATH="$PATH:/usr/bin/pact/bin"
+WORKDIR /opt
+RUN curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh > ./install.sh && bash ./install.sh tag=v1.92.0
+ENV PATH="$PATH:/opt/pact/bin"


### PR DESCRIPTION
Rather than specifying architecture in the install process, use an install script which auto-detects the correct architecture to use.

Fixes VEGA-2453 #patch