### PR TITLE
Show LPA details if in store

### DIFF
--- a/cypress/e2e/digital-lpa.cy.js
+++ b/cypress/e2e/digital-lpa.cy.js
@@ -472,7 +472,7 @@ describe("View a digital LPA", () => {
     });
   });
 
-  it("shows application details when status is Draft", () => {
+  it("shows application details when store is empty", () => {
     cy.visit("/lpa/M-DIGI-LPA3-3334");
 
     cy.contains("LPA details").click();

--- a/web/template/mlpa-details.gohtml
+++ b/web/template/mlpa-details.gohtml
@@ -12,7 +12,7 @@
         </div>
     </div>
 
-    {{ if or (eq .DigitalLpa.LpaStoreData nil) (eq .DigitalLpa.SiriusData.Status "Draft") }}
+    {{ if eq .DigitalLpa.LpaStoreData.Channel "" }}
 
       <!-- draft application -->
       <h2 class="govuk-heading-m">Donor</h2>
@@ -289,10 +289,7 @@
                   <div class="govuk-body">
                     {{ howAttorneysMakeDecisionsLongForm .DigitalLpa.LpaStoreData.HowAttorneysMakeDecisions }}
                     {{ if (gt (len .DigitalLpa.LpaStoreData.HowAttorneysMakeDecisionsDetails) 0) }}
-                      <br>
-                      <span class="app-newlines-as-br">
-                        {{ .DigitalLpa.LpaStoreData.HowAttorneysMakeDecisionsDetails }}
-                      </span>
+                      <p class="app-newlines-as-br">{{ .DigitalLpa.LpaStoreData.HowAttorneysMakeDecisionsDetails }}</p>
                     {{ end }}
                   </div>
                 </dd>
@@ -328,10 +325,7 @@
                     <div class="govuk-body">
                       {{ howAttorneysMakeDecisionsLongForm .DigitalLpa.LpaStoreData.HowReplacementAttorneysMakeDecisions }}
                       {{ if (gt (len .DigitalLpa.LpaStoreData.HowReplacementAttorneysMakeDecisionsDetails) 0) }}
-                        <br>
-                        <span class="app-newlines-as-br">
-                          {{ .DigitalLpa.LpaStoreData.HowReplacementAttorneysMakeDecisionsDetails }}
-                        </span>
+                        <p class="app-newlines-as-br">{{ .DigitalLpa.LpaStoreData.HowReplacementAttorneysMakeDecisionsDetails }}</p>
                       {{ end }}
                     </div>
                   </dd>
@@ -416,9 +410,7 @@
           </div>
           <div id="accordion-default-content-5" class="govuk-accordion__section-content">
             <div class="govuk-body">
-              <span class="app-newlines-as-br">
-                {{ .DigitalLpa.LpaStoreData.RestrictionsAndConditions }}
-              </span>
+              <p class="app-newlines-as-br">{{ .DigitalLpa.LpaStoreData.RestrictionsAndConditions }}</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
If the LPA's status is "Draft" but there's data in the store, show the data in the store.

NB: we have to check the zero-value of the channel (which is a required field) because the LpaStoreData object doesn't have a nil struct (that's not how Go structs work).

This is initiated by making testing easier, but is also part of a move towards not relying on Sirius to determine a case's status.

Also, fix the whitespace around `newlines-as-br` things: excess whitespace (newlines/indent) was being rendered inappropriately, replace it with a `<p>`.

Fixes VEGA-2578 #minor