### PR TITLE
VEGA-2500 : Handle manual change to cancelled status #minor

### DIFF
--- a/cypress/e2e/change-case-status.cy.js
+++ b/cypress/e2e/change-case-status.cy.js
@@ -115,6 +115,6 @@ describe("Change case status", () => {
       .should("be.checked");
     cy.contains(".govuk-radios__label", "Cannot register").click();
     cy.get("button[type=submit]").click();
-    cy.get(".moj-banner").should("exist");
+    cy.url().should("contain", "/lpa/M-DIGI-LPA3-3333");
   });
 });

--- a/internal/server/change_case_status.go
+++ b/internal/server/change_case_status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/templatefn"
 	"net/http"
 )
 
@@ -62,6 +63,11 @@ func ChangeCaseStatus(client ChangeCaseStatusClient, tmpl template.Template) Han
 			} else {
 				data.Success = true
 				data.OldStatus = data.NewStatus
+
+				SetFlash(w, FlashNotification{
+					Title: fmt.Sprintf("Status changed to %s", templatefn.StatusLabelFormat(data.NewStatus)),
+				})
+				return RedirectError(fmt.Sprintf("/lpa/%s", data.CaseUID))
 			}
 		}
 

--- a/internal/server/change_case_status_test.go
+++ b/internal/server/change_case_status_test.go
@@ -88,7 +88,7 @@ func TestPostChangeCaseStatus(t *testing.T) {
 
 	client.
 		On("EditDigitalLPAStatus", mock.Anything, "M-9876-9876-9876", sirius.CaseStatusData{
-			Status: "cancelled",
+			Status: "cannot-register",
 		}).
 		Return(nil)
 
@@ -98,13 +98,13 @@ func TestPostChangeCaseStatus(t *testing.T) {
 			Success:   true,
 			Entity:    "personal-welfare M-9876-9876-9876",
 			CaseUID:   "M-9876-9876-9876",
-			OldStatus: "cancelled",
-			NewStatus: "cancelled",
+			OldStatus: "cannot-register",
+			NewStatus: "cannot-register",
 		}).
 		Return(nil)
 
 	form := url.Values{
-		"status": {"cancelled"},
+		"status": {"cannot-register"},
 	}
 
 	r, _ := http.NewRequest(http.MethodPost, "/change-case-status?uid=M-9876-9876-9876", strings.NewReader(form.Encode()))
@@ -114,7 +114,6 @@ func TestPostChangeCaseStatus(t *testing.T) {
 	err := ChangeCaseStatus(client, template.Func)(w, r)
 	resp := w.Result()
 
-	assert.Nil(t, err)
+	assert.Equal(t, RedirectError("/lpa/M-9876-9876-9876"), err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	mock.AssertExpectationsForObjects(t, client, template)
 }

--- a/internal/templatefn/fn.go
+++ b/internal/templatefn/fn.go
@@ -122,7 +122,7 @@ func All(siriusPublicURL, prefix, staticHash string) map[string]interface{} {
 				return "grey"
 			}
 		},
-		"statusLabel": statusLabelFormat,
+		"statusLabel": StatusLabelFormat,
 		"replace": func(s, find, replace string) string {
 			return strings.ReplaceAll(s, find, replace)
 		},
@@ -316,7 +316,7 @@ func subtypeLongFormat(subtype string) string {
 	}
 }
 
-func statusLabelFormat(status string) string {
+func StatusLabelFormat(status string) string {
 	switch strings.ToLower(status) {
 	case "draft":
 		return "Draft"
@@ -354,7 +354,7 @@ func caseTab(caseSummary sirius.CaseSummary, tabName string) CaseTabData {
 	}
 
 	var linkedCases []linkedCase
-	linkedCases = append(linkedCases, linkedCase{lpa.UID, lpa.Subtype, statusLabelFormat(status), lpa.CreatedDate})
+	linkedCases = append(linkedCases, linkedCase{lpa.UID, lpa.Subtype, StatusLabelFormat(status), lpa.CreatedDate})
 
 	for _, linkedLpa := range lpa.LinkedCases {
 		linkedCases = append(linkedCases, linkedCase{linkedLpa.UID, linkedLpa.Subtype, linkedLpa.Status, linkedLpa.CreatedDate})


### PR DESCRIPTION
This PR covers [VEGA-2500](https://opgtransform.atlassian.net/browse/VEGA-2500)

The PR change adds the redirection of the user back to the LPA Details page after a successful update of the Digital LPA status manually.

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-2500]: https://opgtransform.atlassian.net/browse/VEGA-2500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ