### PR TITLE
VEGA-2501 : Manual Digital LPA Case Status Change #minor

### DIFF
--- a/cypress/e2e/change-case-status.cy.js
+++ b/cypress/e2e/change-case-status.cy.js
@@ -65,6 +65,7 @@ describe("Change case status", () => {
           ],
           lpaType: "pf",
           channel: "online",
+          status: "draft",
           peopleToNotify: [],
         },
       },

--- a/cypress/e2e/change-case-status.cy.js
+++ b/cypress/e2e/change-case-status.cy.js
@@ -1,4 +1,4 @@
-describe("Change status", () => {
+describe("Change case status", () => {
   beforeEach(() => {
     cy.visit("/change-case-status?uid=M-1234-9876-4567");
   });

--- a/cypress/e2e/change-case-status.cy.js
+++ b/cypress/e2e/change-case-status.cy.js
@@ -1,6 +1,6 @@
 describe("Change status", () => {
   beforeEach(() => {
-    cy.visit("/change-case-tatus?uid=M-1234-9876-4567");
+    cy.visit("/change-case-status?uid=M-1234-9876-4567");
   });
 
   it("changes the digital lpa case status", () => {

--- a/cypress/e2e/change-case-status.cy.js
+++ b/cypress/e2e/change-case-status.cy.js
@@ -1,13 +1,114 @@
 describe("Change case status", () => {
   beforeEach(() => {
-    cy.visit("/change-case-status?uid=M-1234-9876-4567");
+    cy.addMock("/lpa-api/v1/digital-lpas/M-DIGI-LPA3-3333", "GET", {
+      status: 200,
+      body: {
+        uId: "M-DIGI-LPA3-3333",
+        "opg.poas.sirius": {
+          id: 333,
+          uId: "M-DIGI-LPA3-3333",
+          status: "Draft",
+          caseSubtype: "property-and-affairs",
+          createdDate: "31/10/2023",
+          dueDate: "01/12/2023",
+          donor: {
+            id: 33,
+          },
+          application: {
+            donorFirstNames: "Agnes",
+            donorLastName: "Hartley",
+            donorDob: "27/05/1998",
+            donorEmail: "agnes@host.example",
+            donorPhone: "073656249524",
+            donorAddress: {
+              addressLine1: "Apartment 3",
+              addressLine2: "Gherkin Building",
+              addressLine3: "33 London Road",
+              country: "GB",
+              postcode: "B15 3AA",
+              town: "Birmingham",
+            },
+            correspondentFirstNames: "Kendrick",
+            correspondentLastName: "Lamar",
+            correspondentAddress: {
+              addressLine1: "Flat 3",
+              addressLine2: "Digital LPA Lane",
+              addressLine3: "Somewhere",
+              country: "GB",
+              postcode: "SW1 1AA",
+              town: "London",
+            },
+          },
+        },
+        "opg.poas.lpastore": {
+          attorneys: [
+            {
+              firstNames: "Esther",
+              lastName: "Greenwood",
+              status: "active",
+            },
+            {
+              firstNames: "Volo",
+              lastName: "McSpolo",
+              status: "active",
+            },
+            {
+              firstNames: "Susanna",
+              lastName: "Kaysen",
+              status: "removed",
+            },
+            {
+              firstNames: "Philomena",
+              lastName: "Guinea",
+              status: "replacement",
+            },
+          ],
+          lpaType: "pf",
+          channel: "online",
+          peopleToNotify: [],
+        },
+      },
+    });
+
+    cy.addMock("/lpa-api/v1/cases/333", "GET", {
+      status: 200,
+      body: {
+        id: 333,
+        uId: "M-DIGI-LPA3-3333",
+        caseType: "DIGITAL_LPA",
+        donor: {
+          id: 33,
+        },
+        status: "Draft",
+      },
+    });
+
+    cy.addMock("/lpa-api/v1/cases/333/tasks", "GET", {
+      status: 200,
+      body: [],
+    });
+
+    cy.addMock("/lpa-api/v1/cases/333/warnings", "GET", {
+      status: 200,
+      body: [],
+    });
+
+    cy.addMock("/lpa-api/v1/digital-lpas/M-DIGI-LPA3-3333/update-case-status", "PUT", {
+      status: 200,
+      body: [],
+    });
   });
 
   it("changes the digital lpa case status", () => {
+    cy.visit("/change-case-status?uid=M-DIGI-LPA3-3333");
     cy.contains("Change case status");
-    cy.contains("M-1234-9876-4567");
+    cy.contains("M-DIGI-LPA3-3333");
     cy.get(".moj-banner").should("not.exist");
-    cy.get("#f-status").select("In progress");
+    cy.contains(".govuk-radios__label", "Draft")
+        .parent()
+        .get("input")
+        .should("be.checked");
+    cy.contains(".govuk-radios__label", "Cannot register").click();
     cy.get("button[type=submit]").click();
     cy.get(".moj-banner").should("exist");
   });

--- a/cypress/e2e/change-case-status.cy.js
+++ b/cypress/e2e/change-case-status.cy.js
@@ -1,0 +1,14 @@
+describe("Change status", () => {
+  beforeEach(() => {
+    cy.visit("/change-case-tatus?uid=M-1234-9876-4567");
+  });
+
+  it("changes the digital lpa case status", () => {
+    cy.contains("Change case status");
+    cy.contains("M-1234-9876-4567");
+    cy.get(".moj-banner").should("not.exist");
+    cy.get("#f-status").select("In progress");
+    cy.get("button[type=submit]").click();
+    cy.get(".moj-banner").should("exist");
+  });
+});

--- a/cypress/e2e/change-case-status.cy.js
+++ b/cypress/e2e/change-case-status.cy.js
@@ -93,10 +93,14 @@ describe("Change case status", () => {
       body: [],
     });
 
-    cy.addMock("/lpa-api/v1/digital-lpas/M-DIGI-LPA3-3333/update-case-status", "PUT", {
-      status: 200,
-      body: [],
-    });
+    cy.addMock(
+      "/lpa-api/v1/digital-lpas/M-DIGI-LPA3-3333/update-case-status",
+      "PUT",
+      {
+        status: 200,
+        body: [],
+      },
+    );
   });
 
   it("changes the digital lpa case status", () => {
@@ -105,9 +109,9 @@ describe("Change case status", () => {
     cy.contains("M-DIGI-LPA3-3333");
     cy.get(".moj-banner").should("not.exist");
     cy.contains(".govuk-radios__label", "Draft")
-        .parent()
-        .get("input")
-        .should("be.checked");
+      .parent()
+      .get("input")
+      .should("be.checked");
     cy.contains(".govuk-radios__label", "Cannot register").click();
     cy.get("button[type=submit]").click();
     cy.get(".moj-banner").should("exist");

--- a/cypress/e2e/change-case-status.cy.js
+++ b/cypress/e2e/change-case-status.cy.js
@@ -98,7 +98,7 @@ describe("Change case status", () => {
       "/lpa-api/v1/digital-lpas/M-DIGI-LPA3-3333/update-case-status",
       "PUT",
       {
-        status: 200,
+        status: 204,
         body: [],
       },
     );

--- a/cypress/e2e/digital-lpa.cy.js
+++ b/cypress/e2e/digital-lpa.cy.js
@@ -545,7 +545,7 @@ describe("View a digital LPA", () => {
 
     cy.url().should("include", "/change-case-status?uid=M-DIGI-LPA3-3333");
     cy.contains("Change case status");
-    cy.get('.govuk-button-group').contains("Cancel").click();
+    cy.get(".govuk-button-group").contains("Cancel").click();
 
     cy.url().should("include", "/lpa/M-DIGI-LPA3-3333");
     cy.contains("Case summary");

--- a/cypress/e2e/digital-lpa.cy.js
+++ b/cypress/e2e/digital-lpa.cy.js
@@ -7,7 +7,7 @@ describe("View a digital LPA", () => {
         "opg.poas.sirius": {
           id: 333,
           uId: "M-DIGI-LPA3-3333",
-          status: "Processing",
+          status: "Draft",
           caseSubtype: "property-and-affairs",
           createdDate: "31/10/2023",
           investigationCount: 2,
@@ -83,6 +83,7 @@ describe("View a digital LPA", () => {
           ],
           lpaType: "pf",
           channel: "online",
+          status: "draft",
           registrationDate: "2022-12-18",
           peopleToNotify: [],
         },
@@ -224,7 +225,7 @@ describe("View a digital LPA", () => {
             {
               uId: "M-DIGI-LPA3-3333",
               caseSubtype: "property-and-affairs",
-              status: "Processing",
+              status: "Draft",
               createdDate: "01/11/2023",
             },
             {
@@ -337,7 +338,7 @@ describe("View a digital LPA", () => {
     cy.get("h1").contains("Agnes Hartley");
 
     cy.contains("M-DIGI-LPA3-3333");
-    cy.get("a[href='/lpa/M-DIGI-LPA3-3333'] .govuk-tag").contains("Processing");
+    cy.get("a[href='/lpa/M-DIGI-LPA3-3333'] .govuk-tag").contains("Draft");
 
     cy.contains("PW M-DIGI-LPA3-3334");
     cy.get("a[href='/lpa/M-DIGI-LPA3-3334'] .govuk-tag").contains("Draft");

--- a/cypress/e2e/digital-lpa.cy.js
+++ b/cypress/e2e/digital-lpa.cy.js
@@ -538,6 +538,19 @@ describe("View a digital LPA", () => {
     cy.contains("Case summary");
   });
 
+  it("can cancel changing the status", () => {
+    cy.visit("/lpa/M-DIGI-LPA3-3333");
+    cy.contains("Case actions").click();
+    cy.contains("Change case status").click();
+
+    cy.url().should("include", "/change-case-status?uid=M-DIGI-LPA3-3333");
+    cy.contains("Change case status");
+    cy.get('.govuk-button-group').contains("Cancel").click();
+
+    cy.url().should("include", "/lpa/M-DIGI-LPA3-3333");
+    cy.contains("Case summary");
+  });
+
   it("can clear a task", () => {
     cy.addMock("/lpa-api/v1/tasks/1/mark-as-completed", "PUT", {
       status: 200,

--- a/cypress/mocks/migrated-from-pact.json
+++ b/cypress/mocks/migrated-from-pact.json
@@ -163,6 +163,17 @@
       }
     },
     {
+      "name": "A request for changing the status of the digital LPA",
+      "request": {
+        "method": "PUT",
+        "url": "/lpa-api/v1/digital-lpas/M-1234-9876-4567/update-case-status"
+      },
+      "response": {
+        "status": 200,
+        "headers": { "Content-Type": "application/json" }
+      }
+    },
+    {
       "name": "A request to add a complaint to the case",
       "request": { "method": "POST", "url": "/lpa-api/v1/lpas/800/complaints" },
       "response": {

--- a/internal/server/change_case_status.go
+++ b/internal/server/change_case_status.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/ministryofjustice/opg-go-common/template"
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+)
+
+type ChangeCaseStatusClient interface {
+	Case(sirius.Context, int) (sirius.Case, error)
+	EditCase(sirius.Context, int, sirius.CaseType, sirius.Case) error
+}
+
+type changeCaseStatusData struct {
+	XSRFToken string
+	Entity    string
+	Success   bool
+	Error     sirius.ValidationError
+
+	NewStatus string
+}
+
+func ChangeCaseStatus(client ChangeCaseStatusClient, tmpl template.Template) Handler {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		caseID, err := strconv.Atoi(r.FormValue("id"))
+		if err != nil {
+			return err
+		}
+
+		ctx := getContext(r)
+
+		caseitem, err := client.Case(ctx, caseID)
+		if err != nil {
+			return err
+		}
+
+		data := changeCaseStatusData{
+			XSRFToken: ctx.XSRFToken,
+			Entity:    fmt.Sprintf("%s %s", caseitem.CaseType, caseitem.UID),
+			NewStatus: postFormString(r, "status"),
+		}
+
+		if r.Method == http.MethodPost {
+			caseDetails := sirius.Case{
+				Status: data.NewStatus,
+			}
+
+			err = client.EditCase(ctx, caseID, sirius.CaseType(caseitem.CaseType), caseDetails)
+
+			if ve, ok := err.(sirius.ValidationError); ok {
+				w.WriteHeader(http.StatusBadRequest)
+				data.Error = ve
+			} else if err != nil {
+				return err
+			} else {
+				data.Success = true
+			}
+		}
+
+		return tmpl(w, data)
+	}
+}

--- a/internal/server/change_case_status.go
+++ b/internal/server/change_case_status.go
@@ -28,7 +28,6 @@ func ChangeCaseStatus(client ChangeCaseStatusClient, tmpl template.Template) Han
 		caseUID := r.FormValue("uid")
 
 		ctx := getContext(r)
-
 		cs, err := client.CaseSummary(ctx, caseUID)
 		if err != nil {
 			return err
@@ -38,7 +37,7 @@ func ChangeCaseStatus(client ChangeCaseStatusClient, tmpl template.Template) Han
 			XSRFToken: ctx.XSRFToken,
 			Entity:    fmt.Sprintf("%s %s", cs.DigitalLpa.SiriusData.Subtype, caseUID),
 			CaseUID:   caseUID,
-			OldStatus: cs.DigitalLpa.SiriusData.Status,
+			OldStatus: cs.DigitalLpa.LpaStoreData.Status,
 			NewStatus: postFormString(r, "status"),
 		}
 

--- a/internal/server/change_case_status.go
+++ b/internal/server/change_case_status.go
@@ -9,7 +9,7 @@ import (
 
 type ChangeCaseStatusClient interface {
 	CaseSummary(ctx sirius.Context, uid string) (sirius.CaseSummary, error)
-	EditDigitalLPA(sirius.Context, string, sirius.CaseStatusData) error
+	EditDigitalLPAStatus(sirius.Context, string, sirius.CaseStatusData) error
 }
 
 type changeCaseStatusData struct {
@@ -45,7 +45,7 @@ func ChangeCaseStatus(client ChangeCaseStatusClient, tmpl template.Template) Han
 				Status: data.NewStatus,
 			}
 
-			err = client.EditDigitalLPA(ctx, caseUID, caseDetails)
+			err = client.EditDigitalLPAStatus(ctx, caseUID, caseDetails)
 
 			if ve, ok := err.(sirius.ValidationError); ok {
 				w.WriteHeader(http.StatusBadRequest)

--- a/internal/server/change_case_status.go
+++ b/internal/server/change_case_status.go
@@ -33,11 +33,17 @@ func ChangeCaseStatus(client ChangeCaseStatusClient, tmpl template.Template) Han
 			return err
 		}
 
+		status := "draft"
+
+		if cs.DigitalLpa.LpaStoreData.Status != "" {
+			status = cs.DigitalLpa.LpaStoreData.Status
+		}
+
 		data := changeCaseStatusData{
 			XSRFToken: ctx.XSRFToken,
 			Entity:    fmt.Sprintf("%s %s", cs.DigitalLpa.SiriusData.Subtype, caseUID),
 			CaseUID:   caseUID,
-			OldStatus: cs.DigitalLpa.LpaStoreData.Status,
+			OldStatus: status,
 			NewStatus: postFormString(r, "status"),
 		}
 

--- a/internal/server/change_case_status.go
+++ b/internal/server/change_case_status.go
@@ -8,13 +8,14 @@ import (
 )
 
 type ChangeCaseStatusClient interface {
-	CaseSummary(ctx sirius.Context, uid string) (sirius.CaseSummary, error)
+	CaseSummary(sirius.Context, string) (sirius.CaseSummary, error)
 	EditDigitalLPAStatus(sirius.Context, string, sirius.CaseStatusData) error
 }
 
 type changeCaseStatusData struct {
 	XSRFToken string
 	Entity    string
+	CaseUID   string
 	Success   bool
 	Error     sirius.ValidationError
 
@@ -36,16 +37,17 @@ func ChangeCaseStatus(client ChangeCaseStatusClient, tmpl template.Template) Han
 		data := changeCaseStatusData{
 			XSRFToken: ctx.XSRFToken,
 			Entity:    fmt.Sprintf("%s %s", cs.DigitalLpa.SiriusData.Subtype, caseUID),
+			CaseUID:   caseUID,
 			OldStatus: cs.DigitalLpa.SiriusData.Status,
 			NewStatus: postFormString(r, "status"),
 		}
 
 		if r.Method == http.MethodPost {
-			caseDetails := sirius.CaseStatusData{
+			caseStatusData := sirius.CaseStatusData{
 				Status: data.NewStatus,
 			}
 
-			err = client.EditDigitalLPAStatus(ctx, caseUID, caseDetails)
+			err = client.EditDigitalLPAStatus(ctx, caseUID, caseStatusData)
 
 			if ve, ok := err.(sirius.ValidationError); ok {
 				w.WriteHeader(http.StatusBadRequest)

--- a/internal/server/change_case_status.go
+++ b/internal/server/change_case_status.go
@@ -56,6 +56,7 @@ func ChangeCaseStatus(client ChangeCaseStatusClient, tmpl template.Template) Han
 				return err
 			} else {
 				data.Success = true
+				data.OldStatus = data.NewStatus
 			}
 		}
 

--- a/internal/server/change_case_status_test.go
+++ b/internal/server/change_case_status_test.go
@@ -35,6 +35,9 @@ func TestGetChangeCaseStatus(t *testing.T) {
 				Subtype: "personal-welfare",
 				Status:  "Draft",
 			},
+			LpaStoreData: sirius.LpaStoreData{
+				Status: "draft",
+			},
 		},
 	}
 
@@ -48,7 +51,7 @@ func TestGetChangeCaseStatus(t *testing.T) {
 		On("Func", mock.Anything, changeCaseStatusData{
 			Entity:    "personal-welfare M-9876-9876-9876",
 			CaseUID:   "M-9876-9876-9876",
-			OldStatus: "Draft",
+			OldStatus: "draft",
 		}).
 		Return(nil)
 
@@ -72,6 +75,9 @@ func TestPostChangeCaseStatus(t *testing.T) {
 				Subtype: "personal-welfare",
 				Status:  "Draft",
 			},
+			LpaStoreData: sirius.LpaStoreData{
+				Status: "draft",
+			},
 		},
 	}
 
@@ -82,7 +88,7 @@ func TestPostChangeCaseStatus(t *testing.T) {
 
 	client.
 		On("EditDigitalLPAStatus", mock.Anything, "M-9876-9876-9876", sirius.CaseStatusData{
-			Status: "Cancelled",
+			Status: "cancelled",
 		}).
 		Return(nil)
 
@@ -92,13 +98,13 @@ func TestPostChangeCaseStatus(t *testing.T) {
 			Success:   true,
 			Entity:    "personal-welfare M-9876-9876-9876",
 			CaseUID:   "M-9876-9876-9876",
-			OldStatus: "Cancelled",
-			NewStatus: "Cancelled",
+			OldStatus: "cancelled",
+			NewStatus: "cancelled",
 		}).
 		Return(nil)
 
 	form := url.Values{
-		"status": {"Cancelled"},
+		"status": {"cancelled"},
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/change-case-status?uid=M-9876-9876-9876", strings.NewReader(form.Encode()))

--- a/internal/server/change_case_status_test.go
+++ b/internal/server/change_case_status_test.go
@@ -47,6 +47,7 @@ func TestGetChangeCaseStatus(t *testing.T) {
 	template.
 		On("Func", mock.Anything, changeCaseStatusData{
 			Entity:    "personal-welfare M-9876-9876-9876",
+			CaseUID:   "M-9876-9876-9876",
 			OldStatus: "Draft",
 		}).
 		Return(nil)
@@ -90,6 +91,7 @@ func TestPostChangeCaseStatus(t *testing.T) {
 		On("Func", mock.Anything, changeCaseStatusData{
 			Success:   true,
 			Entity:    "personal-welfare M-9876-9876-9876",
+			CaseUID:   "M-9876-9876-9876",
 			OldStatus: "Draft",
 			NewStatus: "Cancelled",
 		}).

--- a/internal/server/change_case_status_test.go
+++ b/internal/server/change_case_status_test.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockChangeCaseStatusClient struct {
+	mock.Mock
+}
+
+func (m *mockChangeCaseStatusClient) CaseSummary(ctx sirius.Context, uid string) (sirius.CaseSummary, error) {
+	args := m.Called(ctx, uid)
+	return args.Get(0).(sirius.CaseSummary), args.Error(1)
+}
+
+func (m *mockChangeCaseStatusClient) EditDigitalLPAStatus(ctx sirius.Context, caseUID string, caseStatusData sirius.CaseStatusData) error {
+	args := m.Called(ctx, caseUID, caseStatusData)
+	return args.Error(0)
+}
+
+func TestGetChangeCaseStatus(t *testing.T) {
+	caseSummary := sirius.CaseSummary{
+		DigitalLpa: sirius.DigitalLpa{
+			UID: "M-9876-9876-9876",
+			SiriusData: sirius.SiriusData{
+				ID:      676,
+				Subtype: "personal-welfare",
+				Status:  "Draft",
+			},
+		},
+	}
+
+	client := &mockChangeCaseStatusClient{}
+	client.
+		On("CaseSummary", mock.Anything, "M-9876-9876-9876").
+		Return(caseSummary, nil)
+
+	template := &mockTemplate{}
+	template.
+		On("Func", mock.Anything, changeCaseStatusData{
+			Entity:    "personal-welfare M-9876-9876-9876",
+			OldStatus: "Draft",
+		}).
+		Return(nil)
+
+	r, _ := http.NewRequest(http.MethodGet, "/change-case-status?uid=M-9876-9876-9876", nil)
+	w := httptest.NewRecorder()
+
+	err := ChangeCaseStatus(client, template.Func)(w, r)
+	resp := w.Result()
+
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mock.AssertExpectationsForObjects(t, client, template)
+}

--- a/internal/server/change_case_status_test.go
+++ b/internal/server/change_case_status_test.go
@@ -92,7 +92,7 @@ func TestPostChangeCaseStatus(t *testing.T) {
 			Success:   true,
 			Entity:    "personal-welfare M-9876-9876-9876",
 			CaseUID:   "M-9876-9876-9876",
-			OldStatus: "Draft",
+			OldStatus: "Cancelled",
 			NewStatus: "Cancelled",
 		}).
 		Return(nil)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,8 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-chi/chi/v5"
-	"github.com/go-playground/form/v4"
 	"github.com/ministryofjustice/opg-go-common/securityheaders"
 	"github.com/ministryofjustice/opg-go-common/telemetry"
 	"github.com/ministryofjustice/opg-go-common/template"
@@ -51,6 +49,7 @@ type Client interface {
 	AssignTaskClient
 	ApplyFeeReductionClient
 	ChangeStatusClient
+	ChangeCaseStatusClient
 	ClearTaskClient
 	CreateDonorClient
 	CreateDocumentClient
@@ -116,6 +115,7 @@ func New(logger *slog.Logger, client Client, templates template.Templates, prefi
 	mux.Handle("/edit-complaint", wrap(EditComplaint(client, templates.Get("edit_complaint.gohtml"))))
 	mux.Handle("/unlink-person", wrap(UnlinkPerson(client, templates.Get("unlink_person.gohtml"))))
 	mux.Handle("/change-status", wrap(ChangeStatus(client, templates.Get("change_status.gohtml"))))
+	mux.Handle("/change-case-status", wrap(ChangeCaseStatus(client, templates.Get("change_case_status.gohtml"))))
 	mux.Handle("/allocate-cases", wrap(AllocateCases(client, templates.Get("allocate_cases.gohtml"))))
 	mux.Handle("/assign-task", wrap(AssignTask(client, templates.Get("assign_task.gohtml"))))
 	mux.Handle("/clear-task", wrap(ClearTask(client, templates.Get("clear_task.gohtml"))))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/go-playground/form/v4"
 	"github.com/ministryofjustice/opg-go-common/securityheaders"
 	"github.com/ministryofjustice/opg-go-common/telemetry"
 	"github.com/ministryofjustice/opg-go-common/template"

--- a/internal/sirius/digital_lpa.go
+++ b/internal/sirius/digital_lpa.go
@@ -44,6 +44,7 @@ type Donor struct {
 type LpaStoreData struct {
 	Donor                                       LpaStoreDonor               `json:"donor"`
 	Channel                                     string                      `json:"channel"`
+	Status                                      string                      `json:"status"`
 	Attorneys                                   []LpaStoreAttorney          `json:"attorneys"`
 	CertificateProvider                         LpaStoreCertificateProvider `json:"certificateProvider"`
 	PeopleToNotify                              []LpaStorePersonToNotify    `json:"peopleToNotify"`

--- a/internal/sirius/edit_digital_lpa.go
+++ b/internal/sirius/edit_digital_lpa.go
@@ -1,0 +1,44 @@
+package sirius
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type CaseStatusData struct {
+	Status string
+}
+
+func (c *Client) EditDigitalLPA(ctx Context, caseUID string, caseStatusData CaseStatusData) error {
+	data, err := json.Marshal(caseStatusData)
+	if err != nil {
+		return err
+	}
+
+	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/update-case-status", caseUID), bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //#nosec G307 false positive
+
+	if resp.StatusCode == http.StatusBadRequest {
+		var v ValidationError
+		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+			return err
+		}
+		return v
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return newStatusError(resp)
+	}
+
+	return nil
+}

--- a/internal/sirius/edit_digital_lpa_status.go
+++ b/internal/sirius/edit_digital_lpa_status.go
@@ -8,7 +8,7 @@ import (
 )
 
 type CaseStatusData struct {
-	Status string
+	Status string `json:"status"`
 }
 
 func (c *Client) EditDigitalLPAStatus(ctx Context, caseUID string, caseStatusData CaseStatusData) error {

--- a/internal/sirius/edit_digital_lpa_status.go
+++ b/internal/sirius/edit_digital_lpa_status.go
@@ -11,7 +11,7 @@ type CaseStatusData struct {
 	Status string
 }
 
-func (c *Client) EditDigitalLPA(ctx Context, caseUID string, caseStatusData CaseStatusData) error {
+func (c *Client) EditDigitalLPAStatus(ctx Context, caseUID string, caseStatusData CaseStatusData) error {
 	data, err := json.Marshal(caseStatusData)
 	if err != nil {
 		return err

--- a/internal/sirius/edit_digital_lpa_status.go
+++ b/internal/sirius/edit_digital_lpa_status.go
@@ -36,7 +36,7 @@ func (c *Client) EditDigitalLPAStatus(ctx Context, caseUID string, caseStatusDat
 		return v
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusNoContent {
 		return newStatusError(resp)
 	}
 

--- a/internal/sirius/edit_digital_lpa_status_test.go
+++ b/internal/sirius/edit_digital_lpa_status_test.go
@@ -34,11 +34,11 @@ func TestEditDigitalLPAStatus(t *testing.T) {
 							"Content-Type": dsl.String("application/json"),
 						},
 						Body: map[string]interface{}{
-							"status": "In progress",
+							"status": "in-progress",
 						},
 					}).
 					WillRespondWith(dsl.Response{
-						Status:  http.StatusOK,
+						Status:  http.StatusNoContent,
 						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
 					})
 			},

--- a/internal/sirius/edit_digital_lpa_status_test.go
+++ b/internal/sirius/edit_digital_lpa_status_test.go
@@ -1,0 +1,66 @@
+package sirius
+
+import (
+	"context"
+	"fmt"
+	"github.com/pact-foundation/pact-go/dsl"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestEditDigitalLPAStatus(t *testing.T) {
+	t.Parallel()
+
+	pact := newPact()
+	defer pact.Teardown()
+
+	testCases := []struct {
+		name          string
+		setup         func()
+		expectedError func(int) error
+	}{
+		{
+			name: "OK",
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("A digital LPA exists").
+					UponReceiving("A request for changing the status of the digital LPA").
+					WithRequest(dsl.Request{
+						Method: http.MethodPut,
+						Path:   dsl.String("/lpa-api/v1/digital-lpas/M-1234-9876-4567/update-case-status"),
+						Headers: dsl.MapMatcher{
+							"Content-Type": dsl.String("application/json"),
+						},
+						Body: map[string]interface{}{
+							"status": "In progress",
+						},
+					}).
+					WillRespondWith(dsl.Response{
+						Status:  http.StatusOK,
+						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+					})
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+
+			assert.Nil(t, pact.Verify(func() error {
+				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
+
+				err := client.EditDigitalLPAStatus(Context{Context: context.Background()}, "M-1234-9876-4567", CaseStatusData{Status: "In progress"})
+
+				if tc.expectedError == nil {
+					assert.Nil(t, err)
+				} else {
+					assert.Equal(t, tc.expectedError(pact.Server.Port), err)
+				}
+				return nil
+			}))
+		})
+	}
+}

--- a/internal/sirius/edit_digital_lpa_status_test.go
+++ b/internal/sirius/edit_digital_lpa_status_test.go
@@ -52,7 +52,7 @@ func TestEditDigitalLPAStatus(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.EditDigitalLPAStatus(Context{Context: context.Background()}, "M-1234-9876-4567", CaseStatusData{Status: "In progress"})
+				err := client.EditDigitalLPAStatus(Context{Context: context.Background()}, "M-1234-9876-4567", CaseStatusData{Status: "in-progress"})
 
 				if tc.expectedError == nil {
 					assert.Nil(t, err)

--- a/internal/templatefn/fn.go
+++ b/internal/templatefn/fn.go
@@ -122,6 +122,7 @@ func All(siriusPublicURL, prefix, staticHash string) map[string]interface{} {
 				return "grey"
 			}
 		},
+		"statusLabel": statusLabelFormat,
 		"replace": func(s, find, replace string) string {
 			return strings.ReplaceAll(s, find, replace)
 		},
@@ -303,11 +304,45 @@ func subtypeLongFormat(subtype string) string {
 	}
 }
 
+func statusLabelFormat(status string) string {
+	switch strings.ToLower(status) {
+	case "draft":
+		return "Draft"
+	case "in-progress":
+		return "In progress"
+	case "statutory-waiting-period":
+		return "Statutory waiting period"
+	case "registered":
+		return "Registered"
+	case "suspended":
+		return "Suspended"
+	case "do-not-register":
+		return "Do not register"
+	case "expired":
+		return "Expired"
+	case "cannot-register":
+		return "Cannot register"
+	case "cancelled":
+		return "Cancelled"
+	case "de-registered":
+		return "De-registered"
+	default:
+		return "draft"
+	}
+
+}
+
 func caseTab(caseSummary sirius.CaseSummary, tabName string) CaseTabData {
 	lpa := caseSummary.DigitalLpa.SiriusData
+	lpaStore := caseSummary.DigitalLpa.LpaStoreData
+	status := "draft"
+
+	if lpaStore.Status != "" {
+		status = lpaStore.Status
+	}
 
 	var linkedCases []linkedCase
-	linkedCases = append(linkedCases, linkedCase{lpa.UID, lpa.Subtype, lpa.Status, lpa.CreatedDate})
+	linkedCases = append(linkedCases, linkedCase{lpa.UID, lpa.Subtype, statusLabelFormat(status), lpa.CreatedDate})
 
 	for _, linkedLpa := range lpa.LinkedCases {
 		linkedCases = append(linkedCases, linkedCase{linkedLpa.UID, linkedLpa.Subtype, linkedLpa.Status, linkedLpa.CreatedDate})

--- a/internal/templatefn/fn.go
+++ b/internal/templatefn/fn.go
@@ -104,13 +104,15 @@ func All(siriusPublicURL, prefix, staticHash string) map[string]interface{} {
 		},
 		"statusColour": func(s string) string {
 			switch strings.ToLower(s) {
-			case "registered", "statutory waiting period":
+			case "registered":
 				return "green"
 			case "perfect":
 				return "turquoise"
-			case "pending", "in progress":
+			case "statutory waiting period":
 				return "yellow"
-			case "payment pending", "reduced fees pending":
+			case "in progress":
+				return "light-blue"
+			case "pending", "payment pending", "reduced fees pending":
 				return "blue"
 			case "draft":
 				return "purple"

--- a/internal/templatefn/fn.go
+++ b/internal/templatefn/fn.go
@@ -104,17 +104,17 @@ func All(siriusPublicURL, prefix, staticHash string) map[string]interface{} {
 		},
 		"statusColour": func(s string) string {
 			switch strings.ToLower(s) {
-			case "registered":
+			case "registered", "statutory waiting period":
 				return "green"
 			case "perfect":
 				return "turquoise"
-			case "pending":
+			case "pending", "in progress":
 				return "yellow"
 			case "payment pending", "reduced fees pending":
 				return "blue"
 			case "draft":
 				return "purple"
-			case "cancelled", "rejected", "revoked", "withdrawn", "return - unpaid", "deleted":
+			case "cancelled", "rejected", "revoked", "withdrawn", "return - unpaid", "deleted", "do not register", "expired", "cannot register", "de-registered":
 				return "red"
 			default:
 				return "grey"

--- a/web/template/change_case_status.gohtml
+++ b/web/template/change_case_status.gohtml
@@ -5,8 +5,6 @@
 {{ define "main" }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body"><strong>Change the status of {{ .Entity }} to</strong></p>
-
       {{ template "error-summary" .Error }}
 
       {{ if .Success }}
@@ -19,7 +17,19 @@
       <form class="form" method="POST">
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
 
-
+        <p class="govuk-body">Change the status of <strong>{{ .Entity }}</strong> to</p>
+        {{ template "radios" (radios "status" "" .OldStatus .Error.Field.status
+        (item "Draft" "Draft" "statusTag" true)
+        (item "In progress" "In progress" "statusTag" true)
+        (item "Statutory waiting period" "Statutory waiting period" "statusTag" true)
+        (item "Registered" "Registered" "statusTag" true)
+        (item "Suspended" "Suspended" "statusTag" true)
+        (item "Do not register" "Do not register" "statusTag" true)
+        (item "Expired" "Expired" "statusTag" true)
+        (item "Cannot register" "Cannot register" "statusTag" true)
+        (item "Cancelled" "Cancelled" "statusTag" true)
+        (item "De-registered" "De-registered" "statusTag" true)
+        ) }}
 
         <div class="govuk-button-group">
           <button class="govuk-button" data-module="govuk-button" type="submit">Submit</button>

--- a/web/template/change_case_status.gohtml
+++ b/web/template/change_case_status.gohtml
@@ -1,0 +1,31 @@
+{{ template "page" . }}
+
+{{ define "title" }}{{ if .Error.Any }}Error: {{ end }}Change case status{{ end }}
+
+{{ define "main" }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body"><strong>Change the status of {{ .Entity }} to</strong></p>
+
+      {{ template "error-summary" .Error }}
+
+      {{ if .Success }}
+        <meta data-app-reload="page" />
+        {{ template "success-banner" (printf "Status changed to %s" .NewStatus) }}
+      {{ end }}
+
+      <h1 class="govuk-heading-l app-!-embedded-hide">Change case status</h1>
+
+      <form class="form" method="POST">
+        <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
+
+
+
+        <div class="govuk-button-group">
+          <button class="govuk-button" data-module="govuk-button" type="submit">Submit</button>
+          <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+{{ end }}

--- a/web/template/change_case_status.gohtml
+++ b/web/template/change_case_status.gohtml
@@ -9,7 +9,7 @@
 
       {{ if .Success }}
         <meta data-app-reload="page" />
-        {{ template "success-banner" (printf "Status changed to %s" .NewStatus) }}
+        {{ template "success-banner" (printf "Status changed to %s" statusLabel .NewStatus) }}
       {{ end }}
 
       <h1 class="govuk-heading-l app-!-embedded-hide">Change case status</h1>

--- a/web/template/change_case_status.gohtml
+++ b/web/template/change_case_status.gohtml
@@ -19,16 +19,16 @@
 
         <p class="govuk-body">Change the status of <strong>{{ .Entity }}</strong> to</p>
         {{ template "radios" (radios "status" "" .OldStatus .Error.Field.status
-        (item "Draft" "Draft" "statusTag" true)
-        (item "In progress" "In progress" "statusTag" true)
-        (item "Statutory waiting period" "Statutory waiting period" "statusTag" true)
-        (item "Registered" "Registered" "statusTag" true)
-        (item "Suspended" "Suspended" "statusTag" true)
-        (item "Do not register" "Do not register" "statusTag" true)
-        (item "Expired" "Expired" "statusTag" true)
-        (item "Cannot register" "Cannot register" "statusTag" true)
-        (item "Cancelled" "Cancelled" "statusTag" true)
-        (item "De-registered" "De-registered" "statusTag" true)
+        (item "draft" "Draft" "statusTag" true)
+        (item "in-progress" "In progress" "statusTag" true)
+        (item "statutory-waiting-period" "Statutory waiting period" "statusTag" true)
+        (item "registered" "Registered" "statusTag" true)
+        (item "suspended" "Suspended" "statusTag" true)
+        (item "do-not-register" "Do not register" "statusTag" true)
+        (item "expired" "Expired" "statusTag" true)
+        (item "cannot-register" "Cannot register" "statusTag" true)
+        (item "cancelled" "Cancelled" "statusTag" true)
+        (item "de-registered" "De-registered" "statusTag" true)
         ) }}
 
         <div class="govuk-button-group">

--- a/web/template/change_case_status.gohtml
+++ b/web/template/change_case_status.gohtml
@@ -33,7 +33,7 @@
 
         <div class="govuk-button-group">
           <button class="govuk-button" data-module="govuk-button" type="submit">Submit</button>
-          <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+          <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/lpa/%s" .CaseUID )}}">Cancel</a>
         </div>
       </form>
     </div>

--- a/web/template/change_case_status.gohtml
+++ b/web/template/change_case_status.gohtml
@@ -9,7 +9,8 @@
 
       {{ if .Success }}
         <meta data-app-reload="page" />
-        {{ template "success-banner" (printf "Status changed to %s" statusLabel .NewStatus) }}
+        {{ $updatedStatus := statusLabel .NewStatus }}
+        {{ template "success-banner" (printf "Status changed to %s" $updatedStatus) }}
       {{ end }}
 
       <h1 class="govuk-heading-l app-!-embedded-hide">Change case status</h1>

--- a/web/template/layout/mlpa-header.gohtml
+++ b/web/template/layout/mlpa-header.gohtml
@@ -75,7 +75,7 @@
                     <a href="{{ prefix (printf "/create-event?entity=lpa&id=%d" .CaseSummary.DigitalLpa.SiriusData.ID) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="dropdown-menu">
                         Create an event
                     </a>
-                    <a href="{{ prefix (printf "/change-case-status?id=%d" .CaseSummary.DigitalLpa.SiriusData.ID) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="dropdown-menu">
+                    <a href="{{ prefix (printf "/change-case-status?uid=%s" .CaseSummary.DigitalLpa.UID) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="dropdown-menu">
                         Change case status
                     </a>
                 </div>

--- a/web/template/layout/mlpa-header.gohtml
+++ b/web/template/layout/mlpa-header.gohtml
@@ -75,6 +75,9 @@
                     <a href="{{ prefix (printf "/create-event?entity=lpa&id=%d" .CaseSummary.DigitalLpa.SiriusData.ID) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="dropdown-menu">
                         Create an event
                     </a>
+                    <a href="{{ prefix (printf "/change-case-status?id=%d" .CaseSummary.DigitalLpa.SiriusData.ID) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="dropdown-menu">
+                        Change case status
+                    </a>
                 </div>
             </div>
         </div>

--- a/web/template/layout/radios.gohtml
+++ b/web/template/layout/radios.gohtml
@@ -8,7 +8,11 @@
           <div class="govuk-radios__item">
             <input class="govuk-radios__input" id="f-{{ fieldID $.Name $i }}" name="{{ $.Name }}" type="radio" value="{{ $e.Value }}" {{ if eq $.Value $e.Value }}checked{{ end }} {{ if $e.Attrs.hint }}aria-describedby="{{ fieldID $.Name $i }}-item-hint"{{ end }}>
             <label class="govuk-label govuk-radios__label" for="f-{{ fieldID $.Name $i }}">
-              {{ $e.Label }}
+              {{ if $e.Attrs.statusTag }}
+                {{ template "status-tag" $e.Label }}
+              {{ else }}
+                {{ $e.Label }}
+              {{ end }}
             </label>
             {{ if $e.Attrs.hint }}
               <div id="{{ fieldID $.Name $i }}-item-hint" class="govuk-hint govuk-radios__hint">


### PR DESCRIPTION
This PR covers [VEGA-2501](https://opgtransform.atlassian.net/browse/VEGA-2501)

It adds a new template to allow the users to manually change the status of a Digital LPA. 
## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-2501]: https://opgtransform.atlassian.net/browse/VEGA-2501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ