### PR TITLE
Turn off code duplication checks in SonarCloud

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,1 @@
+sonar.cpd.exclusions=**/*


### PR DESCRIPTION
They're rarely helpful (and sometimes paying down would cause more harm), distracting and confuse things by making builds look like failures.

#patch
