### PR TITLE
VEGA-2501 : Fix for pact test failure with no content returned #patch

### DIFF
--- a/internal/sirius/edit_digital_lpa_status_test.go
+++ b/internal/sirius/edit_digital_lpa_status_test.go
@@ -38,8 +38,7 @@ func TestEditDigitalLPAStatus(t *testing.T) {
 						},
 					}).
 					WillRespondWith(dsl.Response{
-						Status:  http.StatusNoContent,
-						Headers: dsl.MapMatcher{"Content-Type": dsl.String("application/json")},
+						Status: http.StatusNoContent,
 					})
 			},
 		},


### PR DESCRIPTION
This PR is a patch for [VEGA-2501](https://opgtransform.atlassian.net/browse/VEGA-2501)

The 'main' branch workflow is failing due to a Pact test verification failure. This change updates the pact test to remove the response header content type definition since the status returned is a 204.

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-2501]: https://opgtransform.atlassian.net/browse/VEGA-2501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ