### PR TITLE
Fix link to CP ID check

### DIFF
--- a/cypress/e2e/application-progress.cy.js
+++ b/cypress/e2e/application-progress.cy.js
@@ -211,7 +211,7 @@ describe("View the application progress for a digital LPA", () => {
     cy.contains("Certificate provider: Fake Provider");
     cy.contains("Start certificate provider identity check").should("exist");
     cy.get(
-      "a[href='/lpa/identity-check/start?personType=certificate-provider&lpas[]=M-QEQE-EEEE-WERT']",
+      "a[href='/lpa/identity-check/start?personType=certificateProvider&lpas[]=M-QEQE-EEEE-WERT']",
     ).contains("Start certificate provider identity check");
   });
 

--- a/web/template/layout/pi-certificate-provider-id.gohtml
+++ b/web/template/layout/pi-certificate-provider-id.gohtml
@@ -4,7 +4,7 @@
         <td class="govuk-table__cell">
             {{if and (eq .Status "IN_PROGRESS") (eq .CertificateProviderChannel "paper")}}
                 <a class="govuk-link govuk-link--no-visited-state"
-                   href="{{printf "/lpa/identity-check/start?personType=certificate-provider&lpas[]=%s" .UID}}">
+                   href="{{printf "/lpa/identity-check/start?personType=certificateProvider&lpas[]=%s" .UID}}">
                     Start certificate provider identity check
                 </a>
             {{end}}


### PR DESCRIPTION
The person type should be "certificateProvider" not "certificate-provider"

Fixes VEGA-2884 #patch

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [x] I have added styling for Dark Mode
  - N/A
- [x] I have checked that my UI changes meet accessibility standards
  - N/A
