### PR TITLE
VEGA-2450 Rename to 'search' to be consistent with blue Sirius #minor

### DIFF
--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -107,7 +107,7 @@ describe("Search", () => {
         },
       });
 
-      cy.visit("/search?term=bob");
+      cy.visit("/search?search=bob");
 
       cy.contains("You searched for: bob");
       cy.contains("Showing 1 to 4 of 4 results");
@@ -153,7 +153,7 @@ describe("Search", () => {
 
   describe("Search features", () => {
     beforeEach(() => {
-      cy.visit("/search?term=abcdefg");
+      cy.visit("/search?search=abcdefg");
     });
 
     it("it shows/hides filter panel", () => {
@@ -188,7 +188,7 @@ describe("Search", () => {
         },
       });
 
-      cy.visit("/search?term=700000005555");
+      cy.visit("/search?search=700000005555");
     });
 
     it("finds a deleted case", () => {

--- a/internal/server/pagination_test.go
+++ b/internal/server/pagination_test.go
@@ -95,9 +95,9 @@ func TestPagination(t *testing.T) {
 				CurrentPage: tc.CurrentPage,
 				TotalPages:  tc.TotalPages,
 				PageSize:    tc.PageSize,
-			}, "term=bob", "")
+			}, "search=bob", "")
 
-			assert.Equal("?term=bob", pagination.SearchTerm)
+			assert.Equal("?search=bob", pagination.SearchTerm)
 			assert.Equal(tc.Start, pagination.Start())
 			assert.Equal(tc.End, pagination.End())
 			assert.Equal(tc.HasPrevious, pagination.HasPrevious())
@@ -134,7 +134,7 @@ func TestPaginationPagesWhenOverflow(t *testing.T) {
 				CurrentPage: current,
 				TotalPages:  10,
 				PageSize:    25,
-			}, "term=bob", "")
+			}, "search=bob", "")
 
 			assert.Equal(t, pages, pagination.Pages())
 		})
@@ -144,8 +144,8 @@ func TestPaginationPagesWhenOverflow(t *testing.T) {
 func TestPaginationWithFilters(t *testing.T) {
 	assert := assert.New(t)
 
-	pagination := newPagination(&sirius.Pagination{}, "term=bob", "person-type=Donor&person-type=Trust+Corporation")
+	pagination := newPagination(&sirius.Pagination{}, "search=bob", "person-type=Donor&person-type=Trust+Corporation")
 
-	assert.Equal("?term=bob", pagination.SearchTerm)
+	assert.Equal("?search=bob", pagination.SearchTerm)
 	assert.Equal("&person-type=Donor&person-type=Trust+Corporation", pagination.Filters)
 }

--- a/internal/server/search.go
+++ b/internal/server/search.go
@@ -63,12 +63,12 @@ func newSearchFilters(form url.Values) searchFilters {
 func Search(client SearchClient, tmpl template.Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		ctx := getContext(r)
-		searchTerm := r.FormValue("term")
+		searchTerm := r.FormValue("search")
 		if searchTerm == "" {
 			return errors.New("search term required")
 		}
 		search := url.Values{}
-		search.Add("term", r.FormValue("term"))
+		search.Add("search", r.FormValue("search"))
 
 		filters := newSearchFilters(r.Form)
 

--- a/internal/server/search_test.go
+++ b/internal/server/search_test.go
@@ -61,11 +61,11 @@ func TestGetSearch(t *testing.T) {
 			Aggregations: expectedResponse.Aggregations,
 			Filters:      searchFilters{},
 			SearchTerm:   "bob",
-			Pagination:   newPagination(expectedPagination, "term=bob", ""),
+			Pagination:   newPagination(expectedPagination, "search=bob", ""),
 		}).
 		Return(nil)
 
-	req, _ := http.NewRequest(http.MethodGet, "/search?term=bob", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/search?search=bob", nil)
 	w := httptest.NewRecorder()
 
 	err := Search(client, template.Func)(w, req)
@@ -114,13 +114,13 @@ func TestGetSearchFiltered(t *testing.T) {
 			SearchTerm:   "bob",
 			Pagination: newPagination(
 				expectedPagination,
-				"term=bob",
+				"search=bob",
 				"person-type=Donor&person-type=Attorney",
 			),
 		}).
 		Return(nil)
 
-	req, _ := http.NewRequest(http.MethodGet, "/search?term=bob&person-type=Donor&person-type=Attorney", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/search?search=bob&person-type=Donor&person-type=Attorney", nil)
 	w := httptest.NewRecorder()
 
 	err := Search(client, template.Func)(w, req)
@@ -168,11 +168,11 @@ func TestGetSearchPaginationCalculations(t *testing.T) {
 			Aggregations: expectedResponse.Aggregations,
 			Filters:      searchFilters{},
 			SearchTerm:   "bob",
-			Pagination:   newPagination(expectedPagination, "term=bob", ""),
+			Pagination:   newPagination(expectedPagination, "search=bob", ""),
 		}).
 		Return(nil)
 
-	req, _ := http.NewRequest(http.MethodGet, "/search?term=bob&page=2", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/search?search=bob&page=2", nil)
 	w := httptest.NewRecorder()
 
 	err := Search(client, template.Func)(w, req)
@@ -222,12 +222,12 @@ func TestGetSearchCallsDeletedCasesOnFallback(t *testing.T) {
 			Aggregations: expectedResponse.Aggregations,
 			Filters:      searchFilters{},
 			SearchTerm:   "7000-0000-5678",
-			Pagination:   newPagination(expectedPagination, "term=7000-0000-5678", ""),
+			Pagination:   newPagination(expectedPagination, "search=7000-0000-5678", ""),
 			DeletedCases: expectedDeletedCases,
 		}).
 		Return(nil)
 
-	req, _ := http.NewRequest(http.MethodGet, "/search?term=7000-0000-5678", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/search?search=7000-0000-5678", nil)
 	w := httptest.NewRecorder()
 
 	err := Search(client, template.Func)(w, req)
@@ -258,7 +258,7 @@ func TestGetSearchGetDeletedCasesFailure(t *testing.T) {
 		On("DeletedCases", mock.Anything, "700000005678").
 		Return([]sirius.DeletedCase{}, expectedError)
 
-	req, _ := http.NewRequest(http.MethodGet, "/search?term=7000-0000-5678", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/search?search=7000-0000-5678", nil)
 	w := httptest.NewRecorder()
 
 	err := Search(client, nil)(w, req)
@@ -269,7 +269,7 @@ func TestGetSearchGetDeletedCasesFailure(t *testing.T) {
 
 func TestGetSearchBadQuery(t *testing.T) {
 	testCases := map[string]string{
-		"no-search-term": "/search?term=",
+		"no-search-term": "/search?search=",
 		"bad-query":      "/search?abc=hello",
 	}
 
@@ -293,7 +293,7 @@ func TestGetSearchErrors(t *testing.T) {
 		On("Search", mock.Anything, "bob", 1, filters).
 		Return(sirius.SearchResponse{}, &sirius.Pagination{}, expectedError)
 
-	req, _ := http.NewRequest(http.MethodGet, "/search?term=bob", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/search?search=bob", nil)
 	w := httptest.NewRecorder()
 
 	err := Search(client, nil)(w, req)
@@ -333,11 +333,11 @@ func TestGetSearchTemplateErrors(t *testing.T) {
 			Aggregations: expectedResponse.Aggregations,
 			Filters:      searchFilters{},
 			SearchTerm:   "bob",
-			Pagination:   newPagination(expectedPagination, "term=bob", ""),
+			Pagination:   newPagination(expectedPagination, "search=bob", ""),
 		}).
 		Return(expectedError)
 
-	req, _ := http.NewRequest(http.MethodGet, "/search?term=bob", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/search?search=bob", nil)
 	w := httptest.NewRecorder()
 
 	err := Search(client, template.Func)(w, req)

--- a/internal/sirius/search_users.go
+++ b/internal/sirius/search_users.go
@@ -26,7 +26,7 @@ func (c *Client) SearchUsers(ctx Context, term string) ([]User, error) {
 		err := ValidationError{
 			Detail: "Search term must be at least three characters",
 			Field: FieldErrors{
-				"term": {"reason": "Search term must be at least three characters"},
+				"search": {"reason": "Search term must be at least three characters"},
 			},
 		}
 

--- a/internal/sirius/search_users_test.go
+++ b/internal/sirius/search_users_test.go
@@ -80,7 +80,7 @@ func TestSearchUsersTooShort(t *testing.T) {
 	expectedErr := ValidationError{
 		Detail: "Search term must be at least three characters",
 		Field: FieldErrors{
-			"term": {"reason": "Search term must be at least three characters"},
+			"search": {"reason": "Search term must be at least three characters"},
 		},
 	}
 

--- a/web/assets/search-controller.js
+++ b/web/assets/search-controller.js
@@ -4,7 +4,7 @@ const searchController = () => {
   window.addEventListener("load", (event) => {
     if (window.location.pathname.includes("/search")) {
       let params = new URLSearchParams(window.location.search);
-      searchInput.value = params.get("term");
+      searchInput.value = params.get("search");
     }
   });
 };

--- a/web/template/layout/header.gohtml
+++ b/web/template/layout/header.gohtml
@@ -45,7 +45,7 @@
                 <input id="f-search-preview" class="govuk-input moj-search__input app-moj-search__input"
                        data-module="sirius-search-preview"
                        data-sirius-search-preview-attach="#f-search-preview"
-                       name="term" type="search" placeholder="Search for a case" aria-label="Search">
+                       name="search" type="search" placeholder="Search for a case" aria-label="Search">
                 <button class="govuk-button govuk-input__suffix app-!-moj-search__button" data-module="govuk-button">
                   <span class="govuk-visually-hidden">Search</span>
                   <svg class="app-svg-icon" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22" fill="none">
@@ -68,7 +68,7 @@
               <input id="f-search-preview-below-phase-banner" class="govuk-input moj-search__input app-moj-search__input"
                      data-module="sirius-search-preview"
                      data-sirius-search-preview-attach="#f-search-preview-below-phase-banner"
-                     name="term" type="search" placeholder="Search for a case" aria-label="Search">
+                     name="search" type="search" placeholder="Search for a case" aria-label="Search">
               <button class="govuk-button govuk-input__suffix app-!-moj-search__button" data-module="govuk-button">
                 <span class="govuk-visually-hidden">Search</span>
                 <svg class="app-svg-icon" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22" fill="none">

--- a/web/template/layout/search_filter.gohtml
+++ b/web/template/layout/search_filter.gohtml
@@ -31,7 +31,7 @@
 
                 <div class="moj-filter__options">
                     <form class="form" method="get" id="search-filters">
-                        <input type="hidden" name="term" value="{{ .SearchTerm }}"/>
+                        <input type="hidden" name="search" value="{{ .SearchTerm }}"/>
                         <button class="govuk-button" data-module="govuk-button" type="submit">
                             Apply filters
                         </button>


### PR DESCRIPTION
The impetus for this is to enable users with assistive technology to say "click search" in both blue and new Sirius and have the search box selected.

## Checklist

- [X] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards
