### PR TITLE
VEGA-2624 Add digital LPA due date Pact test

### DIFF
--- a/internal/sirius/digital_lpa_test.go
+++ b/internal/sirius/digital_lpa_test.go
@@ -117,12 +117,12 @@ func TestDigitalLpa(t *testing.T) {
 			},
 		},
 		{
-			name: "OK",
+			name: "OK2",
 			setup: func() {
 				pact.
 					AddInteraction().
 					Given("A digital LPA in statutory waiting period").
-					UponReceiving("A request for the digital LPA").
+					UponReceiving("A request for the digital LPA in statutory waiting period").
 					WithRequest(dsl.Request{
 						Method: http.MethodGet,
 						Path:   dsl.String("/lpa-api/v1/digital-lpas/M-1111-2222-3333"),
@@ -147,8 +147,8 @@ func TestDigitalLpa(t *testing.T) {
 									"donorFirstNames": dsl.Like("Lonnie"),
 									"donorLastName":   dsl.Like("Jakubowski"),
 									"donorDob":        dsl.Term("22/03/1949", `^\d{1,2}/\d{1,2}/\d{4}$`),
-									"donorPhone":      dsl.Like("073456249524"),
-									"donorEmail":      dsl.Like("zswanberg@host.example"),
+									"donorPhone":      dsl.Like("07123456789"),
+									"donorEmail":      dsl.Like("Lonnie.Jakubowski@example.com"),
 									"donorAddress": map[string]interface{}{
 										"addressLine1": dsl.Like("528 Fourth Avenue"),
 										"addressLine2": dsl.Like("Lower Kozey Cross"),
@@ -169,6 +169,7 @@ func TestDigitalLpa(t *testing.T) {
 					Subtype:            "property-and-affairs",
 					Status:             "Draft",
 					CreatedDate:        DateString("2018-03-26"),
+					DueDate:            DateString("2018-04-09"),
 					ComplaintCount:     0,
 					InvestigationCount: 0,
 					TaskCount:          0,
@@ -186,8 +187,8 @@ func TestDigitalLpa(t *testing.T) {
 							Postcode: "YL06 6GF",
 							Country:  "GB",
 						},
-						PhoneNumber: "073456249524",
-						Email:       "zswanberg@host.example",
+						PhoneNumber: "07123456789",
+						Email:       "Lonnie.Jakubowski@example.com",
 					},
 				},
 			},

--- a/internal/sirius/digital_lpa_test.go
+++ b/internal/sirius/digital_lpa_test.go
@@ -135,7 +135,7 @@ func TestDigitalLpa(t *testing.T) {
 							"opg.poas.sirius": map[string]interface{}{
 								"id":                 dsl.Like(111),
 								"caseSubtype":        dsl.Like("property-and-affairs"),
-								"status":             dsl.Like("Draft"),
+								"status":             dsl.Like("Statutory waiting period"),
 								"createdDate":        dsl.Term("26/03/2018", `^\d{1,2}/\d{1,2}/\d{4}$`),
 								"dueDate":            dsl.Term("09/04/2018", `^\d{1,2}/\d{1,2}/\d{4}$`),
 								"complaintCount":     dsl.Like(0),
@@ -167,7 +167,7 @@ func TestDigitalLpa(t *testing.T) {
 				SiriusData: SiriusData{
 					ID:                 111,
 					Subtype:            "property-and-affairs",
-					Status:             "Draft",
+					Status:             "Statutory waiting period",
 					CreatedDate:        DateString("2018-03-26"),
 					DueDate:            DateString("2018-04-09"),
 					ComplaintCount:     0,

--- a/internal/sirius/digital_lpa_test.go
+++ b/internal/sirius/digital_lpa_test.go
@@ -116,6 +116,82 @@ func TestDigitalLpa(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "OK",
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("A digital LPA in statutory waiting period").
+					UponReceiving("A request for the digital LPA").
+					WithRequest(dsl.Request{
+						Method: http.MethodGet,
+						Path:   dsl.String("/lpa-api/v1/digital-lpas/M-1111-2222-3333"),
+					}).
+					WillRespondWith(dsl.Response{
+						Status:  http.StatusOK,
+						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+						Body: map[string]interface{}{
+							"uId": dsl.Like("M-1111-2222-3333"),
+							"opg.poas.sirius": map[string]interface{}{
+								"id":                 dsl.Like(111),
+								"caseSubtype":        dsl.Like("property-and-affairs"),
+								"status":             dsl.Like("Draft"),
+								"createdDate":        dsl.Term("26/03/2018", `^\d{1,2}/\d{1,2}/\d{4}$`),
+								"dueDate":            dsl.Term("09/04/2018", `^\d{1,2}/\d{1,2}/\d{4}$`),
+								"complaintCount":     dsl.Like(0),
+								"investigationCount": dsl.Like(0),
+								"taskCount":          dsl.Like(0),
+								"warningCount":       dsl.Like(0),
+								"objectionCount":     dsl.Like(0),
+								"application": map[string]interface{}{
+									"donorFirstNames": dsl.Like("Lonnie"),
+									"donorLastName":   dsl.Like("Jakubowski"),
+									"donorDob":        dsl.Term("22/03/1949", `^\d{1,2}/\d{1,2}/\d{4}$`),
+									"donorPhone":      dsl.Like("073456249524"),
+									"donorEmail":      dsl.Like("zswanberg@host.example"),
+									"donorAddress": map[string]interface{}{
+										"addressLine1": dsl.Like("528 Fourth Avenue"),
+										"addressLine2": dsl.Like("Lower Kozey Cross"),
+										"addressLine3": dsl.Like("East Thiel"),
+										"town":         dsl.Like("Ahlen"),
+										"postcode":     dsl.Like("YL06 6GF"),
+										"country":      dsl.Term("GB", `^[A-Z]{2}$`),
+									},
+								},
+							},
+						},
+					})
+			},
+			expectedResponse: DigitalLpa{
+				UID: "M-1111-2222-3333",
+				SiriusData: SiriusData{
+					ID:                 111,
+					Subtype:            "property-and-affairs",
+					Status:             "Draft",
+					CreatedDate:        DateString("2018-03-26"),
+					ComplaintCount:     0,
+					InvestigationCount: 0,
+					TaskCount:          0,
+					WarningCount:       0,
+					ObjectionCount:     0,
+					Application: Draft{
+						DonorFirstNames: "Lonnie",
+						DonorLastName:   "Jakubowski",
+						DonorDob:        DateString("1949-03-22"),
+						DonorAddress: Address{
+							Line1:    "528 Fourth Avenue",
+							Line2:    "Lower Kozey Cross",
+							Line3:    "East Thiel",
+							Town:     "Ahlen",
+							Postcode: "YL06 6GF",
+							Country:  "GB",
+						},
+						PhoneNumber: "073456249524",
+						Email:       "zswanberg@host.example",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -125,7 +201,7 @@ func TestDigitalLpa(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				digitalLpa, err := client.DigitalLpa(Context{Context: context.Background()}, "M-1234-9876-4567")
+				digitalLpa, err := client.DigitalLpa(Context{Context: context.Background()}, tc.expectedResponse.UID)
 
 				assert.Equal(t, tc.expectedResponse, digitalLpa)
 				if tc.expectedError == nil {


### PR DESCRIPTION
[VEGA-2624](https://opgtransform.atlassian.net/jira/software/projects/VEGA/boards/170?selectedIssue=VEGA-2624) This PR covers adding a PACT test for the Due Date response when getting Digital LPA data through the API.

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-2624]: https://opgtransform.atlassian.net/browse/VEGA-2624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ