### PR TITLE
Use reusable HTTP methods

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.6"
-
 services:
   lpa-frontend:
     image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/sirius/sirius-lpa-frontend:latest

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.6"
-
 services:
   lpa-frontend:
     ports: ["8888:8080"]

--- a/internal/sirius/add_complaint.go
+++ b/internal/sirius/add_complaint.go
@@ -1,40 +1,9 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) AddComplaint(ctx Context, caseID int, caseType CaseType, complaint Complaint) error {
-	data, err := json.Marshal(complaint)
-	if err != nil {
-		return err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("/lpa-api/v1/%ss/%d/complaints", caseType, caseID), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.post(ctx, fmt.Sprintf("/lpa-api/v1/%ss/%d/complaints", caseType, caseID), complaint, nil)
 }

--- a/internal/sirius/add_document.go
+++ b/internal/sirius/add_document.go
@@ -1,10 +1,7 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 type addDocumentRequestData struct {
@@ -17,44 +14,21 @@ type addDocumentRequestData struct {
 }
 
 func (c *Client) AddDocument(ctx Context, caseID int, document Document, docType string) (Document, error) {
-	data, err := json.Marshal(addDocumentRequestData{
+	data := addDocumentRequestData{
 		CaseId:          caseID,
 		CorrespondentID: document.Correspondent.ID,
 		Type:            docType,
 		FileName:        document.FileName,
 		SystemType:      document.SystemType,
 		Content:         document.Content,
-	})
-	if err != nil {
-		return Document{}, err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("/lpa-api/v1/lpas/%d/documents", caseID), bytes.NewReader(data))
-	if err != nil {
-		return Document{}, err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return Document{}, err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return Document{}, err
-		}
-		return Document{}, v
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return Document{}, newStatusError(resp)
 	}
 
 	var d Document
-	if err := json.NewDecoder(resp.Body).Decode(&d); err != nil {
+
+	err := c.post(ctx, fmt.Sprintf("/lpa-api/v1/lpas/%d/documents", caseID), data, &d)
+	if err != nil {
 		return Document{}, err
 	}
+
 	return d, nil
 }

--- a/internal/sirius/add_fee_decision.go
+++ b/internal/sirius/add_fee_decision.go
@@ -1,14 +1,11 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) AddFeeDecision(ctx Context, caseID int, decisionType string, decisionReason string, decisionDate DateString) error {
-	postData, err := json.Marshal(struct {
+	data := struct {
 		DecisionType   string     `json:"decisionType"`
 		DecisionReason string     `json:"decisionReason"`
 		DecisionDate   DateString `json:"decisionDate"`
@@ -16,36 +13,7 @@ func (c *Client) AddFeeDecision(ctx Context, caseID int, decisionType string, de
 		DecisionType:   decisionType,
 		DecisionReason: decisionReason,
 		DecisionDate:   decisionDate,
-	})
-
-	if err != nil {
-		return err
 	}
 
-	req, _ := c.newRequest(
-		ctx,
-		http.MethodPost,
-		fmt.Sprintf("/lpa-api/v1/cases/%d/fee-decisions", caseID),
-		bytes.NewReader(postData),
-	)
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.post(ctx, fmt.Sprintf("/lpa-api/v1/cases/%d/fee-decisions", caseID), data, nil)
 }

--- a/internal/sirius/add_payment.go
+++ b/internal/sirius/add_payment.go
@@ -1,14 +1,11 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) AddPayment(ctx Context, caseID int, amount int, source string, paymentDate DateString) error {
-	postData, err := json.Marshal(struct {
+	data := struct {
 		Amount      int        `json:"amount"`
 		Source      string     `json:"source"`
 		PaymentDate DateString `json:"paymentDate"`
@@ -16,34 +13,7 @@ func (c *Client) AddPayment(ctx Context, caseID int, amount int, source string, 
 		Amount:      amount,
 		Source:      source,
 		PaymentDate: paymentDate,
-	})
-
-	if err != nil {
-		return err
 	}
 
-	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("/lpa-api/v1/cases/%d/payments", caseID), bytes.NewReader(postData))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.post(ctx, fmt.Sprintf("/lpa-api/v1/cases/%d/payments", caseID), data, nil)
 }

--- a/internal/sirius/allocate_cases.go
+++ b/internal/sirius/allocate_cases.go
@@ -1,10 +1,7 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"strconv"
 )
 
@@ -18,38 +15,12 @@ type allocateCasesRequest struct {
 }
 
 func (c *Client) AllocateCases(ctx Context, assigneeID int, allocations []CaseAllocation) error {
-	data, err := json.Marshal(allocateCasesRequest{Data: allocations})
-	if err != nil {
-		return err
-	}
+	data := allocateCasesRequest{Data: allocations}
 
 	caseIDs := strconv.Itoa(allocations[0].ID)
 	for _, allocation := range allocations[1:] {
 		caseIDs += "+" + strconv.Itoa(allocation.ID)
 	}
 
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/users/%d/cases/%s", assigneeID, caseIDs), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/users/%d/cases/%s", assigneeID, caseIDs), data, nil)
 }

--- a/internal/sirius/apply_fee_reduction.go
+++ b/internal/sirius/apply_fee_reduction.go
@@ -1,16 +1,13 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 const FeeReductionSource = "FEE_REDUCTION"
 
 func (c *Client) ApplyFeeReduction(ctx Context, caseID int, feeReductionType string, paymentEvidence string, paymentDate DateString) error {
-	postData, err := json.Marshal(struct {
+	data := struct {
 		Source           string     `json:"source"`
 		PaymentEvidence  string     `json:"paymentEvidence"`
 		FeeReductionType string     `json:"feeReductionType"`
@@ -20,34 +17,7 @@ func (c *Client) ApplyFeeReduction(ctx Context, caseID int, feeReductionType str
 		PaymentEvidence:  paymentEvidence,
 		FeeReductionType: feeReductionType,
 		PaymentDate:      paymentDate,
-	})
-
-	if err != nil {
-		return err
 	}
 
-	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("/lpa-api/v1/cases/%d/payments", caseID), bytes.NewReader(postData))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.post(ctx, fmt.Sprintf("/lpa-api/v1/cases/%d/payments", caseID), data, nil)
 }

--- a/internal/sirius/assign_tasks.go
+++ b/internal/sirius/assign_tasks.go
@@ -1,11 +1,8 @@
 package sirius
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"strconv"
-	"strings"
 )
 
 func (c *Client) AssignTasks(ctx Context, assigneeID int, taskIDs []int) error {
@@ -14,28 +11,5 @@ func (c *Client) AssignTasks(ctx Context, assigneeID int, taskIDs []int) error {
 		urlIDs += "+" + strconv.Itoa(taskID)
 	}
 
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/users/%d/tasks/%s", assigneeID, urlIDs), strings.NewReader(""))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/users/%d/tasks/%s", assigneeID, urlIDs), nil, nil)
 }

--- a/internal/sirius/change_attorney_details.go
+++ b/internal/sirius/change_attorney_details.go
@@ -1,10 +1,7 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 type ChangeAttorneyDetails struct {
@@ -18,33 +15,7 @@ type ChangeAttorneyDetails struct {
 }
 
 func (c *Client) ChangeAttorneyDetails(ctx Context, caseUID string, attorneyUID string, attorneyDetails ChangeAttorneyDetails) error {
-	data, err := json.Marshal(attorneyDetails)
-	if err != nil {
-		return err
-	}
+	path := fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/attorney/%s/change-details", caseUID, attorneyUID)
 
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/attorney/%s/change-details", caseUID, attorneyUID), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusNoContent {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.put(ctx, path, attorneyDetails, nil)
 }

--- a/internal/sirius/change_attorney_status.go
+++ b/internal/sirius/change_attorney_status.go
@@ -1,10 +1,7 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 type AttorneyUpdatedStatus struct {
@@ -17,33 +14,7 @@ type attorneyStatusRequest struct {
 }
 
 func (c *Client) ChangeAttorneyStatus(ctx Context, caseUID string, attorneyUpdatedStatus []AttorneyUpdatedStatus) error {
-	data, err := json.Marshal(attorneyStatusRequest{AttorneyStatuses: attorneyUpdatedStatus})
-	if err != nil {
-		return err
-	}
+	data := attorneyStatusRequest{AttorneyStatuses: attorneyUpdatedStatus}
 
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/attorney-status", caseUID), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusNoContent {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/attorney-status", caseUID), data, nil)
 }

--- a/internal/sirius/change_donor_details.go
+++ b/internal/sirius/change_donor_details.go
@@ -1,10 +1,7 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 type ChangeDonorDetails struct {
@@ -19,33 +16,5 @@ type ChangeDonorDetails struct {
 }
 
 func (c *Client) ChangeDonorDetails(ctx Context, caseUID string, donorDetails ChangeDonorDetails) error {
-	data, err := json.Marshal(donorDetails)
-	if err != nil {
-		return err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/change-donor-details", caseUID), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusNoContent {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/change-donor-details", caseUID), donorDetails, nil)
 }

--- a/internal/sirius/change_draft.go
+++ b/internal/sirius/change_draft.go
@@ -1,10 +1,7 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 type ChangeDraft struct {
@@ -17,33 +14,5 @@ type ChangeDraft struct {
 }
 
 func (c *Client) ChangeDraft(ctx Context, caseUID string, draftDetails ChangeDraft) error {
-	data, err := json.Marshal(draftDetails)
-	if err != nil {
-		return err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/change-draft", caseUID), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusNoContent {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/change-draft", caseUID), draftDetails, nil)
 }

--- a/internal/sirius/clear_task.go
+++ b/internal/sirius/clear_task.go
@@ -2,27 +2,11 @@ package sirius
 
 import (
 	"fmt"
-	"net/http"
-	"strings"
 )
 
 func (c *Client) ClearTask(ctx Context, taskID int) error {
+	var v interface{}
+	err := c.put(ctx, fmt.Sprintf("/lpa-api/v1/tasks/%d/mark-as-completed", taskID), nil, &v)
 
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/tasks/%d/mark-as-completed", taskID), strings.NewReader(""))
-
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode != http.StatusOK {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return err
 }

--- a/internal/sirius/client.go
+++ b/internal/sirius/client.go
@@ -1,6 +1,7 @@
 package sirius
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -95,6 +96,125 @@ func (c *Client) get(ctx Context, path string, v interface{}) error {
 	}
 
 	return json.NewDecoder(resp.Body).Decode(&v)
+}
+
+func (c *Client) post(ctx Context, path string, body interface{}, response interface{}) error {
+	data := []byte{}
+
+	if body != nil {
+		var err error
+		if data, err = json.Marshal(body); err != nil {
+			return err
+		}
+	}
+
+	req, err := c.newRequest(ctx, http.MethodPost, path, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //#nosec G307 false positive
+
+	if resp.StatusCode == http.StatusBadRequest {
+		var v ValidationError
+		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+			return err
+		}
+		return v
+	}
+
+	if resp.StatusCode != http.StatusOK &&
+		resp.StatusCode != http.StatusCreated &&
+		resp.StatusCode != http.StatusNoContent {
+		return newStatusError(resp)
+	}
+
+	var buf []byte
+	if buf, err = io.ReadAll(resp.Body); err != nil {
+		return err
+	}
+
+	if len(buf) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(buf, &response); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) put(ctx Context, path string, body interface{}, response interface{}) error {
+	data := []byte{}
+	var err error
+
+	if body != nil {
+		if data, err = json.Marshal(body); err != nil {
+			return err
+		}
+	}
+
+	req, err := c.newRequest(ctx, http.MethodPut, path, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //#nosec G307 false positive
+
+	if resp.StatusCode == http.StatusBadRequest {
+		var v ValidationError
+		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+			return err
+		}
+		return v
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return newStatusError(resp)
+	}
+
+	var buf []byte
+	if buf, err = io.ReadAll(resp.Body); err != nil {
+		return err
+	}
+
+	if len(buf) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(buf, &response); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) delete(ctx Context, path string) error {
+	req, err := c.newRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //#nosec G307 false positive
+
+	if resp.StatusCode != http.StatusNoContent {
+		return newStatusError(resp)
+	}
+
+	return nil
 }
 
 type StatusError struct {

--- a/internal/sirius/client_test.go
+++ b/internal/sirius/client_test.go
@@ -1,13 +1,17 @@
 package sirius
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/pact-foundation/pact-go/dsl"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func newPact() *dsl.Pact {
@@ -88,4 +92,189 @@ func TestValidationErrorSummary(t *testing.T) {
 	}
 
 	assert.Equal(t, "This case is in a Registered status and cannot be deleted", descriptiveValidationError.Error())
+}
+
+type mockHTTPClient struct {
+	mock.Mock
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	args := m.Called(req)
+	return args.Get(0).(*http.Response), args.Error(1)
+}
+
+func TestRequestInternalError(t *testing.T) {
+	testCases := map[string]struct {
+		fn func(client *Client) error
+	}{
+		"get": {
+			fn: func(client *Client) error {
+				return client.get(Context{Context: context.Background()}, "/resource/14", nil)
+			},
+		},
+		"post": {
+			fn: func(client *Client) error {
+				return client.post(Context{Context: context.Background()}, "/resource/14", nil, nil)
+			},
+		},
+		"put": {
+			fn: func(client *Client) error {
+				return client.put(Context{Context: context.Background()}, "/resource/14", nil, nil)
+			},
+		},
+		"delete": {
+			fn: func(client *Client) error {
+				return client.delete(Context{Context: context.Background()}, "/resource/14")
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			expectedErr := errors.New("something went wrong")
+
+			mockHttpClient := &mockHTTPClient{}
+			mockHttpClient.
+				On("Do", mock.Anything).
+				Return(&http.Response{}, expectedErr)
+
+			client := NewClient(mockHttpClient, "https://host.example")
+
+			err := tc.fn(client)
+
+			assert.Equal(t, expectedErr, err)
+		})
+	}
+}
+
+func TestRequestStatusError(t *testing.T) {
+	testCases := map[string]struct {
+		fn func(client *Client) error
+	}{
+		"get": {
+			fn: func(client *Client) error {
+				return client.get(Context{Context: context.Background()}, "/resource/14", nil)
+			},
+		},
+		"post": {
+			fn: func(client *Client) error {
+				return client.post(Context{Context: context.Background()}, "/resource/14", nil, nil)
+			},
+		},
+		"put": {
+			fn: func(client *Client) error {
+				return client.put(Context{Context: context.Background()}, "/resource/14", nil, nil)
+			},
+		},
+		"delete": {
+			fn: func(client *Client) error {
+				return client.delete(Context{Context: context.Background()}, "/resource/14")
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			mockHttpClient := &mockHTTPClient{}
+			mockCall := mockHttpClient.On("Do", mock.Anything)
+
+			mockCall.RunFn = func(args mock.Arguments) {
+				mockCall.ReturnArguments = mock.Arguments{&http.Response{
+					Request:    args.Get(0).(*http.Request),
+					StatusCode: http.StatusServiceUnavailable,
+					Body:       io.NopCloser(strings.NewReader(`{"id":492, "name":"policy_4"}`)),
+				}, nil}
+			}
+
+			client := NewClient(mockHttpClient, "https://host.example")
+
+			err := tc.fn(client)
+
+			statusError, ok := err.(StatusError)
+			if !ok {
+				t.Error("expected error to be StatusError")
+			}
+
+			assert.Equal(t, http.StatusServiceUnavailable, statusError.Code)
+		})
+	}
+}
+
+func TestRequestMarshalBodyError(t *testing.T) {
+	testCases := map[string]struct {
+		fn func(client *Client) error
+	}{
+		"post": {
+			fn: func(client *Client) error {
+				return client.post(Context{Context: context.Background()}, "/resource/14", complex(1, 16), nil)
+			},
+		},
+		"put": {
+			fn: func(client *Client) error {
+				return client.put(Context{Context: context.Background()}, "/resource/14", complex(1, 16), nil)
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			mockHttpClient := &mockHTTPClient{}
+
+			client := NewClient(mockHttpClient, "https://host.example")
+
+			err := tc.fn(client)
+
+			assert.Equal(t, "json: unsupported type: complex128", err.Error())
+		})
+	}
+}
+
+func TestRequestUnmarshalError(t *testing.T) {
+	testCases := map[string]struct {
+		status int
+		fn     func(client *Client) error
+	}{
+		"get": {
+			fn: func(client *Client) error {
+				resp := ""
+				return client.get(Context{Context: context.Background()}, "/resource/14", &resp)
+			},
+			status: http.StatusOK,
+		},
+		"post": {
+			fn: func(client *Client) error {
+				resp := ""
+				return client.post(Context{Context: context.Background()}, "/resource/14", nil, &resp)
+			},
+			status: http.StatusCreated,
+		},
+		"put": {
+			fn: func(client *Client) error {
+				resp := ""
+				return client.put(Context{Context: context.Background()}, "/resource/14", nil, &resp)
+			},
+			status: http.StatusNoContent,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			mockHttpClient := &mockHTTPClient{}
+			mockCall := mockHttpClient.On("Do", mock.Anything)
+
+			mockCall.RunFn = func(args mock.Arguments) {
+				mockCall.ReturnArguments = mock.Arguments{&http.Response{
+					Request:    args.Get(0).(*http.Request),
+					StatusCode: tc.status,
+					Body:       io.NopCloser(strings.NewReader(`{"id":492, "name":"policy_4"}`)),
+				}, nil}
+			}
+
+			client := NewClient(mockHttpClient, "https://host.example")
+
+			err := tc.fn(client)
+
+			assert.Equal(t, "json: cannot unmarshal object into Go value of type string", err.Error())
+		})
+	}
 }

--- a/internal/sirius/create_additional_draft.go
+++ b/internal/sirius/create_additional_draft.go
@@ -1,10 +1,7 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 type AdditionalDraft struct {
@@ -18,43 +15,16 @@ type AdditionalDraft struct {
 }
 
 func (c *Client) CreateAdditionalDraft(ctx Context, donorID int, lpa AdditionalDraft) (map[string]string, error) {
-	data, err := json.Marshal(lpa)
 	out := map[string]string{}
-
-	if err != nil {
-		return out, err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("/lpa-api/v1/donors/%d/digital-lpas", donorID), bytes.NewReader(data))
-	if err != nil {
-		return out, err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return out, err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return out, err
-		}
-		return out, v
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return out, newStatusError(resp)
-	}
-
 	var v []struct {
 		Subtype string `json:"caseSubtype"`
 		Uid     string `json:"uId"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-		return out, err
+	err := c.post(ctx, fmt.Sprintf("/lpa-api/v1/donors/%d/digital-lpas", donorID), lpa, &v)
+
+	if err != nil {
+		return out, nil
 	}
 
 	for _, lpa := range v {

--- a/internal/sirius/create_contact.go
+++ b/internal/sirius/create_contact.go
@@ -1,44 +1,9 @@
 package sirius
 
-import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-)
-
 func (c *Client) CreateContact(ctx Context, contact Person) (Person, error) {
-	data, err := json.Marshal(contact)
-	if err != nil {
-		return Person{}, err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPost, "/lpa-api/v1/non-case-contacts", bytes.NewReader(data))
-	if err != nil {
-		return Person{}, err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return Person{}, err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return Person{}, err
-		}
-		return Person{}, v
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return Person{}, newStatusError(resp)
-	}
-
 	var v Person
-	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-		return Person{}, err
-	}
 
-	return v, nil
+	err := c.post(ctx, "/lpa-api/v1/non-case-contacts", contact, &v)
+
+	return v, err
 }

--- a/internal/sirius/create_donor.go
+++ b/internal/sirius/create_donor.go
@@ -1,44 +1,8 @@
 package sirius
 
-import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-)
-
 func (c *Client) CreateDonor(ctx Context, person Person) (Person, error) {
-	data, err := json.Marshal(person)
-	if err != nil {
-		return Person{}, err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPost, "/lpa-api/v1/donors", bytes.NewReader(data))
-	if err != nil {
-		return Person{}, err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return Person{}, err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return Person{}, err
-		}
-		return Person{}, v
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return Person{}, newStatusError(resp)
-	}
-
 	var v Person
-	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-		return Person{}, err
-	}
+	err := c.post(ctx, "/lpa-api/v1/donors", person, &v)
 
-	return v, nil
+	return v, err
 }

--- a/internal/sirius/create_draft.go
+++ b/internal/sirius/create_draft.go
@@ -1,11 +1,5 @@
 package sirius
 
-import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-)
-
 type Address struct {
 	Line1    string `json:"addressLine1"`
 	Line2    string `json:"addressLine2,omitempty"`
@@ -32,48 +26,16 @@ type Draft struct {
 }
 
 func (c *Client) CreateDraft(ctx Context, draft Draft) (map[string]string, error) {
-	data, err := json.Marshal(draft)
-	out := map[string]string{}
-
-	if err != nil {
-		return out, err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPost, "/lpa-api/v1/digital-lpas", bytes.NewReader(data))
-	if err != nil {
-		return out, err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return out, err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return out, err
-		}
-		return out, v
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return out, newStatusError(resp)
-	}
-
 	var v []struct {
 		Subtype string `json:"caseSubtype"`
 		Uid     string `json:"uId"`
 	}
+	err := c.post(ctx, "/lpa-api/v1/digital-lpas", draft, &v)
 
-	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-		return out, err
-	}
-
+	out := map[string]string{}
 	for _, lpa := range v {
 		out[lpa.Subtype] = lpa.Uid
 	}
 
-	return out, nil
+	return out, err
 }

--- a/internal/sirius/create_investigation.go
+++ b/internal/sirius/create_investigation.go
@@ -1,40 +1,9 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) CreateInvestigation(ctx Context, caseID int, caseType CaseType, investigation Investigation) error {
-	data, err := json.Marshal(investigation)
-	if err != nil {
-		return err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("/lpa-api/v1/%ss/%d/investigations", caseType, caseID), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.post(ctx, fmt.Sprintf("/lpa-api/v1/%ss/%d/investigations", caseType, caseID), investigation, nil)
 }

--- a/internal/sirius/create_person_reference.go
+++ b/internal/sirius/create_person_reference.go
@@ -1,10 +1,7 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 type createPersonReferenceRequest struct {
@@ -13,38 +10,10 @@ type createPersonReferenceRequest struct {
 }
 
 func (c *Client) CreatePersonReference(ctx Context, personID int, referencedUID, reason string) error {
-	data, err := json.Marshal(createPersonReferenceRequest{
+	data := createPersonReferenceRequest{
 		Reason:        reason,
 		ReferencedUID: referencedUID,
-	})
-	if err != nil {
-		return err
 	}
 
-	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("/lpa-api/v1/persons/%d/references", personID), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-
-		return v
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.post(ctx, fmt.Sprintf("/lpa-api/v1/persons/%d/references", personID), data, nil)
 }

--- a/internal/sirius/create_task.go
+++ b/internal/sirius/create_task.go
@@ -1,10 +1,7 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 type TaskRequest struct {
@@ -16,32 +13,5 @@ type TaskRequest struct {
 }
 
 func (c *Client) CreateTask(ctx Context, caseID int, task TaskRequest) error {
-	data, err := json.Marshal(task)
-	if err != nil {
-		return err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("/lpa-api/v1/cases/%d/tasks", caseID), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return newStatusError(resp)
-	}
-	return nil
+	return c.post(ctx, fmt.Sprintf("/lpa-api/v1/cases/%d/tasks", caseID), task, nil)
 }

--- a/internal/sirius/create_warning.go
+++ b/internal/sirius/create_warning.go
@@ -1,11 +1,5 @@
 package sirius
 
-import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-)
-
 func (c *Client) CreateWarning(ctx Context, personId int, warningType string, warningNote string, caseIDs []int) error {
 	type WarningRequest struct {
 		PersonID    int    `json:"personId,omitempty"`
@@ -14,46 +8,12 @@ func (c *Client) CreateWarning(ctx Context, personId int, warningType string, wa
 		WarningText string `json:"warningText"`
 	}
 
-	Data := WarningRequest{
+	data := WarningRequest{
 		PersonID:    personId,
 		CaseIDs:     caseIDs,
 		WarningType: warningType,
 		WarningText: warningNote,
 	}
 
-	postData, err := json.Marshal(Data)
-
-	if err != nil {
-		return err
-	}
-
-	req, err := c.newRequest(
-		ctx, http.MethodPost,
-		"/lpa-api/v1/warnings",
-		bytes.NewReader(postData),
-	)
-
-	if err != nil {
-		return err
-	}
-
-	res, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-
-	defer res.Body.Close() //#nosec G307 false positive
-
-	if res.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if res.StatusCode != http.StatusCreated {
-		return newStatusError(res)
-	}
-	return nil
+	return c.post(ctx, "/lpa-api/v1/warnings", data, nil)
 }

--- a/internal/sirius/delete_document.go
+++ b/internal/sirius/delete_document.go
@@ -2,24 +2,8 @@ package sirius
 
 import (
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) DeleteDocument(ctx Context, uuid string) error {
-	req, err := c.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/lpa-api/v1/documents/%s", uuid), nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode != http.StatusNoContent {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.delete(ctx, fmt.Sprintf("/lpa-api/v1/documents/%s", uuid))
 }

--- a/internal/sirius/delete_payment.go
+++ b/internal/sirius/delete_payment.go
@@ -2,24 +2,8 @@ package sirius
 
 import (
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) DeletePayment(ctx Context, paymentID int) error {
-	req, err := c.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/lpa-api/v1/payments/%d", paymentID), nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode != http.StatusNoContent {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.delete(ctx, fmt.Sprintf("/lpa-api/v1/payments/%d", paymentID))
 }

--- a/internal/sirius/delete_person_reference.go
+++ b/internal/sirius/delete_person_reference.go
@@ -2,24 +2,8 @@ package sirius
 
 import (
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) DeletePersonReference(ctx Context, referenceID int) error {
-	req, err := c.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/lpa-api/v1/person-references/%d", referenceID), nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode != http.StatusNoContent {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.delete(ctx, fmt.Sprintf("/lpa-api/v1/person-references/%d", referenceID))
 }

--- a/internal/sirius/document_templates.go
+++ b/internal/sirius/document_templates.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"sort"
 )
 
@@ -108,19 +107,10 @@ func (c *Client) DocumentTemplates(ctx Context, caseType CaseType) ([]DocumentTe
 		templateSet = "digitallpa"
 	}
 
-	req, err := c.newRequest(ctx, http.MethodGet, fmt.Sprintf("/lpa-api/v1/templates/%s", templateSet), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
 	var v documentTemplateApiResponse
-	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+
+	err := c.get(ctx, fmt.Sprintf("/lpa-api/v1/templates/%s", templateSet), &v)
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/sirius/edit_case.go
+++ b/internal/sirius/edit_case.go
@@ -1,41 +1,10 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"strings"
 )
 
 func (c *Client) EditCase(ctx Context, caseID int, caseType CaseType, caseDetails Case) error {
-	data, err := json.Marshal(caseDetails)
-	if err != nil {
-		return err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/%ss/%d", strings.ToLower(string(caseType)), caseID), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/%ss/%d", strings.ToLower(string(caseType)), caseID), caseDetails, nil)
 }

--- a/internal/sirius/edit_complaint.go
+++ b/internal/sirius/edit_complaint.go
@@ -1,40 +1,9 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) EditComplaint(ctx Context, id int, complaint Complaint) error {
-	data, err := json.Marshal(complaint)
-	if err != nil {
-		return err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/complaints/%d", id), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/complaints/%d", id), complaint, nil)
 }

--- a/internal/sirius/edit_dates.go
+++ b/internal/sirius/edit_dates.go
@@ -1,10 +1,7 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 type Dates struct {
@@ -20,33 +17,5 @@ type Dates struct {
 }
 
 func (c *Client) EditDates(ctx Context, caseID int, caseType CaseType, dates Dates) error {
-	data, err := json.Marshal(dates)
-	if err != nil {
-		return err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/%ss/%d/edit-dates", caseType, caseID), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/%ss/%d/edit-dates", caseType, caseID), dates, nil)
 }

--- a/internal/sirius/edit_digital_lpa_status.go
+++ b/internal/sirius/edit_digital_lpa_status.go
@@ -1,10 +1,7 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 type CaseStatusData struct {
@@ -12,33 +9,5 @@ type CaseStatusData struct {
 }
 
 func (c *Client) EditDigitalLPAStatus(ctx Context, caseUID string, caseStatusData CaseStatusData) error {
-	data, err := json.Marshal(caseStatusData)
-	if err != nil {
-		return err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/update-case-status", caseUID), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusNoContent {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/update-case-status", caseUID), caseStatusData, nil)
 }

--- a/internal/sirius/edit_document.go
+++ b/internal/sirius/edit_document.go
@@ -1,48 +1,18 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) EditDocument(ctx Context, uuid string, content string) (Document, error) {
-	postData, err := json.Marshal(struct {
+	var document Document
+	data := struct {
 		Content string `json:"content"`
 	}{
 		Content: content,
-	})
-	if err != nil {
-		return Document{}, err
 	}
 
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/documents/%s", uuid), bytes.NewReader(postData))
-	if err != nil {
-		return Document{}, err
-	}
+	err := c.put(ctx, fmt.Sprintf("/lpa-api/v1/documents/%s", uuid), data, &document)
 
-	res, err := c.http.Do(req)
-	if err != nil {
-		return Document{}, err
-	}
-	defer res.Body.Close() //#nosec G307 false positive
-
-	if res.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
-			return Document{}, err
-		}
-		return Document{}, v
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return Document{}, newStatusError(res)
-	}
-
-	var d Document
-	if err := json.NewDecoder(res.Body).Decode(&d); err != nil {
-		return Document{}, err
-	}
-	return d, nil
+	return document, err
 }

--- a/internal/sirius/edit_donor.go
+++ b/internal/sirius/edit_donor.go
@@ -1,40 +1,9 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) EditDonor(ctx Context, personID int, person Person) error {
-	data, err := json.Marshal(person)
-	if err != nil {
-		return err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/donors/%d", personID), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/donors/%d", personID), person, nil)
 }

--- a/internal/sirius/edit_investigation.go
+++ b/internal/sirius/edit_investigation.go
@@ -1,50 +1,9 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) EditInvestigation(ctx Context, investigationID int, investigation Investigation) error {
-	data, err := json.Marshal(investigation)
-	if err != nil {
-		return err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/investigations/%d", investigationID), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v struct {
-			Detail string              `json:"detail"`
-			Field  flexibleFieldErrors `json:"validation_errors"`
-		}
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		fieldErrors, err := v.Field.toFieldErrors()
-		if err != nil {
-			return err
-		}
-		return ValidationError{
-			Detail: v.Detail,
-			Field:  fieldErrors,
-		}
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/investigations/%d", investigationID), investigation, nil)
 }

--- a/internal/sirius/edit_payment.go
+++ b/internal/sirius/edit_payment.go
@@ -1,40 +1,9 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) EditPayment(ctx Context, paymentID int, payment Payment) error {
-	data, err := json.Marshal(payment)
-	if err != nil {
-		return err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPut, fmt.Sprintf("/lpa-api/v1/payments/%d", paymentID), bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/payments/%d", paymentID), payment, nil)
 }

--- a/internal/sirius/link_people.go
+++ b/internal/sirius/link_people.go
@@ -1,53 +1,13 @@
 package sirius
 
-import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-)
-
 func (c *Client) LinkPeople(ctx Context, parentId int, childId int) error {
-	postData, err := json.Marshal(struct {
+	postData := struct {
 		ParentId int `json:"parentId"`
 		ChildId  int `json:"childId"`
 	}{
 		ParentId: parentId,
 		ChildId:  childId,
-	})
-
-	if err != nil {
-		return err
 	}
 
-	req, err := c.newRequest(
-		ctx,
-		http.MethodPost,
-		"/lpa-api/v1/person-links",
-		bytes.NewReader(postData),
-	)
-
-	if err != nil {
-		return err
-	}
-
-	res, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-
-	defer res.Body.Close() //#nosec G307 false positive
-
-	if res.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if res.StatusCode != http.StatusNoContent {
-		return newStatusError(res)
-	}
-
-	return nil
+	return c.post(ctx, "/lpa-api/v1/person-links", postData, nil)
 }

--- a/internal/sirius/place_investigation_on_hold.go
+++ b/internal/sirius/place_investigation_on_hold.go
@@ -1,44 +1,15 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) PlaceInvestigationOnHold(ctx Context, investigationID int, reason string) error {
-	postData, err := json.Marshal(struct {
+	postData := struct {
 		Reason string `json:"reason"`
 	}{
 		Reason: reason,
-	})
-	if err != nil {
-		return err
 	}
 
-	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("/lpa-api/v1/investigations/%d/hold-periods", investigationID), bytes.NewReader(postData))
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.post(ctx, fmt.Sprintf("/lpa-api/v1/investigations/%d/hold-periods", investigationID), postData, nil)
 }

--- a/internal/sirius/search.go
+++ b/internal/sirius/search.go
@@ -1,10 +1,7 @@
 package sirius
 
 import (
-	"bytes"
-	"encoding/json"
 	"math"
-	"net/http"
 )
 
 const PageLimit = 25
@@ -59,27 +56,10 @@ func (c *Client) Search(ctx Context, term string, page int, personTypeFilters []
 		personTypeFilters = AllPersonTypes
 	}
 
-	data, err := json.Marshal(searchRequest{Term: term, PersonTypes: personTypeFilters, Limit: PageLimit, From: PageLimit * (page - 1)})
+	data := searchRequest{Term: term, PersonTypes: personTypeFilters, Limit: PageLimit, From: PageLimit * (page - 1)}
+
+	err := c.post(ctx, "/lpa-api/v1/search/persons", data, &v)
 	if err != nil {
-		return v, nil, err
-	}
-
-	req, err := c.newRequest(ctx, http.MethodPost, "/lpa-api/v1/search/persons", bytes.NewReader(data))
-	if err != nil {
-		return v, nil, err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return v, nil, err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode != http.StatusOK {
-		return v, nil, newStatusError(resp)
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
 		return v, nil, err
 	}
 

--- a/internal/sirius/take_investigation_off_hold.go
+++ b/internal/sirius/take_investigation_off_hold.go
@@ -1,34 +1,9 @@
 package sirius
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 func (c *Client) TakeInvestigationOffHold(ctx Context, holdPeriodId int) error {
-	req, err := c.newRequest(ctx, http.MethodDelete, fmt.Sprintf("/lpa-api/v1/hold-periods/%d", holdPeriodId), nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode == http.StatusBadRequest {
-		var v ValidationError
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return err
-		}
-		return v
-	}
-
-	if resp.StatusCode != http.StatusNoContent {
-		return newStatusError(resp)
-	}
-
-	return nil
+	return c.delete(ctx, fmt.Sprintf("/lpa-api/v1/hold-periods/%d", holdPeriodId))
 }

--- a/internal/sirius/warning.go
+++ b/internal/sirius/warning.go
@@ -1,9 +1,7 @@
 package sirius
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 type Warning struct {
@@ -15,27 +13,10 @@ type Warning struct {
 }
 
 func (c *Client) WarningsForCase(ctx Context, caseId int) ([]Warning, error) {
+	var warningList []Warning
 	path := fmt.Sprintf("/lpa-api/v1/cases/%d/warnings", caseId)
 
-	req, err := c.newRequest(ctx, http.MethodGet, path, nil)
-
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close() //#nosec G307 false positive
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, newStatusError(resp)
-	}
-
-	var warningList []Warning
-	err = json.NewDecoder(resp.Body).Decode(&warningList)
+	err := c.get(ctx, path, &warningList)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Reduce duplication in Sirius client code by introducing reusable put/post/delete methods.

#patch
