### PR TITLE
Don't try to read UID of null LPA

### DIFF
--- a/internal/server/assign_task.go
+++ b/internal/server/assign_task.go
@@ -80,9 +80,8 @@ func AssignTask(client AssignTaskClient, tmpl template.Template) Handler {
 
 				if lpa == nil && len(task.CaseItems) > 0 {
 					lpa = &task.CaseItems[0]
+					data.Uid = lpa.UID
 				}
-
-				data.Uid = lpa.UID
 
 				tasksMu.Lock()
 				data.Entities = append(data.Entities, task.Summary())


### PR DESCRIPTION
We pick an LPA to go back to if the "Cancel" button is pressed. Currently this assumes that every task has a case, but some don't.

Instead, only set the back UID if the task has an LPA.

Fixes VEGA-2576 #patch
