### PR TITLE
VEGA-2667 edit donor detail form

### DIFF
--- a/cypress/e2e/change-donor-details.cy.js
+++ b/cypress/e2e/change-donor-details.cy.js
@@ -1,0 +1,150 @@
+describe("Change donor details", () => {
+    beforeEach(() => {
+        cy.addMock("/lpa-api/v1/digital-lpas/M-0000-0000-0001", "GET", {
+            status: 200,
+            body: {
+                uId: "M-0000-0000-0001",
+                "opg.poas.sirius": {
+                    id: 666,
+                    uId: "M-0000-0000-0001",
+                    status: "Draft",
+                    caseSubtype: "personal-welfare",
+                    createdDate: "31/10/2023",
+                    investigationCount: 0,
+                    complaintCount: 0,
+                    taskCount: 0,
+                    warningCount: 0,
+                    donor: {
+                        id: 33,
+                    },
+                    application: {
+                        donorFirstNames: "Agnes",
+                        donorLastName: "Hartley",
+                        donorDob: "27/05/1998",
+                        donorEmail: "agnes@host.example",
+                        donorPhone: "073656249524",
+                        donorAddress: {
+                            addressLine1: "Apartment 3",
+                            addressLine2: "Gherkin Building",
+                            addressLine3: "33 London Road",
+                            country: "GB",
+                            postcode: "B15 3AA",
+                            town: "Birmingham",
+                        },
+                        correspondentFirstNames: "Kendrick",
+                        correspondentLastName: "Lamar",
+                        correspondentAddress: {
+                            addressLine1: "Flat 3",
+                            addressLine2: "Digital LPA Lane",
+                            addressLine3: "Somewhere",
+                            country: "GB",
+                            postcode: "SW1 1AA",
+                            town: "London",
+                        },
+                    },
+                },
+                "opg.poas.lpastore": {
+                    donor: {
+                        uid: "5ff557dd-1e27-4426-9681-ed6e90c2c08d",
+                        firstNames: "James",
+                        lastName: "Rubin",
+                        otherNamesKnownBy: "Somebody",
+                        dateOfBirth: "1990-02-22",
+                        address: {
+                            postcode: "B29 6BL",
+                            country: "GB",
+                            town: "Birmingham",
+                            line1: "29 Grange Road"
+                        },
+                        contactLanguagePreference: "en",
+                        email: "jrubin@mail.example"
+                    },
+                    attorneys: [
+                        {
+                            firstNames: "Esther",
+                            lastName: "Greenwood",
+                            status: "active",
+                        },
+                        {
+                            firstNames: "Rico",
+                            lastName: "Welch",
+                            status: "replacement",
+                            signedAt: "2022-12-19T09:12:59Z",
+                        },
+                    ],
+                    certificateProvider: {
+                        uid: "e4d5e24e-2a8d-434e-b815-9898620acc71",
+                        firstNames: "Timothy",
+                        lastNames: "Turner",
+                        signedAt: "2022-12-18T11:46:24Z",
+                    },
+                    signedAt: "2022-12-18T11:46:24Z",
+                    lpaType: "pw",
+                    channel: "online",
+                    registrationDate: "2022-12-18",
+                    peopleToNotify: [],
+                },
+            },
+        });
+
+
+        cy.addMock("/lpa-api/v1/cases/666", "GET", {
+            status: 200,
+            body: {
+                id: 666,
+                uId: "M-0000-0000-0001",
+                caseType: "DIGITAL_LPA",
+                donor: {
+                    id: 666,
+                },
+                status: "Draft",
+            },
+        });
+
+        cy.addMock("/lpa-api/v1/cases/666/warnings", "GET", {
+            status: 200,
+            body: [],
+        });
+
+        cy.addMock(
+            "/lpa-api/v1/cases/666/tasks?filter=status%3ANot+started%2Cactive%3Atrue&limit=99&sort=duedate%3AASC",
+            "GET",
+            {
+                status: 200,
+                body: {
+                    tasks: [],
+                },
+            },
+        );
+
+
+        cy.addMock("/lpa-api/v1/digital-lpas/M-0000-0000-0001/change-donor-details", "PUT", {
+            status: 204,
+        });
+
+        cy.visit("/change-donor-details?uid=M-0000-0000-0001");
+    });
+
+    it("Can edit the change donor details form", () => {
+        cy.contains("Change donor details");
+        cy.contains("Details that apply to all LPAs for this donor");
+        cy.get(".moj-banner").should("not.exist");
+
+        cy.get("#f-firstNames").clear()
+        cy.get("#f-firstNames").type("Coleen Stephanie");
+
+        cy.get("#f-lastName").clear();
+        cy.get("#f-lastName").type("Morneault");
+
+        cy.get("#f-dob-day").clear();
+        cy.get("#f-dob-month").clear();
+        cy.get("#f-dob-year").clear();
+
+        cy.get("#f-dob-day").type("8");
+        cy.get("#f-dob-month").type("4");
+        cy.get("#f-dob-year").type("1952");
+
+        cy.get("button[type=submit]").click();
+        cy.get(".moj-banner").should("exist");
+    });
+});

--- a/cypress/e2e/change-donor-details.cy.js
+++ b/cypress/e2e/change-donor-details.cy.js
@@ -1,150 +1,213 @@
-describe("Change donor details", () => {
-    beforeEach(() => {
-        cy.addMock("/lpa-api/v1/digital-lpas/M-0000-0000-0001", "GET", {
-            status: 200,
-            body: {
-                uId: "M-0000-0000-0001",
-                "opg.poas.sirius": {
-                    id: 666,
-                    uId: "M-0000-0000-0001",
-                    status: "Draft",
-                    caseSubtype: "personal-welfare",
-                    createdDate: "31/10/2023",
-                    investigationCount: 0,
-                    complaintCount: 0,
-                    taskCount: 0,
-                    warningCount: 0,
-                    donor: {
-                        id: 33,
-                    },
-                    application: {
-                        donorFirstNames: "Agnes",
-                        donorLastName: "Hartley",
-                        donorDob: "27/05/1998",
-                        donorEmail: "agnes@host.example",
-                        donorPhone: "073656249524",
-                        donorAddress: {
-                            addressLine1: "Apartment 3",
-                            addressLine2: "Gherkin Building",
-                            addressLine3: "33 London Road",
-                            country: "GB",
-                            postcode: "B15 3AA",
-                            town: "Birmingham",
-                        },
-                        correspondentFirstNames: "Kendrick",
-                        correspondentLastName: "Lamar",
-                        correspondentAddress: {
-                            addressLine1: "Flat 3",
-                            addressLine2: "Digital LPA Lane",
-                            addressLine3: "Somewhere",
-                            country: "GB",
-                            postcode: "SW1 1AA",
-                            town: "London",
-                        },
-                    },
-                },
-                "opg.poas.lpastore": {
-                    donor: {
-                        uid: "5ff557dd-1e27-4426-9681-ed6e90c2c08d",
-                        firstNames: "James",
-                        lastName: "Rubin",
-                        otherNamesKnownBy: "Somebody",
-                        dateOfBirth: "1990-02-22",
-                        address: {
-                            postcode: "B29 6BL",
-                            country: "GB",
-                            town: "Birmingham",
-                            line1: "29 Grange Road"
-                        },
-                        contactLanguagePreference: "en",
-                        email: "jrubin@mail.example"
-                    },
-                    attorneys: [
-                        {
-                            firstNames: "Esther",
-                            lastName: "Greenwood",
-                            status: "active",
-                        },
-                        {
-                            firstNames: "Rico",
-                            lastName: "Welch",
-                            status: "replacement",
-                            signedAt: "2022-12-19T09:12:59Z",
-                        },
-                    ],
-                    certificateProvider: {
-                        uid: "e4d5e24e-2a8d-434e-b815-9898620acc71",
-                        firstNames: "Timothy",
-                        lastNames: "Turner",
-                        signedAt: "2022-12-18T11:46:24Z",
-                    },
-                    signedAt: "2022-12-18T11:46:24Z",
-                    lpaType: "pw",
-                    channel: "online",
-                    registrationDate: "2022-12-18",
-                    peopleToNotify: [],
-                },
+describe("Change donor details form", () => {
+  beforeEach(() => {
+    cy.addMock("/lpa-api/v1/digital-lpas/M-0000-0000-0001", "GET", {
+      status: 200,
+      body: {
+        uId: "M-0000-0000-0001",
+        "opg.poas.sirius": {
+          id: 666,
+          uId: "M-0000-0000-0001",
+          status: "Draft",
+          caseSubtype: "personal-welfare",
+          createdDate: "31/10/2023",
+          investigationCount: 0,
+          complaintCount: 0,
+          taskCount: 0,
+          warningCount: 0,
+          donor: {
+            id: 33,
+          },
+          application: {
+            donorFirstNames: "James",
+            donorLastName: "Rubin",
+            donorDob: "22/02/1990",
+            donorEmail: "jrubin@mail.example",
+            donorPhone: "073656249524",
+            donorAddress: {
+              addressLine1: "Apartment 3",
+              country: "GB",
+              postcode: "B15 3AA",
+              town: "Birmingham",
             },
-        });
-
-
-        cy.addMock("/lpa-api/v1/cases/666", "GET", {
-            status: 200,
-            body: {
-                id: 666,
-                uId: "M-0000-0000-0001",
-                caseType: "DIGITAL_LPA",
-                donor: {
-                    id: 666,
-                },
-                status: "Draft",
+            correspondentFirstNames: "Kendrick",
+            correspondentLastName: "Lamar",
+            correspondentAddress: {
+              addressLine1: "Flat 3",
+              country: "GB",
+              postcode: "SW1 1AA",
+              town: "London",
             },
-        });
-
-        cy.addMock("/lpa-api/v1/cases/666/warnings", "GET", {
-            status: 200,
-            body: [],
-        });
-
-        cy.addMock(
-            "/lpa-api/v1/cases/666/tasks?filter=status%3ANot+started%2Cactive%3Atrue&limit=99&sort=duedate%3AASC",
-            "GET",
+          },
+        },
+        "opg.poas.lpastore": {
+          donor: {
+            uid: "5ff557dd-1e27-4426-9681-ed6e90c2c08d",
+            firstNames: "James",
+            lastName: "Rubin",
+            otherNamesKnownBy: "Somebody",
+            dateOfBirth: "1990-02-22",
+            address: {
+              line1: "Apartment 3",
+              town: "Birmingham",
+              country: "GB",
+              postcode: "B15 3AA",
+            },
+            contactLanguagePreference: "en",
+            email: "jrubin@mail.example",
+          },
+          attorneys: [
             {
-                status: 200,
-                body: {
-                    tasks: [],
-                },
+              firstNames: "Esther",
+              lastName: "Greenwood",
+              status: "active",
             },
-        );
-
-
-        cy.addMock("/lpa-api/v1/digital-lpas/M-0000-0000-0001/change-donor-details", "PUT", {
-            status: 204,
-        });
-
-        cy.visit("/change-donor-details?uid=M-0000-0000-0001");
+          ],
+          certificateProvider: {
+            uid: "e4d5e24e-2a8d-434e-b815-9898620acc71",
+            firstNames: "Timothy",
+            lastNames: "Turner",
+            signedAt: "2022-12-18T11:46:24Z",
+          },
+          signedAt: "2024-10-18T11:46:24Z",
+          lpaType: "pw",
+          channel: "online",
+          registrationDate: "2024-11-11",
+          peopleToNotify: [],
+        },
+      },
     });
 
-    it("Can edit the change donor details form", () => {
-        cy.contains("Change donor details");
-        cy.contains("Details that apply to all LPAs for this donor");
-        cy.get(".moj-banner").should("not.exist");
-
-        cy.get("#f-firstNames").clear()
-        cy.get("#f-firstNames").type("Coleen Stephanie");
-
-        cy.get("#f-lastName").clear();
-        cy.get("#f-lastName").type("Morneault");
-
-        cy.get("#f-dob-day").clear();
-        cy.get("#f-dob-month").clear();
-        cy.get("#f-dob-year").clear();
-
-        cy.get("#f-dob-day").type("8");
-        cy.get("#f-dob-month").type("4");
-        cy.get("#f-dob-year").type("1952");
-
-        cy.get("button[type=submit]").click();
-        cy.get(".moj-banner").should("exist");
+    cy.addMock("/lpa-api/v1/cases/666", "GET", {
+      status: 200,
+      body: {
+        id: 666,
+        uId: "M-0000-0000-0001",
+        caseType: "DIGITAL_LPA",
+        donor: {
+          id: 666,
+        },
+        status: "Draft",
+      },
     });
+
+    cy.addMock("/lpa-api/v1/cases/666/warnings", "GET", {
+      status: 200,
+      body: [],
+    });
+
+    cy.addMock(
+      "/lpa-api/v1/cases/666/tasks?filter=status%3ANot+started%2Cactive%3Atrue&limit=99&sort=duedate%3AASC",
+      "GET",
+      {
+        status: 200,
+        body: {
+          tasks: [],
+        },
+      },
+    );
+
+    cy.visit("/change-donor-details?uid=M-0000-0000-0001");
+  });
+
+  it("can be visited from the LPA details Change link", () => {
+    cy.visit("/lpa/M-0000-0000-0001/lpa-details").then(() => {
+      Cypress.$("span:contains('Donor')").closest("button")[0].click();
+      cy.contains("Change").click();
+      cy.contains("Details that apply to all LPAs for this donor");
+    });
+  });
+
+  it("populates donor details", () => {
+    cy.get("#f-firstNames").should("have.value", "James");
+    cy.get("#f-lastName").should("have.value", "Rubin");
+    cy.get("#f-otherNamesKnownBy").should("have.value", "Somebody");
+
+    cy.get("#f-dob-day").should("have.value", "22");
+    cy.get("#f-dob-month").should("have.value", "2");
+    cy.get("#f-dob-year").should("have.value", "1990");
+
+    cy.get("#f-address\\.Line1").should("have.value", "Apartment 3");
+    cy.get("#f-address\\.Line2").should("have.value", "");
+    cy.get("#f-address\\.Line3").should("have.value", "");
+    cy.get("#f-address\\.Town").should("have.value", "Birmingham");
+    cy.get("#f-address\\.Postcode").should("have.value", "B15 3AA");
+    cy.get("#f-address\\.Country").should("have.value", "GB");
+
+    cy.get("#f-phoneNumber").should("have.value", "073656249524");
+    cy.get("#f-email").should("have.value", "jrubin@mail.example");
+
+    cy.get("#f-lpaSignedOn-day").should("have.value", "18");
+    cy.get("#f-lpaSignedOn-month").should("have.value", "10");
+    cy.get("#f-lpaSignedOn-year").should("have.value", "2024");
+  });
+
+  it("can go Back to LPA details", () => {
+    cy.contains("Back to LPA details").click();
+    cy.url().should("contain", "/lpa/M-0000-0000-0001/lpa-details");
+  });
+
+  it("can be cancelled, returning to the LPA details", () => {
+    cy.contains("Cancel").click();
+    cy.url().should("contain", "/lpa/M-0000-0000-0001/lpa-details");
+  });
+
+  it("Can edit all donor details", () => {
+    cy.addMock(
+      "/lpa-api/v1/digital-lpas/M-0000-0000-0001/change-donor-details",
+      "PUT",
+      {
+        status: 204,
+      },
+    );
+
+    cy.get("#f-firstNames").clear();
+    cy.get("#f-firstNames").type("Jonathan");
+
+    cy.get("#f-lastName").clear();
+    cy.get("#f-lastName").type("Ruby");
+
+    cy.get("#f-otherNamesKnownBy").clear();
+    cy.get("#f-otherNamesKnownBy").type("Jim");
+
+    cy.get("#f-dob-day").clear();
+    cy.get("#f-dob-month").clear();
+    cy.get("#f-dob-year").clear();
+
+    cy.get("#f-dob-day").type("31");
+    cy.get("#f-dob-month").type("1");
+    cy.get("#f-dob-year").type("2000");
+
+    cy.get("#f-address\\.Line2").clear();
+    cy.get("#f-address\\.Line3").clear();
+    cy.get("#f-address\\.Town").clear();
+    cy.get("#f-address\\.Postcode").clear();
+
+    cy.get("#f-address\\.Line1").type("4");
+    cy.get("#f-address\\.Line2").type("Gherkin Building");
+    cy.get("#f-address\\.Line3").type("33 London Road");
+    cy.get("#f-address\\.Town").type("London");
+    cy.get("#f-address\\.Postcode").type("B29 6BL");
+
+    cy.get("#f-phoneNumber").clear();
+    cy.get("#f-phoneNumber").type("07777777777");
+
+    cy.get("#f-email").clear();
+    cy.get("#f-email").type("jimR@mail.example");
+
+    cy.get("#f-lpaSignedOn-day").clear();
+    cy.get("#f-lpaSignedOn-month").clear();
+    cy.get("#f-lpaSignedOn-year").clear();
+
+    cy.get("#f-lpaSignedOn-day").type("11");
+    cy.get("#f-lpaSignedOn-month").type("11");
+    cy.get("#f-lpaSignedOn-year").type("2023");
+
+    cy.get("button[type=submit]").click();
+    cy.get(".moj-banner").should("exist");
+
+    cy.url().should("contain", "/lpa/M-0000-0000-0001/lpa-details");
+
+    cy.contains("Donor").click();
+    //todo: Add check for new details after lpa-store changes added
+  });
 });

--- a/cypress/e2e/change-donor-details.cy.js
+++ b/cypress/e2e/change-donor-details.cy.js
@@ -111,8 +111,8 @@ describe("Change donor details form", () => {
 
   it("can be visited from the LPA details Change link", () => {
     cy.visit("/lpa/M-0000-0000-0001/lpa-details").then(() => {
-      cy.contains("Donor").click();
-      cy.contains("Change").click();
+      cy.get(".govuk-accordion__section-button").contains("Donor").click();
+      cy.get("#f-change-donor-details").click();
       cy.contains("Details that apply to all LPAs for this donor");
     });
   });

--- a/cypress/e2e/change-donor-details.cy.js
+++ b/cypress/e2e/change-donor-details.cy.js
@@ -111,7 +111,7 @@ describe("Change donor details form", () => {
 
   it("can be visited from the LPA details Change link", () => {
     cy.visit("/lpa/M-0000-0000-0001/lpa-details").then(() => {
-      Cypress.$("span:contains('Donor')").closest("button")[0].click();
+      cy.contains("Donor").click();
       cy.contains("Change").click();
       cy.contains("Details that apply to all LPAs for this donor");
     });

--- a/cypress/e2e/digital-lpa.cy.js
+++ b/cypress/e2e/digital-lpa.cy.js
@@ -59,6 +59,21 @@ describe("View a digital LPA", () => {
           ],
         },
         "opg.poas.lpastore": {
+          donor: {
+            uid: "5ff557dd-1e27-4426-9681-ed6e90c2c08d",
+            firstNames: "James",
+            lastName: "Rubin",
+            otherNamesKnownBy: "Somebody",
+            dateOfBirth: "1990-02-22",
+            address: {
+              postcode: "B29 6BL",
+              country: "GB",
+              town: "Birmingham",
+              line1: "29 Grange Road"
+            },
+            contactLanguagePreference: "en",
+            email: "jrubin@mail.example"
+          },
           attorneys: [
             {
               firstNames: "Esther",
@@ -99,6 +114,7 @@ describe("View a digital LPA", () => {
           status: "draft",
           registrationDate: "2022-12-18",
           peopleToNotify: [],
+          signedAt: "2022-12-18T11:46:24Z",
         },
       },
     });
@@ -484,6 +500,46 @@ describe("View a digital LPA", () => {
     cy.visit("/lpa/M-DIGI-LPA3-3333/lpa-details").then(() => {
       Cypress.$("span:contains('Donor')").closest("button")[0].click();
       cy.contains("Online");
+    });
+  });
+
+  it("can go to change link for donor", () => {
+
+    cy.addMock("/lpa-api/v1/digital-lpas/M-DIGI-LPA3-3333/change-donor-details", "PUT", {
+      status: 204,
+    });
+
+    cy.visit("/lpa/M-DIGI-LPA3-3333/lpa-details").then(() => {
+      Cypress.$("span:contains('Donor')").closest("button")[0].click();
+      cy.contains("Online");
+      cy.contains("Change").click();
+
+      cy.get("#f-firstNames").clear()
+      cy.get("#f-firstNames").type("Coleen Stephanie");
+
+      cy.get("#f-lastName").clear();
+      cy.get("#f-lastName").type("Morneault");
+
+      cy.get("#f-dob-day").clear();
+      cy.get("#f-dob-month").clear();
+      cy.get("#f-dob-year").clear();
+
+      cy.get("#f-dob-day").type("8");
+      cy.get("#f-dob-month").type("4");
+      cy.get("#f-dob-year").type("1952");
+
+      cy.get("button[type=submit]").click();
+      cy.get(".moj-banner").should("exist");
+    });
+  });
+
+  it("can go to change link for donor and go back", () => {
+    cy.visit("/lpa/M-DIGI-LPA3-3333/lpa-details").then(() => {
+      Cypress.$("span:contains('Donor')").closest("button")[0].click();
+      cy.contains("Online");
+      cy.contains("Change").click();
+      cy.contains("Back to LPA details").click();
+      cy.url().should("contain", "/lpa/M-DIGI-LPA3-3333/lpa-details");
     });
   });
 

--- a/cypress/e2e/digital-lpa.cy.js
+++ b/cypress/e2e/digital-lpa.cy.js
@@ -59,21 +59,6 @@ describe("View a digital LPA", () => {
           ],
         },
         "opg.poas.lpastore": {
-          donor: {
-            uid: "5ff557dd-1e27-4426-9681-ed6e90c2c08d",
-            firstNames: "James",
-            lastName: "Rubin",
-            otherNamesKnownBy: "Somebody",
-            dateOfBirth: "1990-02-22",
-            address: {
-              postcode: "B29 6BL",
-              country: "GB",
-              town: "Birmingham",
-              line1: "29 Grange Road"
-            },
-            contactLanguagePreference: "en",
-            email: "jrubin@mail.example"
-          },
           attorneys: [
             {
               firstNames: "Esther",
@@ -114,7 +99,6 @@ describe("View a digital LPA", () => {
           status: "draft",
           registrationDate: "2022-12-18",
           peopleToNotify: [],
-          signedAt: "2022-12-18T11:46:24Z",
         },
       },
     });
@@ -500,46 +484,6 @@ describe("View a digital LPA", () => {
     cy.visit("/lpa/M-DIGI-LPA3-3333/lpa-details").then(() => {
       Cypress.$("span:contains('Donor')").closest("button")[0].click();
       cy.contains("Online");
-    });
-  });
-
-  it("can go to change link for donor", () => {
-
-    cy.addMock("/lpa-api/v1/digital-lpas/M-DIGI-LPA3-3333/change-donor-details", "PUT", {
-      status: 204,
-    });
-
-    cy.visit("/lpa/M-DIGI-LPA3-3333/lpa-details").then(() => {
-      Cypress.$("span:contains('Donor')").closest("button")[0].click();
-      cy.contains("Online");
-      cy.contains("Change").click();
-
-      cy.get("#f-firstNames").clear()
-      cy.get("#f-firstNames").type("Coleen Stephanie");
-
-      cy.get("#f-lastName").clear();
-      cy.get("#f-lastName").type("Morneault");
-
-      cy.get("#f-dob-day").clear();
-      cy.get("#f-dob-month").clear();
-      cy.get("#f-dob-year").clear();
-
-      cy.get("#f-dob-day").type("8");
-      cy.get("#f-dob-month").type("4");
-      cy.get("#f-dob-year").type("1952");
-
-      cy.get("button[type=submit]").click();
-      cy.get(".moj-banner").should("exist");
-    });
-  });
-
-  it("can go to change link for donor and go back", () => {
-    cy.visit("/lpa/M-DIGI-LPA3-3333/lpa-details").then(() => {
-      Cypress.$("span:contains('Donor')").closest("button")[0].click();
-      cy.contains("Online");
-      cy.contains("Change").click();
-      cy.contains("Back to LPA details").click();
-      cy.url().should("contain", "/lpa/M-DIGI-LPA3-3333/lpa-details");
     });
   });
 

--- a/internal/server/change_donor_details.go
+++ b/internal/server/change_donor_details.go
@@ -49,17 +49,17 @@ func parseDate(dateString string) dob {
 	}
 }
 
-func parseDateTime(dateTimeString string) dob {
+func parseDateTime(dateTimeString string) (dob, error) {
 	parsedTime, err := time.Parse(time.RFC3339, dateTimeString) // Parse ISO 8601 date-time
 	if err != nil {
-		return dob{}
+		return dob{}, err
 	}
 
 	return dob{
 		Day:   parsedTime.Day(),
 		Month: int(parsedTime.Month()),
 		Year:  parsedTime.Year(),
-	}
+	}, nil
 }
 
 func ChangeDonorDetails(client ChangeDonorDetailsClient, tmpl template.Template) Handler {
@@ -80,7 +80,10 @@ func ChangeDonorDetails(client ChangeDonorDetailsClient, tmpl template.Template)
 		lpaStore := cs.DigitalLpa.LpaStoreData
 		donorDob := parseDate(lpaStore.Donor.DateOfBirth)
 
-		signedAt := parseDateTime(lpaStore.SignedAt)
+		signedAt, err := parseDateTime(lpaStore.SignedAt)
+		if err != nil {
+			return err
+		}
 
 		data := changeDonorDetailsData{
 			XSRFToken: ctx.XSRFToken,

--- a/internal/server/change_donor_details.go
+++ b/internal/server/change_donor_details.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"fmt"
+	"github.com/go-playground/form/v4"
+	"github.com/ministryofjustice/opg-go-common/template"
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"golang.org/x/sync/errgroup"
+	"net/http"
+)
+
+type ChangeDonorDetailsClient interface {
+	CaseSummary(sirius.Context, string) (sirius.CaseSummary, error)
+	ChangeDonorDetails(sirius.Context, string, sirius.ChangeDonorDetailsData) error
+	GetUserDetails(ctx sirius.Context) (sirius.User, error)
+	RefDataByCategory(ctx sirius.Context, category string) ([]sirius.RefDataItem, error)
+}
+
+type ChangeDonorDetailsData struct {
+	XSRFToken string
+	Countries []sirius.RefDataItem
+	Entity    string
+	Success   bool
+	Error     sirius.ValidationError
+	CaseUID   string
+	Form      formDonorDetails
+}
+
+type formDonorDetails struct {
+	FirstNames        string         `form:"firstNames"`
+	LastName          string         `form:"lastName"`
+	OtherNamesKnownBy string         `form:"otherNamesKnownBy"`
+	DateOfBirth       dob            `form:"dob"`
+	Address           sirius.Address `form:"address"`
+	PhoneNumber       string         `form:"phoneNumber"`
+	Email             string         `form:"email"`
+	LpaSignedOn       dob            `form:"lpaSignedOn"`
+}
+
+func ChangeDonorDetails(client ChangeDonorDetailsClient, tmpl template.Template) Handler {
+	if decoder == nil {
+		decoder = form.NewDecoder()
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) error {
+		caseUID := r.FormValue("uid")
+
+		ctx := getContext(r)
+
+		cs, err := client.CaseSummary(ctx, caseUID)
+		if err != nil {
+			return err
+		}
+
+		group, groupCtx := errgroup.WithContext(ctx.Context)
+
+		data := ChangeDonorDetailsData{
+			XSRFToken: ctx.XSRFToken,
+			Entity:    fmt.Sprintf("%s %s", cs.DigitalLpa.SiriusData.Subtype, caseUID),
+			CaseUID:   caseUID,
+		}
+
+		group.Go(func() error {
+			var err error
+			data.Countries, err = client.RefDataByCategory(ctx.With(groupCtx), sirius.CountryCategory)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+
+		if err := group.Wait(); err != nil {
+			return err
+		}
+
+		if r.Method == http.MethodPost {
+			err := decoder.Decode(&data.Form, r.PostForm)
+			if err != nil {
+				return err
+			}
+
+			donorDetailsData := sirius.ChangeDonorDetailsData{
+				FirstNames:        data.Form.FirstNames,
+				LastName:          data.Form.LastName,
+				OtherNamesKnownBy: data.Form.OtherNamesKnownBy,
+				DateOfBirth:       data.Form.DateOfBirth.toDateString(),
+				Address:           data.Form.Address,
+				Phone:             data.Form.PhoneNumber,
+				Email:             data.Form.Email,
+				LpaSignedOn:       data.Form.LpaSignedOn.toDateString(),
+			}
+
+			err = client.ChangeDonorDetails(ctx, caseUID, donorDetailsData)
+
+			if ve, ok := err.(sirius.ValidationError); ok {
+				w.WriteHeader(http.StatusBadRequest)
+				data.Error = ve
+			} else if err != nil {
+				return err
+			} else {
+				data.Success = true
+
+				return RedirectError(fmt.Sprintf("/lpa/%s/lpa-details", caseUID))
+			}
+		}
+
+		return tmpl(w, data)
+	}
+}

--- a/internal/server/change_donor_details.go
+++ b/internal/server/change_donor_details.go
@@ -36,17 +36,17 @@ type formDonorDetails struct {
 	LpaSignedOn       dob            `form:"lpaSignedOn"`
 }
 
-func parseDate(dateString string) dob {
+func parseDate(dateString string) (dob, error) {
 	parsedTime, err := time.Parse("2006-01-02", dateString) // Parses date in "YYYY-MM-DD" format
 	if err != nil {
-		return dob{}
+		return dob{}, err
 	}
 
 	return dob{
 		Day:   parsedTime.Day(),
 		Month: int(parsedTime.Month()),
 		Year:  parsedTime.Year(),
-	}
+	}, nil
 }
 
 func parseDateTime(dateTimeString string) (dob, error) {
@@ -78,7 +78,10 @@ func ChangeDonorDetails(client ChangeDonorDetailsClient, tmpl template.Template)
 		}
 
 		lpaStore := cs.DigitalLpa.LpaStoreData
-		donorDob := parseDate(lpaStore.Donor.DateOfBirth)
+		donorDob, err := parseDate(lpaStore.Donor.DateOfBirth)
+		if err != nil {
+			return err
+		}
 
 		signedAt, err := parseDateTime(lpaStore.SignedAt)
 		if err != nil {

--- a/internal/server/change_donor_details.go
+++ b/internal/server/change_donor_details.go
@@ -101,6 +101,10 @@ func ChangeDonorDetails(client ChangeDonorDetailsClient, tmpl template.Template)
 			} else {
 				data.Success = true
 
+				SetFlash(w, FlashNotification{
+					Title: "Changes confirmed",
+				})
+
 				return RedirectError(fmt.Sprintf("/lpa/%s/lpa-details", caseUID))
 			}
 		}

--- a/internal/server/change_donor_details_test.go
+++ b/internal/server/change_donor_details_test.go
@@ -1,0 +1,303 @@
+package server
+
+import (
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+type mockChangeDonorDetailsClient struct {
+	mock.Mock
+}
+
+func (m *mockChangeDonorDetailsClient) CaseSummary(ctx sirius.Context, uid string) (sirius.CaseSummary, error) {
+	args := m.Called(ctx, uid)
+	return args.Get(0).(sirius.CaseSummary), args.Error(1)
+}
+
+func (m *mockChangeDonorDetailsClient) ChangeDonorDetails(ctx sirius.Context, caseUID string, donorDetailsData sirius.ChangeDonorDetails) error {
+	return m.Called(ctx, caseUID, donorDetailsData).Error(0)
+
+}
+
+func (m *mockChangeDonorDetailsClient) RefDataByCategory(ctx sirius.Context, category string) ([]sirius.RefDataItem, error) {
+	args := m.Called(ctx, category)
+	if args.Get(0) != nil {
+		return args.Get(0).([]sirius.RefDataItem), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+var testCaseSummary = sirius.CaseSummary{
+	DigitalLpa: sirius.DigitalLpa{
+		UID: "M-AAAA-1111-BBBB",
+		SiriusData: sirius.SiriusData{
+			ID: 15,
+			Application: sirius.Draft{
+				DonorFirstNames: "Zackary",
+				DonorLastName:   "Lemmonds",
+				DonorAddress: sirius.Address{
+					Line1:    "9 Mount Pleasant Drive",
+					Town:     "East Harling",
+					Postcode: "NR16 2GB",
+					Country:  "UK",
+				},
+				PhoneNumber: "1234567890",
+			},
+		},
+		LpaStoreData: sirius.LpaStoreData{
+			Donor: sirius.LpaStoreDonor{
+				LpaStorePerson: sirius.LpaStorePerson{
+					Uid:        "302b05c7-896c-4290-904e-2005e4f1e81e",
+					FirstNames: "Zackary",
+					LastName:   "Lemmonds",
+					Address: sirius.LpaStoreAddress{
+						Line1:    "9 Mount Pleasant Drive",
+						Town:     "East Harling",
+						Postcode: "NR16 2GB",
+						Country:  "UK",
+					},
+				},
+				DateOfBirth: "1965-04-18",
+			},
+		},
+	},
+}
+
+func TestGetChangeDonorDetails(t *testing.T) {
+	client := &mockChangeDonorDetailsClient{}
+	client.
+		On("CaseSummary", mock.Anything, "M-AAAA-1111-BBBB").
+		Return(testCaseSummary, nil)
+	client.
+		On("RefDataByCategory", mock.Anything, sirius.CountryCategory).
+		Return([]sirius.RefDataItem{{Handle: "GB", Label: "Great Britain"}}, nil)
+
+	template := &mockTemplate{}
+	template.
+		On("Func", mock.Anything,
+			changeDonorDetailsData{
+				Countries: []sirius.RefDataItem{{Handle: "GB", Label: "Great Britain"}},
+				CaseUID:   "M-AAAA-1111-BBBB",
+				Form: formDonorDetails{
+					FirstNames:        "Zackary",
+					LastName:          "Lemmonds",
+					OtherNamesKnownBy: "",
+					DateOfBirth:       dob{Day: 18, Month: 4, Year: 1965},
+					Address: sirius.Address{
+						Line1:    "9 Mount Pleasant Drive",
+						Town:     "East Harling",
+						Postcode: "NR16 2GB",
+						Country:  "UK",
+					},
+					PhoneNumber: "1234567890",
+					LpaSignedOn: dob{},
+				},
+			}).
+		Return(nil)
+
+	r, _ := http.NewRequest(http.MethodGet, "/change-donor-details/?uid=M-AAAA-1111-BBBB", nil)
+	w := httptest.NewRecorder()
+
+	err := ChangeDonorDetails(client, template.Func)(w, r)
+	resp := w.Result()
+
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mock.AssertExpectationsForObjects(t, client, template)
+}
+
+func TestGetChangeDonorDetailsWhenCaseSummaryErrors(t *testing.T) {
+
+	client := &mockChangeDonorDetailsClient{}
+	client.
+		On("CaseSummary", mock.Anything, "M-EEEE-EEEE-EEEE").
+		Return(sirius.CaseSummary{}, expectedError)
+
+	assertChangeDonorDetailsErrors(t, client, "M-EEEE-EEEE-EEEE", expectedError)
+}
+
+func TestGetChangeDonorDetailsWhenRefDataByCategoryErrors(t *testing.T) {
+	client := &mockChangeDonorDetailsClient{}
+	client.
+		On("CaseSummary", mock.Anything, "M-AAAA-1111-BBBB").
+		Return(testCaseSummary, nil)
+	client.
+		On("RefDataByCategory", mock.Anything, sirius.CountryCategory).
+		Return([]sirius.RefDataItem{}, expectedError)
+
+	assertChangeDonorDetailsErrors(t, client, "M-AAAA-1111-BBBB", expectedError)
+}
+
+func assertChangeDonorDetailsErrors(t *testing.T, client *mockChangeDonorDetailsClient, uid string, expectedError error) {
+	r, _ := http.NewRequest(http.MethodGet, "/change-donor-details/?uid="+uid, nil)
+	w := httptest.NewRecorder()
+
+	err := ChangeDonorDetails(client, nil)(w, r)
+
+	assert.Equal(t, expectedError, err)
+	mock.AssertExpectationsForObjects(t, client)
+}
+
+func TestGetChangeDonorDetailsWhenTemplateErrors(t *testing.T) {
+	client := &mockChangeDonorDetailsClient{}
+	client.
+		On("CaseSummary", mock.Anything, "M-AAAA-1111-BBBB").
+		Return(testCaseSummary, nil)
+	client.
+		On("RefDataByCategory", mock.Anything, sirius.CountryCategory).
+		Return([]sirius.RefDataItem{{Handle: "GB", Label: "Great Britain"}}, nil)
+
+	template := &mockTemplate{}
+	template.
+		On("Func", mock.Anything,
+			changeDonorDetailsData{
+				Countries: []sirius.RefDataItem{{Handle: "GB", Label: "Great Britain"}},
+				CaseUID:   "M-AAAA-1111-BBBB",
+				Form: formDonorDetails{
+					FirstNames:        "Zackary",
+					LastName:          "Lemmonds",
+					OtherNamesKnownBy: "",
+					DateOfBirth:       dob{Day: 18, Month: 4, Year: 1965},
+					Address: sirius.Address{
+						Line1:    "9 Mount Pleasant Drive",
+						Town:     "East Harling",
+						Postcode: "NR16 2GB",
+						Country:  "UK",
+					},
+					PhoneNumber: "1234567890",
+					LpaSignedOn: dob{},
+				},
+			}).
+		Return(expectedError)
+
+	r, _ := http.NewRequest(http.MethodGet, "/change-donor-details/?uid=M-AAAA-1111-BBBB", nil)
+	w := httptest.NewRecorder()
+
+	err := ChangeDonorDetails(client, template.Func)(w, r)
+
+	assert.Equal(t, expectedError, err)
+	mock.AssertExpectationsForObjects(t, client, template)
+}
+
+func TestPostChangeDonorDetails(t *testing.T) {
+	client := &mockChangeDonorDetailsClient{}
+	client.
+		On("CaseSummary", mock.Anything, "M-AAAA-1111-BBBB").
+		Return(testCaseSummary, nil)
+	client.
+		On("RefDataByCategory", mock.Anything, sirius.CountryCategory).
+		Return([]sirius.RefDataItem{{Handle: "GB", Label: "Great Britain"}}, nil)
+	client.
+		On("ChangeDonorDetails", mock.Anything, "M-AAAA-1111-BBBB", sirius.ChangeDonorDetails{
+			FirstNames:        "Samuel",
+			LastName:          "Smith",
+			OtherNamesKnownBy: "Sam",
+			DateOfBirth:       "1991-01-01",
+			Address: sirius.Address{
+				Line1:    "9 Mount",
+				Line2:    "Pleasant Drive",
+				Line3:    "Norwich",
+				Town:     "East Harling",
+				Postcode: "NR16 2GB",
+				Country:  "GB",
+			},
+			Phone:       "",
+			Email:       "test@test.com",
+			LpaSignedOn: "",
+		}).
+		Return(nil)
+
+	template := &mockTemplate{}
+
+	form := url.Values{
+		"firstNames":        {"Samuel"},
+		"lastName":          {"Smith"},
+		"otherNamesKnownBy": {"Sam"},
+		"dob.day":           {"1"},
+		"dob.month":         {"1"},
+		"dob.year":          {"1991"},
+		"address.Line1":     {"9 Mount"},
+		"address.Line2":     {"Pleasant Drive"},
+		"address.Line3":     {"Norwich"},
+		"address.Town":      {"East Harling"},
+		"address.Postcode":  {"NR16 2GB"},
+		"address.Country":   {"GB"},
+		"phoneNumber":       {""},
+		"email":             {"test@test.com"},
+		"lpaSignedOn":       {""},
+	}
+
+	r, _ := http.NewRequest(http.MethodPost, "/change-donor-details/?uid=M-AAAA-1111-BBBB", strings.NewReader(form.Encode()))
+	r.Header.Add("Content-Type", formUrlEncoded)
+	w := httptest.NewRecorder()
+
+	err := ChangeDonorDetails(client, template.Func)(w, r)
+	resp := w.Result()
+
+	assert.Equal(t, RedirectError("/lpa/M-AAAA-1111-BBBB/lpa-details"), err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mock.AssertExpectationsForObjects(t, client, template)
+}
+
+func TestPostChangeDonorDetailsWhenAPIFails(t *testing.T) {
+	client := &mockChangeDonorDetailsClient{}
+	client.
+		On("CaseSummary", mock.Anything, "M-AAAA-1111-BBBB").
+		Return(testCaseSummary, nil)
+	client.
+		On("RefDataByCategory", mock.Anything, sirius.CountryCategory).
+		Return([]sirius.RefDataItem{{Handle: "GB", Label: "Great Britain"}}, nil)
+	client.
+		On("ChangeDonorDetails", mock.Anything, "M-AAAA-1111-BBBB", sirius.ChangeDonorDetails{
+			FirstNames:        "Samuel",
+			LastName:          "Smith",
+			OtherNamesKnownBy: "Sam",
+			DateOfBirth:       "1991-01-01",
+			Address: sirius.Address{
+				Line1:    "9 Mount",
+				Line2:    "Pleasant Drive",
+				Line3:    "Norwich",
+				Town:     "East Harling",
+				Postcode: "NR16 2GB",
+				Country:  "GB",
+			},
+			Phone:       "",
+			Email:       "test@test.com",
+			LpaSignedOn: "",
+		}).
+		Return(expectedError)
+
+	template := &mockTemplate{}
+
+	form := url.Values{
+		"firstNames":        {"Samuel"},
+		"lastName":          {"Smith"},
+		"otherNamesKnownBy": {"Sam"},
+		"dob.day":           {"1"},
+		"dob.month":         {"1"},
+		"dob.year":          {"1991"},
+		"address.Line1":     {"9 Mount"},
+		"address.Line2":     {"Pleasant Drive"},
+		"address.Line3":     {"Norwich"},
+		"address.Town":      {"East Harling"},
+		"address.Postcode":  {"NR16 2GB"},
+		"address.Country":   {"GB"},
+		"phoneNumber":       {""},
+		"email":             {"test@test.com"},
+		"lpaSignedOn":       {""},
+	}
+
+	r, _ := http.NewRequest(http.MethodPost, "/change-donor-details/?uid=M-AAAA-1111-BBBB", strings.NewReader(form.Encode()))
+	r.Header.Add("Content-Type", formUrlEncoded)
+	w := httptest.NewRecorder()
+
+	err := ChangeDonorDetails(client, template.Func)(w, r)
+	assert.Equal(t, expectedError, err)
+	mock.AssertExpectationsForObjects(t, client, template)
+}

--- a/internal/server/change_donor_details_test.go
+++ b/internal/server/change_donor_details_test.go
@@ -65,6 +65,7 @@ var testCaseSummary = sirius.CaseSummary{
 				},
 				DateOfBirth: "1965-04-18",
 			},
+			SignedAt: "2024-02-11T15:04:05Z",
 		},
 	},
 }
@@ -96,7 +97,7 @@ func TestGetChangeDonorDetails(t *testing.T) {
 						Country:  "UK",
 					},
 					PhoneNumber: "1234567890",
-					LpaSignedOn: dob{},
+					LpaSignedOn: dob{11, 2, 2024},
 				},
 			}).
 		Return(nil)
@@ -171,7 +172,7 @@ func TestGetChangeDonorDetailsWhenTemplateErrors(t *testing.T) {
 						Country:  "UK",
 					},
 					PhoneNumber: "1234567890",
-					LpaSignedOn: dob{},
+					LpaSignedOn: dob{11, 2, 2024},
 				},
 			}).
 		Return(expectedError)
@@ -209,7 +210,7 @@ func TestPostChangeDonorDetails(t *testing.T) {
 			},
 			Phone:       "",
 			Email:       "test@test.com",
-			LpaSignedOn: "",
+			LpaSignedOn: "2024-10-09",
 		}).
 		Return(nil)
 
@@ -230,7 +231,9 @@ func TestPostChangeDonorDetails(t *testing.T) {
 		"address.Country":   {"GB"},
 		"phoneNumber":       {""},
 		"email":             {"test@test.com"},
-		"lpaSignedOn":       {""},
+		"lpaSignedOn.day":   {"9"},
+		"lpaSignedOn.month": {"10"},
+		"lpaSignedOn.year":  {"2024"},
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/change-donor-details/?uid=M-AAAA-1111-BBBB", strings.NewReader(form.Encode()))
@@ -269,7 +272,7 @@ func TestPostChangeDonorDetailsWhenAPIFails(t *testing.T) {
 			},
 			Phone:       "",
 			Email:       "test@test.com",
-			LpaSignedOn: "",
+			LpaSignedOn: "2024-10-09",
 		}).
 		Return(expectedError)
 
@@ -290,7 +293,9 @@ func TestPostChangeDonorDetailsWhenAPIFails(t *testing.T) {
 		"address.Country":   {"GB"},
 		"phoneNumber":       {""},
 		"email":             {"test@test.com"},
-		"lpaSignedOn":       {""},
+		"lpaSignedOn.day":   {"9"},
+		"lpaSignedOn.month": {"10"},
+		"lpaSignedOn.year":  {"2024"},
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/change-donor-details/?uid=M-AAAA-1111-BBBB", strings.NewReader(form.Encode()))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -50,6 +50,7 @@ type Client interface {
 	AllocateCasesClient
 	AssignTaskClient
 	ApplyFeeReductionClient
+	ChangeDonorDetailsClient
 	ChangeStatusClient
 	ChangeCaseStatusClient
 	ClearTaskClient
@@ -98,6 +99,7 @@ func New(logger *slog.Logger, client Client, templates template.Templates, prefi
 	mux.Handle("/", http.NotFoundHandler())
 	mux.HandleFunc("/health-check", func(w http.ResponseWriter, r *http.Request) {})
 
+	mux.Handle("/change-donor-details", wrap(ChangeDonorDetails(client, templates.Get("change-donor-details.gohtml"))))
 	mux.Handle("/create-warning", wrap(Warning(client, templates.Get("warning.gohtml"))))
 	mux.Handle("/create-event", wrap(Event(client, templates.Get("event.gohtml"))))
 	mux.Handle("/create-task", wrap(Task(client, templates.Get("task.gohtml"))))

--- a/internal/sirius/change_donor_details.go
+++ b/internal/sirius/change_donor_details.go
@@ -1,0 +1,51 @@
+package sirius
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type ChangeDonorDetailsData struct {
+	FirstNames        string     `json:"firstNames"`
+	LastName          string     `json:"lastName"`
+	OtherNamesKnownBy string     `json:"otherNamesKnownBy"`
+	DateOfBirth       DateString `json:"dateOfBirth"`
+	Address           Address    `json:"address"`
+	Phone             string     `json:"phoneNumber"`
+	Email             string     `json:"email"`
+	LpaSignedOn       DateString `json:"lpaSignedOn"`
+}
+
+func (c *Client) ChangeDonorDetails(ctx Context, caseUID string, donorDetails ChangeDonorDetailsData) error {
+	data, err := json.Marshal(donorDetails)
+	if err != nil {
+		return err
+	}
+
+	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/change-donor-details", caseUID), bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusBadRequest {
+		var v ValidationError
+		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+			return err
+		}
+		return v
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		return newStatusError(resp)
+	}
+
+	return nil
+}

--- a/internal/sirius/change_donor_details.go
+++ b/internal/sirius/change_donor_details.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 )
 
-type ChangeDonorDetailsData struct {
+type ChangeDonorDetails struct {
 	FirstNames        string     `json:"firstNames"`
 	LastName          string     `json:"lastName"`
 	OtherNamesKnownBy string     `json:"otherNamesKnownBy"`
@@ -18,7 +18,7 @@ type ChangeDonorDetailsData struct {
 	LpaSignedOn       DateString `json:"lpaSignedOn"`
 }
 
-func (c *Client) ChangeDonorDetails(ctx Context, caseUID string, donorDetails ChangeDonorDetailsData) error {
+func (c *Client) ChangeDonorDetails(ctx Context, caseUID string, donorDetails ChangeDonorDetails) error {
 	data, err := json.Marshal(donorDetails)
 	if err != nil {
 		return err

--- a/internal/sirius/change_donor_details_test.go
+++ b/internal/sirius/change_donor_details_test.go
@@ -29,7 +29,9 @@ func TestChangeDonorDetails(t *testing.T) {
 				OtherNamesKnownBy: "Jack",
 				DateOfBirth:       "2000-11-12",
 				Address: Address{
-					Line1:    "Fluke House",
+					Line1:    "Flat Number",
+					Line2:    "Building",
+					Line3:    "Road Name",
 					Town:     "South Bend",
 					Postcode: "AI1 6VW",
 					Country:  "GB",
@@ -41,7 +43,7 @@ func TestChangeDonorDetails(t *testing.T) {
 			setup: func() {
 				pact.
 					AddInteraction().
-					Given("A donor with a digital LPA exists").
+					Given("A digital LPA exists").
 					UponReceiving("A request for changing donor details").
 					WithRequest(dsl.Request{
 						Method: http.MethodPut,
@@ -55,7 +57,9 @@ func TestChangeDonorDetails(t *testing.T) {
 							"otherNamesKnownBy": "Jack",
 							"dateOfBirth":       "12/11/2000",
 							"address": map[string]string{
-								"addressLine1": "Fluke House",
+								"addressLine1": "Flat Number",
+								"addressLine2": "Building",
+								"addressLine3": "Road Name",
 								"town":         "South Bend",
 								"postcode":     "AI1 6VW",
 								"country":      "GB",
@@ -66,8 +70,7 @@ func TestChangeDonorDetails(t *testing.T) {
 						},
 					}).
 					WillRespondWith(dsl.Response{
-						Status:  http.StatusNoContent,
-						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+						Status: http.StatusNoContent,
 					})
 			},
 		},

--- a/internal/sirius/change_donor_details_test.go
+++ b/internal/sirius/change_donor_details_test.go
@@ -1,0 +1,94 @@
+package sirius
+
+import (
+	"context"
+	"fmt"
+	"github.com/pact-foundation/pact-go/dsl"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestChangeDonorDetails(t *testing.T) {
+	t.Parallel()
+
+	pact := newPact()
+	defer pact.Teardown()
+
+	testCases := []struct {
+		name          string
+		changeData    ChangeDonorDetails
+		setup         func()
+		expectedError func(int) error
+	}{
+		{
+			name: "OK",
+			changeData: ChangeDonorDetails{
+				FirstNames:        "Jake",
+				LastName:          "Sullivan",
+				OtherNamesKnownBy: "Jack",
+				DateOfBirth:       "2000-11-12",
+				Address: Address{
+					Line1:    "Fluke House",
+					Town:     "South Bend",
+					Postcode: "AI1 6VW",
+					Country:  "GB",
+				},
+				Phone:       "12345678",
+				Email:       "test@test.com",
+				LpaSignedOn: "2024-10-01",
+			},
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("A donor with a digital LPA exists").
+					UponReceiving("A request for changing donor details").
+					WithRequest(dsl.Request{
+						Method: http.MethodPut,
+						Path:   dsl.String("/lpa-api/v1/digital-lpas/M-1234-9876-4567/change-donor-details"),
+						Headers: dsl.MapMatcher{
+							"Content-Type": dsl.String("application/json"),
+						},
+						Body: map[string]interface{}{
+							"firstNames":        "Jake",
+							"lastName":          "Sullivan",
+							"otherNamesKnownBy": "Jack",
+							"dateOfBirth":       "12/11/2000",
+							"address": map[string]string{
+								"addressLine1": "Fluke House",
+								"town":         "South Bend",
+								"postcode":     "AI1 6VW",
+								"country":      "GB",
+							},
+							"phoneNumber": "12345678",
+							"email":       "test@test.com",
+							"lpaSignedOn": "01/10/2024",
+						},
+					}).
+					WillRespondWith(dsl.Response{
+						Status:  http.StatusNoContent,
+						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+					})
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+
+			assert.Nil(t, pact.Verify(func() error {
+				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
+
+				err := client.ChangeDonorDetails(Context{Context: context.Background()}, "M-1234-9876-4567", tc.changeData)
+
+				if tc.expectedError == nil {
+					assert.Nil(t, err)
+				} else {
+					assert.Equal(t, tc.expectedError(pact.Server.Port), err)
+				}
+				return nil
+			}))
+		})
+	}
+}

--- a/web/template/change-donor-details.gohtml
+++ b/web/template/change-donor-details.gohtml
@@ -1,6 +1,6 @@
 {{ template "page" . }}
 
-{{ define "title" }}Manage fees{{ end }}
+{{ define "title" }}Change donor details{{ end }}
 
 {{ define "main" }}
     <div class="govuk-grid-row">

--- a/web/template/change-donor-details.gohtml
+++ b/web/template/change-donor-details.gohtml
@@ -1,0 +1,55 @@
+{{ template "page" . }}
+
+{{ define "title" }}Manage fees{{ end }}
+
+{{ define "main" }}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+            <a href="{{ prefix (printf "/lpa/%s/lpa-details" .CaseUID )}}" class="govuk-back-link">Back to LPA details</a>
+
+            {{ template "error-summary" .Error }}
+
+            {{ if .Success }}
+                <meta data-app-reload="page" />
+                {{ template "success-banner" "You have changed donor details." }}
+            {{ end }}
+
+            <h1 class="govuk-heading-l app-!-embedded-hide">
+                Change donor details
+            </h1>
+
+            <p class="govuk-body govuk-!-font-weight-bold">
+                Details that apply to all LPAs for this donor
+            </p>
+
+            <form class="form" method="POST">
+                <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
+
+                {{ template "input" (field "firstNames" "Donor’s first names" .Form.FirstNames .Error.Field.FirstNames) }}
+                {{ template "input" (field "lastName" "Donor’s last name" .Form.LastName .Error.Field.LastName) }}
+                {{ template "input" (field "otherNamesKnownBy" "Otherwise known as" .Form.OtherNamesKnownBy .Error.Field.OtherNamesKnownBy) }}
+                {{ template "date" (field "dob" "Date of birth" .Form.DateOfBirth .Error.Field.DateOfBirth) }}
+
+                <div class="govuk-form-group {{ if .Error.Field.Address }}govuk-form-group--error{{ end }}" data-app-address-finder-label="Donor's address">
+                    {{ template "input" (field "address.Line1" "Address line 1" .Form.Address.Line1 (index .Error.Field "address/addressLine1") "data-app-address-finder-map" "addressLine1") }}
+                    {{ template "input" (field "address.Line2" "Address line 2 (optional)" .Form.Address.Line2 (index .Error.Field "address/addressLine2") "data-app-address-finder-map" "addressLine2") }}
+                    {{ template "input" (field "address.Line3" "Address line 3 (optional)" .Form.Address.Line3 (index .Error.Field "address/addressLine3") "data-app-address-finder-map" "addressLine3") }}
+                    {{ template "input" (field "address.Town" "Town or city" .Form.Address.Town (index .Error.Field "address/town") "data-app-address-finder-map" "town" "class" "govuk-!-width-two-thirds") }}
+                    {{ template "input" (field "address.Postcode" "Postcode" .Form.Address.Postcode (index .Error.Field "address/postcode") "data-app-address-finder-map" "postcode" "class" "govuk-!-width-two-thirds") }}
+                    {{ template "select" (select "address.Country" "Country" .Form.Address.Country (index .Error.Field "address/country") (options .Countries) "data-app-address-finder-map" "country") }}
+                </div>
+
+                {{ template "input" (field "phoneNumber" "Donor’s phone number (optional)" .Form.PhoneNumber .Error.Field.PhoneNumber) }}
+                {{ template "input" (field "email" "Donor’s email address (optional)" .Form.Email .Error.Field.Email) }}
+                {{ template "date" (field "lpaSignedOn" "LPA signed on" .Form.LpaSignedOn .Error.Field.LpaSignedOn) }}
+
+                <div class="govuk-button-group">
+                    <button class="govuk-button" data-module="govuk-button" type="submit">Save and continue</button><br/>
+                    <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/lpa/%s/lpa-details" .CaseUID )}}">Cancel</a>
+                </div>
+
+            </form>
+        </div>
+    </div>
+{{ end }}

--- a/web/template/change-donor-details.gohtml
+++ b/web/template/change-donor-details.gohtml
@@ -28,7 +28,7 @@
 
                 {{ template "input" (field "firstNames" "Donor’s first names" .Form.FirstNames .Error.Field.FirstNames) }}
                 {{ template "input" (field "lastName" "Donor’s last name" .Form.LastName .Error.Field.LastName) }}
-                {{ template "input" (field "otherNamesKnownBy" "Otherwise known as" .Form.OtherNamesKnownBy .Error.Field.OtherNamesKnownBy) }}
+                {{ template "input" (field "otherNamesKnownBy" "Otherwise known as (optional)" .Form.OtherNamesKnownBy .Error.Field.OtherNamesKnownBy) }}
                 {{ template "date" (field "dob" "Date of birth" .Form.DateOfBirth .Error.Field.DateOfBirth) }}
 
                 <div class="govuk-form-group {{ if .Error.Field.Address }}govuk-form-group--error{{ end }}" data-app-address-finder-label="Donor's address">

--- a/web/template/create_additional_draft.gohtml
+++ b/web/template/create_additional_draft.gohtml
@@ -52,6 +52,8 @@
 				<form class="form" method="POST">
 					<input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
 
+
+
 					<div class="govuk-form-group {{ if .Error.Field.types }}govuk-form-group--error{{ end }}" id="f-types">
 						<fieldset class="govuk-fieldset" aria-describedby="f-type-hint">
 							<legend class="govuk-fieldset__legend">What LPA types are required?</legend>
@@ -122,7 +124,7 @@
 										{{ template "input" (field "alternativeAddress.Line3" "Address line 3 (optional)" .Form.AlternativeAddress.Line3 (index .Error.Field "correspondentAddress/addressLine3") "data-app-address-finder-map" "addressLine3") }}
 										{{ template "input" (field "alternativeAddress.Town" "Town or city" .Form.AlternativeAddress.Town (index .Error.Field "correspondentAddress/town") "data-app-address-finder-map" "town" "class" "govuk-!-width-two-thirds") }}
 										{{ template "input" (field "alternativeAddress.Postcode" "Postcode" .Form.AlternativeAddress.Postcode (index .Error.Field "correspondentAddress/postcode") "data-app-address-finder-map" "postcode" "class" "govuk-!-width-two-thirds") }}
-										{{ template "select" (select "alternativeCountry.Country" "Country" .Form.AlternativeAddress.Country (index .Error.Field "correspondentAddress/country") (options .Countries) "data-app-address-finder-map" "country") }}
+										{{ template "select" (select "alternativeAddress.Country" "Country" .Form.AlternativeAddress.Country (index .Error.Field "correspondentAddress/country") (options .Countries) "data-app-address-finder-map" "country") }}
 									</div>
 								</div>
 								<div class="govuk-radios__item">

--- a/web/template/layout/date.gohtml
+++ b/web/template/layout/date.gohtml
@@ -1,0 +1,38 @@
+{{ define "date" }}
+    <div class="govuk-form-group {{ if .Error }}govuk-form-group--error{{ end }}" id="f-{{ .Name }}">
+        <fieldset class="govuk-fieldset" role="group" aria-describedby="f-{{ .Name }}-hint">
+            <legend class="govuk-fieldset__legend">
+                <h1 class="govuk-fieldset__heading">
+                    {{ .Label }}
+                </h1>
+            </legend>
+            {{ template "errors" .Error }}
+            <div class="govuk-date-input" id="f-{{ .Name }}">
+                <div class="govuk-date-input__item">
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-date-input__label" for="f-{{ .Name }}-day">
+                            Day
+                        </label>
+                        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="f-dob-day" name="{{ .Name }}.day" type="text" inputmode="numeric" {{ if not (eq .Value.Day 0) }}value="{{ .Value.Day }}"{{ end }}>
+                    </div>
+                </div>
+                <div class="govuk-date-input__item">
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-date-input__label" for="f-{{ .Name }}-month">
+                            Month
+                        </label>
+                        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="f-{{ .Name }}-month" name="{{ .Name }}.month" type="text" inputmode="numeric" {{ if not (eq .Value.Month 0) }}value="{{ .Value.Month }}"{{ end }}>
+                    </div>
+                </div>
+                <div class="govuk-date-input__item">
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-date-input__label" for="f-{{ .Name }}-year">
+                            Year
+                        </label>
+                        <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="f-{{ .Name }}-year" name="{{ .Name }}.year" type="text" inputmode="numeric" {{ if not (eq .Value.Year 0) }}value="{{ .Value.Year }}"{{ end }}>
+                    </div>
+                </div>
+            </div>
+        </fieldset>
+    </div>
+{{ end }}

--- a/web/template/layout/date.gohtml
+++ b/web/template/layout/date.gohtml
@@ -13,7 +13,7 @@
                         <label class="govuk-label govuk-date-input__label" for="f-{{ .Name }}-day">
                             Day
                         </label>
-                        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="f-dob-day" name="{{ .Name }}.day" type="text" inputmode="numeric" {{ if not (eq .Value.Day 0) }}value="{{ .Value.Day }}"{{ end }}>
+                        <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="f-{{ .Name }}-day" name="{{ .Name }}.day" type="text" inputmode="numeric" {{ if not (eq .Value.Day 0) }}value="{{ .Value.Day }}"{{ end }}>
                     </div>
                 </div>
                 <div class="govuk-date-input__item">

--- a/web/template/layout/donor-details.gohtml
+++ b/web/template/layout/donor-details.gohtml
@@ -1,0 +1,109 @@
+{{ define "donor-details" }}
+    <!-- donor -->
+    <div class="govuk-accordion__section">
+
+        <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+                Donor
+              </span>
+            </h2>
+        </div>
+
+        <div id="accordion-default-content-1" class="govuk-accordion__section-content">
+            <dl class="govuk-summary-list">
+
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key"></dt>
+                    <dd class="govuk-summary-list__value"></dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" id="f-change-donor-details" href="{{ prefix (printf "/change-donor-details?uid=%s" .CaseSummary.DigitalLpa.UID) }}">Change</a>
+                    </dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">First names</dt>
+                    <dd class="govuk-summary-list__value">{{ .DigitalLpa.LpaStoreData.Donor.FirstNames }}</dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Last name</dt>
+                    <dd class="govuk-summary-list__value">{{ .DigitalLpa.LpaStoreData.Donor.LastName }}</dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Otherwise known as</dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ if (eq .DigitalLpa.LpaStoreData.Donor.OtherNamesKnownBy "") }}
+                            No other name specified
+                        {{ else }}
+                            {{ .DigitalLpa.LpaStoreData.Donor.OtherNamesKnownBy }}
+                        {{ end }}
+                    </dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Date of birth</dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ if not (eq .DigitalLpa.LpaStoreData.Donor.DateOfBirth "") }}
+                            {{ parseAndFormatDate .DigitalLpa.LpaStoreData.Donor.DateOfBirth "2006-01-02" "2 January 2006" }}
+                        {{ end }}
+                    </dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Address</dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ template "mlpa-address" .DigitalLpa.LpaStoreData.Donor.Address }}
+                    </dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Email</dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ if (eq .DigitalLpa.LpaStoreData.Donor.Email "") }}
+                            Not provided
+                        {{ else }}
+                            {{ .DigitalLpa.LpaStoreData.Donor.Email }}
+                        {{ end }}
+                    </dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Phone</dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ if (eq .DigitalLpa.SiriusData.Application.PhoneNumber "") }}
+                            Not provided
+                        {{ else }}
+                            {{ .DigitalLpa.SiriusData.Application.PhoneNumber }}
+                        {{ end }}
+                    </dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Format</dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ channelForFormat .DigitalLpa.LpaStoreData.Channel }}
+                        {{ if not (eq .DigitalLpa.LpaStoreData.Donor.ContactLanguagePreference "") }}
+                            <br>{{ languageForFormat .DigitalLpa.LpaStoreData.Donor.ContactLanguagePreference }}
+                        {{ end }}
+                    </dd>
+                </div>
+
+                <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
+                    <dt class="govuk-summary-list__key">Signed on</dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ if (eq .DigitalLpa.LpaStoreData.SignedAt "") }}
+                            Not provided
+                        {{ else }}
+                            {{ parseAndFormatDate .DigitalLpa.LpaStoreData.SignedAt "2006-01-02T15:04:05Z" "2 January 2006" }}
+                        {{ end }}
+                    </dd>
+                </div>
+
+            </dl>
+
+        </div>
+
+    </div>
+{{ end }}

--- a/web/template/mlpa-details.gohtml
+++ b/web/template/mlpa-details.gohtml
@@ -133,92 +133,9 @@
         </div>
       </div>
 
-      <!-- donor -->
       <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-        <div class="govuk-accordion__section">
-          <div class="govuk-accordion__section-header">
-            <h2 class="govuk-accordion__section-heading">
-              <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
-                Donor
-              </span>
-            </h2>
-          </div>
-          <div id="accordion-default-content-1" class="govuk-accordion__section-content">
-            <dl class="govuk-summary-list">
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">First names</dt>
-                <dd class="govuk-summary-list__value">{{ .DigitalLpa.LpaStoreData.Donor.FirstNames }}</dd>
-              </div>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Last name</dt>
-                <dd class="govuk-summary-list__value">{{ .DigitalLpa.LpaStoreData.Donor.LastName }}</dd>
-              </div>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Otherwise known as</dt>
-                <dd class="govuk-summary-list__value">
-                  {{ if (eq .DigitalLpa.LpaStoreData.Donor.OtherNamesKnownBy "") }}
-                    No other name specified
-                  {{ else }}
-                    {{ .DigitalLpa.LpaStoreData.Donor.OtherNamesKnownBy }}
-                  {{ end }}
-                </dd>
-              </div>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Date of birth</dt>
-                <dd class="govuk-summary-list__value">
-                  {{ if not (eq .DigitalLpa.LpaStoreData.Donor.DateOfBirth "") }}
-                    {{ parseAndFormatDate .DigitalLpa.LpaStoreData.Donor.DateOfBirth "2006-01-02" "2 January 2006" }}
-                  {{ end }}
-                </dd>
-              </div>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Address</dt>
-                <dd class="govuk-summary-list__value">
-                  {{ template "mlpa-address" .DigitalLpa.LpaStoreData.Donor.Address }}
-                </dd>
-              </div>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Email</dt>
-                <dd class="govuk-summary-list__value">
-                  {{ if (eq .DigitalLpa.LpaStoreData.Donor.Email "") }}
-                    Not provided
-                  {{ else }}
-                    {{ .DigitalLpa.LpaStoreData.Donor.Email }}
-                  {{ end }}
-                </dd>
-              </div>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Phone</dt>
-                <dd class="govuk-summary-list__value">
-                  {{ if (eq .DigitalLpa.SiriusData.Application.PhoneNumber "") }}
-                    Not provided
-                  {{ else }}
-                    {{ .DigitalLpa.SiriusData.Application.PhoneNumber }}
-                  {{ end }}
-                </dd>
-              </div>
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Format</dt>
-                <dd class="govuk-summary-list__value">
-                  {{ channelForFormat .DigitalLpa.LpaStoreData.Channel }}
-                  {{ if not (eq .DigitalLpa.LpaStoreData.Donor.ContactLanguagePreference "") }}
-                    <br>{{ languageForFormat .DigitalLpa.LpaStoreData.Donor.ContactLanguagePreference }}
-                  {{ end }}
-                </dd>
-              </div>
-              <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
-                <dt class="govuk-summary-list__key">Signed on</dt>
-                <dd class="govuk-summary-list__value">
-                  {{ if (eq .DigitalLpa.LpaStoreData.SignedAt "") }}
-                    Not provided
-                  {{ else }}
-                    {{ parseAndFormatDate .DigitalLpa.LpaStoreData.SignedAt "2006-01-02T15:04:05Z" "2 January 2006" }}
-                  {{ end }}
-                </dd>
-              </div>
-            </dl>
-          </div>
-        </div>
+        {{ . }}
+        {{ template "donor-details" . }}
 
         <!-- attorneys -->
         {{ $anomaliesForSection := .AnomalyDisplay.GetAnomaliesForSection "attorneys" }}

--- a/web/template/mlpa-details.gohtml
+++ b/web/template/mlpa-details.gohtml
@@ -114,6 +114,11 @@
           {{ template "mlpa-header" (caseTabs .CaseSummary "lpa-details") }}
 
           <div class="govuk-!-margin-bottom-5">
+
+            {{ if .FlashMessage.Title }}
+              {{ template "notification-banner" .FlashMessage }}
+            {{ end }}
+
             <h1 class="govuk-heading-l govuk-!-margin-bottom-1">LPA details</h1>
 
             {{ if ne .DigitalLpa.SiriusData.DueDate "" }}
@@ -134,7 +139,6 @@
       </div>
 
       <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-        {{ . }}
         {{ template "donor-details" . }}
 
         <!-- attorneys -->


### PR DESCRIPTION
PR that adds a change link on the donor details section, which directs users to the edit donor details form. 

PR also:
- moves the donor details section to it's own template
- creates a reusable date template 
- Fixes the country drop down menu not working in the create additional draft form

Fixes VEGA-2667

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards
