### PR TITLE
VEGA-2771 : Updates for enabling replacement attorney while removing an attorney

### DIFF
--- a/cypress/e2e/remove-an-attorney.cy.js
+++ b/cypress/e2e/remove-an-attorney.cy.js
@@ -278,12 +278,14 @@ describe("Remove an attorney", () => {
       .should("not.include", "remove-an-attorney");
   });
 
-  it("shows the Remove an attorney page with active attorneys", () => {
+  it("shows the Remove an attorney page with active attorneys and inactive attorneys", () => {
     cy.contains("Remove an attorney");
     cy.get('input[name="confirmRemoval"]').should("not.exist");
+    cy.contains("Select an attorney to remove");
     cy.get(".govuk-label").contains("Katheryn Collins");
     cy.get(".govuk-label").contains("Rachel Jones");
-    cy.get(".govuk-label").contains("Barry Smith").should("not.exist");
+    cy.contains("Select replacement attorneys to step in");
+    cy.get(".govuk-label").contains("Barry Smith");
   });
 
   it("shows an error when submitting a blank Remove an attorney form", () => {
@@ -291,13 +293,15 @@ describe("Remove an attorney", () => {
     cy.contains("There is a problem");
   });
 
-  it("shows the Confirm removal of attorney page when submitting the Remove an attorney form with an active attorney selected", () => {
+  it("shows the Confirm removal of attorney page when submitting the Remove an attorney form with an active attorney and an inactive attorney selected", () => {
     cy.contains("Remove an attorney");
     cy.get('input[name="confirmRemoval"]').should("not.exist");
-    cy.get("#f-attorney-1").click();
+    cy.get("#f-activeAttorney-1").click();
+    cy.get("#f-inactiveAttorney-1").click();
     cy.get("button").contains("Continue").click();
     cy.url().should("include", "/lpa/M-1111-1111-1111/remove-an-attorney");
     cy.contains("Confirm removal of attorney");
     cy.get(".govuk-summary-list__value").contains("Katheryn Collins");
+    cy.get(".govuk-summary-list__value").contains("Barry Smith");
   });
 });

--- a/internal/server/remove_an_attorney.go
+++ b/internal/server/remove_an_attorney.go
@@ -95,7 +95,7 @@ func RemoveAnAttorney(client RemoveAnAttorneyClient, removeTmpl template.Templat
 
 			if len(data.Form.EnabledAttorneyUids) > 0 && postFormCheckboxChecked(r, "skipEnableAttorney", "yes") {
 				data.Error.Field["enableAttorney"] = map[string]string{
-					"reason": "Please do not select both the options",
+					"reason": "Please do not select both a replacement attorney and the option to skip",
 				}
 			}
 

--- a/web/template/mlpa-confirm-attorney-removal.gohtml
+++ b/web/template/mlpa-confirm-attorney-removal.gohtml
@@ -15,33 +15,77 @@
 
       <form class="form" method="POST">
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}">
-        <input type="hidden" name="selectedAttorney" value="{{ .SelectedAttorneyUid }}"/>
+        <input type="hidden" name="removedAttorney" value="{{ .Form.RemovedAttorneyUid }}"/>
+        {{ range $idx, $enabledAttUid := .Form.EnabledAttorneyUids }}
+          <input type="hidden" name="enabledAttorney" value="{{ $enabledAttUid }}"/>
+        {{ end }}
+        <input type="hidden" name="skipEnableAttorney" value="{{ .Form.SkipEnableAttorney }}"/>
         <input type="hidden" name="confirmRemoval"/>
 
-        <div class="govuk-form-group{{ if .Error.Field.selectAttorney }} govuk-form-group--error{{ end }}">
+        <div class="govuk-form-group{{ if .Error.Field.removeAttorney }} govuk-form-group--error{{ end }}">
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend"><strong>Attorney to be removed</strong></legend>
-            {{ template "errors" .Error.Field.selectAttorney }}
+            {{ template "errors" .Error.Field.removeAttorney }}
 
             <dl class="govuk-summary-list">
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Name</dt>
                 <dd class="govuk-summary-list__value govuk-!-font-weight-bold">
-                  {{ .SelectedAttorneyName }}
+                  {{ .RemovedAttorneysDetails.SelectedAttorneyName }}
                 </dd>
               </div>
 
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Date of birth</dt>
                 <dd class="govuk-summary-list__value">
-                  {{ if not (eq .SelectedAttorneyDob "") }}
-                    {{ parseAndFormatDate .SelectedAttorneyDob "2006-01-02" "2 January 2006" }}
+                  {{ if not (eq .RemovedAttorneysDetails.SelectedAttorneyDob "") }}
+                    {{ parseAndFormatDate .RemovedAttorneysDetails.SelectedAttorneyDob "2006-01-02" "2 January 2006" }}
                   {{ end }}
                 </dd>
               </div>
             </dl>
           </fieldset>
         </div>
+
+        {{ if gt (len .Form.EnabledAttorneyUids) 0 }}
+          <div class="govuk-form-group{{ if .Error.Field.enableAttorney }} govuk-form-group--error{{ end }}">
+            <fieldset class="govuk-fieldset">
+              <legend class="govuk-fieldset__legend"><strong>Replacement Attorneys stepping in</strong></legend>
+              {{ template "errors" .Error.Field.enableAttorney }}
+
+              {{ range $idx, $enabledAttorney := .EnabledAttorneysDetails }}
+                <dl class="govuk-summary-list">
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Name</dt>
+                    <dd class="govuk-summary-list__value govuk-!-font-weight-bold">
+                      {{ $enabledAttorney.SelectedAttorneyName }}
+                    </dd>
+                  </div>
+
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Date of birth</dt>
+                    <dd class="govuk-summary-list__value">
+                      {{ if not (eq $enabledAttorney.SelectedAttorneyDob "") }}
+                        {{ parseAndFormatDate $enabledAttorney.SelectedAttorneyDob "2006-01-02" "2 January 2006" }}
+                      {{ end }}
+                    </dd>
+                  </div>
+                </dl>
+              {{ end }}
+            </fieldset>
+          </div>
+        {{ else }}
+          <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset">
+              <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                  <p>No replacement attorneys to step in</p>
+                </div>
+              </dl>
+            </fieldset>
+          </div>
+        {{ end }}
+
         <div class="govuk-button-group">
           <button class="govuk-button" data-module="govuk-button" type="submit">Confirm removal</button>
           <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/lpa/%s/remove-an-attorney" .CaseSummary.DigitalLpa.UID )}}">Return to previous screen</a>

--- a/web/template/mlpa-confirm-attorney-removal.gohtml
+++ b/web/template/mlpa-confirm-attorney-removal.gohtml
@@ -16,7 +16,7 @@
       <form class="form" method="POST">
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}">
         <input type="hidden" name="removedAttorney" value="{{ .Form.RemovedAttorneyUid }}"/>
-        {{ range $idx, $enabledAttUid := .Form.EnabledAttorneyUids }}
+        {{ range $enabledAttUid := .Form.EnabledAttorneyUids }}
           <input type="hidden" name="enabledAttorney" value="{{ $enabledAttUid }}"/>
         {{ end }}
         <input type="hidden" name="skipEnableAttorney" value="{{ .Form.SkipEnableAttorney }}"/>
@@ -53,7 +53,7 @@
               <legend class="govuk-fieldset__legend"><strong>Replacement Attorneys stepping in</strong></legend>
               {{ template "errors" .Error.Field.enableAttorney }}
 
-              {{ range $idx, $enabledAttorney := .EnabledAttorneysDetails }}
+              {{ range $enabledAttorney := .EnabledAttorneysDetails }}
                 <dl class="govuk-summary-list">
                   <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">Name</dt>

--- a/web/template/mlpa-remove-attorney.gohtml
+++ b/web/template/mlpa-remove-attorney.gohtml
@@ -60,8 +60,8 @@
                   </div>
                 {{ end }}
               </div>
+              <p class="govuk-body">or</p>
             {{ end }}
-            <p class="govuk-body">or</p>
           </fieldset>
           <fieldset class="govuk-fieldset">
             <div class="govuk-checkboxes" data-module="govuk-checkboxes">

--- a/web/template/mlpa-remove-attorney.gohtml
+++ b/web/template/mlpa-remove-attorney.gohtml
@@ -16,24 +16,62 @@
       <form class="form" method="POST">
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}">
 
-        <div class="govuk-form-group{{ if .Error.Field.selectAttorney }} govuk-form-group--error{{ end }}">
+        <div class="govuk-form-group{{ if .Error.Field.removeAttorney }} govuk-form-group--error{{ end }}">
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend"><strong>Select an attorney to remove</strong></legend>
-            {{ template "errors" .Error.Field.selectAttorney }}
+            {{ template "errors" .Error.Field.removeAttorney }}
 
             <div class="govuk-radios" data-module="govuk-radios">
-              {{ range $num, $attorney := .ActiveAttorneys }}
+              {{ range $num, $activeAttorney := .ActiveAttorneys }}
                 <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="f-attorney-{{ plusN $num 1 }}" name="selectedAttorney" type="radio" value="{{ $attorney.Uid }}" {{ if eq $attorney.Uid $.SelectedAttorneyUid }}checked{{ end }}>
-                  <label class="govuk-label govuk-radios__label" for="f-attorney-{{ plusN $num 1 }}">
-                    {{ $attorney.FirstNames }} {{ $attorney.LastName }}
+                  <input class="govuk-radios__input" id="f-activeAttorney-{{ plusN $num 1 }}" name="removedAttorney" type="radio" value="{{ $activeAttorney.Uid }}"
+                         {{ if eq $activeAttorney.Uid $.Form.RemovedAttorneyUid }}checked{{ end }}>
+                  <label class="govuk-label govuk-radios__label" for="f-activeAttorney-{{ plusN $num 1 }}">
+                    {{ $activeAttorney.FirstNames }} {{ $activeAttorney.LastName }}
                     <br>
-                    {{ if not (eq $attorney.DateOfBirth "") }}
-                      {{ parseAndFormatDate $attorney.DateOfBirth "2006-01-02" "2 January 2006" }}
+                    {{ if not (eq $activeAttorney.DateOfBirth "") }}
+                      {{ parseAndFormatDate $activeAttorney.DateOfBirth "2006-01-02" "2 January 2006" }}
                     {{ end }}
                   </label>
                 </div>
               {{ end }}
+            </div>
+          </fieldset>
+        </div>
+
+        <div class="govuk-form-group{{ if .Error.Field.enableAttorney }} govuk-form-group--error{{ end }}">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend"><strong>Select replacement attorneys to step in</strong></legend>
+            {{ template "errors" .Error.Field.enableAttorney }}
+
+            {{ if gt (len .InactiveAttorneys) 0 }}
+              <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                {{ range $idx, $inactiveAttorney := .InactiveAttorneys }}
+                  <div class="govuk-checkboxes__item">
+                    <input class="govuk-checkboxes__input" id="f-inactiveAttorney-{{ plusN $idx 1 }}" name="enabledAttorney" type="checkbox" value="{{ $inactiveAttorney.Uid }}"
+                           {{ if contains $.Form.EnabledAttorneyUids $inactiveAttorney.Uid }}checked{{ end }}>
+                    <label class="govuk-label govuk-checkboxes__label" for="f-inactiveAttorney-{{ plusN $idx 1 }}">
+                      {{ $inactiveAttorney.FirstNames }} {{ $inactiveAttorney.LastName }}
+                      <br>
+                      {{ if not (eq $inactiveAttorney.DateOfBirth "") }}
+                        {{ parseAndFormatDate $inactiveAttorney.DateOfBirth "2006-01-02" "2 January 2006" }}
+                      {{ end }}
+                    </label>
+                  </div>
+                {{ end }}
+              </div>
+            {{ end }}
+            <p class="govuk-body">or</p>
+          </fieldset>
+          <fieldset class="govuk-fieldset">
+            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="f-skipEnableAttorney" name="skipEnableAttorney" type="checkbox" value="yes"
+                         {{ if eq "yes" $.Form.SkipEnableAttorney }}checked{{ end }}>
+                  <label class="govuk-label govuk-checkboxes__label" for="f-skipEnableAttorney">
+                    No replacement attorneys to step in
+                  </label>
+                </div>
             </div>
           </fieldset>
         </div>


### PR DESCRIPTION
This PR covers [VEGA-2771](https://opgtransform.atlassian.net/browse/VEGA-2771)

The implementation around the attorney removal (done initially) has been changed to fit in the enabling of the replacement attorneys so that they can be sent as a single data request of attorney statuses to the API. 

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-2771]: https://opgtransform.atlassian.net/browse/VEGA-2771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ