### PR TITLE
VEGA-2821 : Changes for submitting the remove an attorney form

### DIFF
--- a/internal/server/remove_an_attorney.go
+++ b/internal/server/remove_an_attorney.go
@@ -11,6 +11,7 @@ import (
 
 type RemoveAnAttorneyClient interface {
 	CaseSummary(sirius.Context, string) (sirius.CaseSummary, error)
+	ChangeAttorneyStatus(sirius.Context, string, []sirius.AttorneyUpdatedStatus) error
 }
 
 type removeAnAttorneyData struct {
@@ -20,6 +21,7 @@ type removeAnAttorneyData struct {
 	SelectedAttorneyUid  string
 	SelectedAttorneyName string
 	SelectedAttorneyDob  string
+	Success              bool
 	Error                sirius.ValidationError
 	XSRFToken            string
 }
@@ -74,7 +76,30 @@ func RemoveAnAttorney(client RemoveAnAttorneyClient, removeTmpl template.Templat
 
 					return confirmTmpl(w, data)
 				} else {
-					return RedirectError(fmt.Sprintf("/lpa/%s", caseSummary.DigitalLpa.UID))
+					var attorneyUpdatedStatus []sirius.AttorneyUpdatedStatus
+
+					for _, att := range data.ActiveAttorneys {
+						if att.Uid == data.SelectedAttorneyUid {
+							attorneyUpdatedStatus = append(attorneyUpdatedStatus, sirius.AttorneyUpdatedStatus{
+								UID:    att.Uid,
+								Status: shared.RemovedAttorneyStatus.String(),
+							})
+						}
+					}
+
+					err = client.ChangeAttorneyStatus(ctx, uid, attorneyUpdatedStatus)
+
+					if ve, ok := err.(sirius.ValidationError); ok {
+						w.WriteHeader(http.StatusBadRequest)
+						data.Error = ve
+					} else if err != nil {
+						return err
+					} else {
+						data.Success = true
+
+						SetFlash(w, FlashNotification{Title: "Attorney statuses updated"})
+						return RedirectError(fmt.Sprintf("/lpa/%s", uid))
+					}
 				}
 			}
 		}

--- a/internal/server/remove_an_attorney.go
+++ b/internal/server/remove_an_attorney.go
@@ -2,11 +2,12 @@ package server
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/shared"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
-	"net/http"
 )
 
 type RemoveAnAttorneyClient interface {
@@ -97,7 +98,7 @@ func RemoveAnAttorney(client RemoveAnAttorneyClient, removeTmpl template.Templat
 					} else {
 						data.Success = true
 
-						SetFlash(w, FlashNotification{Title: "Attorney statuses updated"})
+						SetFlash(w, FlashNotification{Title: "Update saved"})
 						return RedirectError(fmt.Sprintf("/lpa/%s", uid))
 					}
 				}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -80,6 +80,7 @@ type Client interface {
 	ManageAttorneysClient
 	ManageFeesClient
 	MiReportingClient
+	RemoveAnAttorneyClient
 	RelationshipClient
 	SearchDonorsClient
 	SearchClient

--- a/internal/sirius/change_attorney_status.go
+++ b/internal/sirius/change_attorney_status.go
@@ -1,0 +1,49 @@
+package sirius
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type AttorneyUpdatedStatus struct {
+	UID    string `json:"uid"`
+	Status string `json:"status"`
+}
+
+type attorneyStatusRequest struct {
+	AttorneyStatuses []AttorneyUpdatedStatus `json:"attorneyStatuses"`
+}
+
+func (c *Client) ChangeAttorneyStatus(ctx Context, caseUID string, attorneyUpdatedStatus []AttorneyUpdatedStatus) error {
+	data, err := json.Marshal(attorneyStatusRequest{AttorneyStatuses: attorneyUpdatedStatus})
+	if err != nil {
+		return err
+	}
+
+	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/attorney-status", caseUID), bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //#nosec G307 false positive
+
+	if resp.StatusCode == http.StatusBadRequest {
+		var v ValidationError
+		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+			return err
+		}
+		return v
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		return newStatusError(resp)
+	}
+
+	return nil
+}

--- a/internal/sirius/change_attorney_status_test.go
+++ b/internal/sirius/change_attorney_status_test.go
@@ -1,0 +1,68 @@
+package sirius
+
+import (
+	"context"
+	"fmt"
+	"github.com/pact-foundation/pact-go/dsl"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestChangeAttorneyStatus(t *testing.T) {
+	t.Parallel()
+
+	pact := newPact()
+	defer pact.Teardown()
+
+	testCases := []struct {
+		name          string
+		setup         func()
+		expectedError func(int) error
+	}{
+		{
+			name: "OK",
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("A digital LPA exists").
+					UponReceiving("A request for changing the status of the digital LPA attorney").
+					WithRequest(dsl.Request{
+						Method: http.MethodPut,
+						Path:   dsl.String("/lpa-api/v1/digital-lpas/M-1234-9876-4567/attorney-status"),
+						Headers: dsl.MapMatcher{
+							"Content-Type": dsl.String("application/json"),
+						},
+						Body: map[string]interface{}{
+							"attorneyStatuses": []map[string]interface{}{{
+								"uid":    "302b05c7-896c-4290-904e-2005e4f1e81e",
+								"status": "removed",
+							}},
+						},
+					}).
+					WillRespondWith(dsl.Response{
+						Status: http.StatusNoContent,
+					})
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+
+			assert.Nil(t, pact.Verify(func() error {
+				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
+
+				err := client.ChangeAttorneyStatus(Context{Context: context.Background()}, "M-1234-9876-4567", []AttorneyUpdatedStatus{{UID: "302b05c7-896c-4290-904e-2005e4f1e81e", Status: "removed"}})
+
+				if tc.expectedError == nil {
+					assert.Nil(t, err)
+				} else {
+					assert.Equal(t, tc.expectedError(pact.Server.Port), err)
+				}
+				return nil
+			}))
+		})
+	}
+}

--- a/internal/sirius/change_attorney_status_test.go
+++ b/internal/sirius/change_attorney_status_test.go
@@ -35,7 +35,7 @@ func TestChangeAttorneyStatus(t *testing.T) {
 						},
 						Body: map[string]interface{}{
 							"attorneyStatuses": []map[string]interface{}{{
-								"uid":    "302b05c7-896c-4290-904e-2005e4f1e81e",
+								"uid":    "cf128305-37c8-4ceb-bedf-89ed5f4ae661",
 								"status": "removed",
 							}},
 						},
@@ -54,7 +54,7 @@ func TestChangeAttorneyStatus(t *testing.T) {
 			assert.Nil(t, pact.Verify(func() error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", pact.Server.Port))
 
-				err := client.ChangeAttorneyStatus(Context{Context: context.Background()}, "M-1234-9876-4567", []AttorneyUpdatedStatus{{UID: "302b05c7-896c-4290-904e-2005e4f1e81e", Status: "removed"}})
+				err := client.ChangeAttorneyStatus(Context{Context: context.Background()}, "M-1234-9876-4567", []AttorneyUpdatedStatus{{UID: "cf128305-37c8-4ceb-bedf-89ed5f4ae661", Status: "removed"}})
 
 				if tc.expectedError == nil {
 					assert.Nil(t, err)


### PR DESCRIPTION
This PR covers [VEGA-2821](https://opgtransform.atlassian.net/browse/VEGA-2821)

Currently, these frontend changes cater to the removal of an attorney. When the enabling of the replacement attorneys functionality is implemented, then the code will need to be updated to accommodate the additional status changes in the request array.

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-2821]: https://opgtransform.atlassian.net/browse/VEGA-2821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ