### PR TITLE
vega-2701 - Add content for lifeSustainingTreatment options

### DIFF
--- a/internal/templatefn/fn.go
+++ b/internal/templatefn/fn.go
@@ -193,9 +193,9 @@ func All(siriusPublicURL, prefix, staticHash string) map[string]interface{} {
 		"lifeSustainingTreatmentOptionLongForm": func(s string) string {
 			switch s {
 			case "option-a":
-				return "Option A"
+				return "Attorneys can give or refuse consent to LST"
 			case "option-b":
-				return "Option B"
+				return "Attorneys cannot give or refuse consent to LST"
 			case "":
 				return "Not specified"
 			default:

--- a/internal/templatefn/fn_test.go
+++ b/internal/templatefn/fn_test.go
@@ -86,8 +86,8 @@ func TestHowReplacementAttorneysStepInLongForm(t *testing.T) {
 
 func TestLifeSustainingTreatmentOptionLongForm(t *testing.T) {
 	expectations := map[string]string{
-		"option-a": "Option A",
-		"option-b": "Option B",
+		"option-a": "Attorneys can give or refuse consent to LST",
+		"option-b": "Attorneys cannot give or refuse consent to LST",
 		"":         "Not specified",
 		"foo":      "lifeSustainingTreatmentOption NOT RECOGNISED: foo",
 	}


### PR DESCRIPTION
[vega-2701](https://opgtransform.atlassian.net/browse/VEGA-2701) - to add in the finalised content for lifeSustainingTreatment options 

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards
