### PR TITLE
Show ValidationError details where set

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -139,7 +139,7 @@ func TestErrorHandlerJsonError(t *testing.T) {
 
 	body := new(bytes.Buffer)
 	_, _ = body.ReadFrom(resp.Body)
-	assert.Equal(`{"title":"validation error","detail":"Not valid complaint","validationErrors":{"title":{"tooShort":"The title must be at least 5 characters"}}}`, strings.Trim(body.String(), "\n"))
+	assert.Equal(`{"title":"Not valid complaint","detail":"Not valid complaint","validationErrors":{"title":{"tooShort":"The title must be at least 5 characters"}}}`, strings.Trim(body.String(), "\n"))
 
 	assert.Nil(buf.Bytes())
 }

--- a/internal/sirius/client.go
+++ b/internal/sirius/client.go
@@ -162,6 +162,10 @@ func (e ValidationError) Any() bool {
 	return len(e.Detail) > 0 || len(e.Field) > 0
 }
 
-func (ValidationError) Error() string {
+func (e ValidationError) Error() string {
+	if len(e.Detail) > 0 {
+		return e.Detail
+	}
+
 	return "validation error"
 }

--- a/internal/sirius/client_test.go
+++ b/internal/sirius/client_test.go
@@ -77,3 +77,15 @@ func TestToFieldErrorsThrowsError(t *testing.T) {
 	assert.Equal(t, err, errors.New("could not parse field validation_errors"))
 	assert.Nil(t, result)
 }
+
+func TestValidationErrorSummary(t *testing.T) {
+	emptyValidationError := ValidationError{}
+
+	assert.Equal(t, "validation error", emptyValidationError.Error())
+
+	descriptiveValidationError := ValidationError{
+		Detail: "This case is in a Registered status and cannot be deleted",
+	}
+
+	assert.Equal(t, "This case is in a Registered status and cannot be deleted", descriptiveValidationError.Error())
+}


### PR DESCRIPTION
If a ValidationError has a Detail provided, use that as the error summary.

This allows the error summary to be shown properly in the Sirius UI, rather than the generic "validation error" text.

Discovered in VEGA-2573 #minor

| Before | After |
| ---- | ---- |
| <img width="484" alt="imagen" src="https://github.com/user-attachments/assets/7c69d4a6-f610-4929-8fe5-2abf00e21c32"> |  <img width="489" alt="imagen" src="https://github.com/user-attachments/assets/90195980-698a-4f71-b264-e0f2dcff9315"> |