### PR TITLE
VEGA-2886 : Add Removed Attorneys section #minor

### DIFF
--- a/cypress/e2e/digital-lpa.cy.js
+++ b/cypress/e2e/digital-lpa.cy.js
@@ -670,6 +670,7 @@ describe("View a digital LPA", () => {
     cy.contains("LPA details").click();
     cy.contains("Attorneys (2)");
     cy.contains("Replacement attorneys (2)");
+    cy.contains("Removed attorneys (1)");
     cy.contains("Notified people (0)");
     cy.contains("Correspondent");
 

--- a/internal/server/get_lpa_details.go
+++ b/internal/server/get_lpa_details.go
@@ -22,6 +22,7 @@ type getLpaDetails struct {
 	ReviewRestrictions      bool
 	ReplacementAttorneys    []sirius.LpaStoreAttorney
 	NonReplacementAttorneys []sirius.LpaStoreAttorney
+	RemovedAttorneys        []sirius.LpaStoreAttorney
 	FlashMessage            FlashNotification
 }
 
@@ -74,21 +75,21 @@ func GetLpaDetails(client GetLpaDetailsClient, tmpl template.Template) Handler {
 
 		var replacementAttorneys []sirius.LpaStoreAttorney
 		var nonReplacementAttorneys []sirius.LpaStoreAttorney
+		var removedAttorneys []sirius.LpaStoreAttorney
 		for _, attorney := range data.DigitalLpa.LpaStoreData.Attorneys {
-			if attorney.Status == shared.RemovedAttorneyStatus.String() {
-				continue
-			}
-
 			if attorney.Status == shared.ActiveAttorneyStatus.String() {
 				nonReplacementAttorneys = append(nonReplacementAttorneys, attorney)
 			} else if attorney.Status == shared.InactiveAttorneyStatus.String() &&
 				attorney.AppointmentType == shared.ReplacementAppointmentType.String() {
 				replacementAttorneys = append(replacementAttorneys, attorney)
+			} else if attorney.Status == shared.RemovedAttorneyStatus.String() {
+				removedAttorneys = append(removedAttorneys, attorney)
 			}
 		}
 
 		data.ReplacementAttorneys = replacementAttorneys
 		data.NonReplacementAttorneys = nonReplacementAttorneys
+		data.RemovedAttorneys = removedAttorneys
 
 		return tmpl(w, data)
 	}

--- a/internal/server/get_lpa_details_test.go
+++ b/internal/server/get_lpa_details_test.go
@@ -230,6 +230,15 @@ func TestGetLpaDetailsSuccess(t *testing.T) {
 							},
 						},
 					},
+					RemovedAttorneys: []sirius.LpaStoreAttorney{
+						{
+							Status:          shared.RemovedAttorneyStatus.String(),
+							AppointmentType: shared.OriginalAppointmentType.String(),
+							LpaStorePerson: sirius.LpaStorePerson{
+								Email: "fifth@does.not.exist",
+							},
+						},
+					},
 				}).
 				Return(nil)
 

--- a/web/template/layout/removed-attorney-details.gohtml
+++ b/web/template/layout/removed-attorney-details.gohtml
@@ -13,7 +13,7 @@
     </div>
     <div id="accordion-default-content-4" class="govuk-accordion__section-content">
         {{ if (gt (len .RemovedAttorneys) 0) }}
-            {{ range $num, $attorney := .ReplacementAttorneys }}
+            {{ range $num, $attorney := .RemovedAttorneys }}
                 <h2 class="govuk-heading-m">
                     Removed attorney {{ plusN $num 1 }}
                 </h2>

--- a/web/template/layout/removed-attorney-details.gohtml
+++ b/web/template/layout/removed-attorney-details.gohtml
@@ -1,0 +1,101 @@
+{{ define "removed-attorney-details" }}
+
+{{ $caseUID :=  .CaseSummary.DigitalLpa.UID}}
+
+<!-- removed attorneys -->
+<div class="govuk-accordion__section">
+    <div class="govuk-accordion__section-header">
+        <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-default-heading-9">
+                Removed attorneys ({{ len .RemovedAttorneys }})
+              </span>
+        </h2>
+    </div>
+    <div id="accordion-default-content-4" class="govuk-accordion__section-content">
+        {{ if (gt (len .RemovedAttorneys) 0) }}
+            {{ range $num, $attorney := .ReplacementAttorneys }}
+                <h2 class="govuk-heading-m">
+                    Removed attorney {{ plusN $num 1 }}
+                </h2>
+
+                <dl class="govuk-summary-list">
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">First names</dt>
+                        <dd class="govuk-summary-list__value">{{ $attorney.FirstNames }}</dd>
+                    </div>
+
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">Last name</dt>
+                        <dd class="govuk-summary-list__value">{{ $attorney.LastName }}</dd>
+                    </div>
+
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">Date of birth</dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ if not (eq $attorney.DateOfBirth "") }}
+                                {{ parseAndFormatDate $attorney.DateOfBirth "2006-01-02" "2 January 2006" }}
+                            {{ end }}
+                        </dd>
+                    </div>
+
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">Address</dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ template "mlpa-address" $attorney.Address }}
+                        </dd>
+                    </div>
+
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">Email</dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ if (eq $attorney.Email "") }}
+                                Not provided
+                            {{ else }}
+                                {{ $attorney.Email }}
+                            {{ end }}
+                        </dd>
+                    </div>
+
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">Phone</dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ if (eq $attorney.Mobile "") }}
+                                Not provided
+                            {{ else }}
+                                {{ $attorney.Mobile }}
+                            {{ end }}
+                        </dd>
+                    </div>
+
+                    <div class="govuk-summary-list__row{{ if eq $attorney.SignedAt "" }} govuk-summary-list__row--no-border{{ end }}">
+                        <dt class="govuk-summary-list__key">Format</dt>
+                        <dd class="govuk-summary-list__value">
+                            {{ if (eq $attorney.Email "") }}
+                                Paper
+                            {{ else }}
+                                Online
+                            {{ end }}
+                            {{ if not (eq $attorney.ContactLanguagePreference "") }}
+                                <br>{{ languageForFormat $attorney.ContactLanguagePreference }}
+                            {{ end }}
+                        </dd>
+                    </div>
+
+                    {{ if ne $attorney.SignedAt "" }}
+                        <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
+                            <dt class="govuk-summary-list__key">Signed on</dt>
+                            <dd class="govuk-summary-list__value">
+                                {{ parseAndFormatDate $attorney.SignedAt "2006-01-02T15:04:05Z" "2 January 2006" }}
+                            </dd>
+                        </div>
+                    {{ end }}
+
+                </dl>
+            {{ end }}
+
+        {{ else }}
+            <p class="govuk-body">No attorneys have been removed from this LPA</p>
+        {{ end }}
+    </div>
+</div>
+{{ end }}

--- a/web/template/mlpa-details.gohtml
+++ b/web/template/mlpa-details.gohtml
@@ -224,6 +224,8 @@
 
         {{ template "restrictions-and-conditions" . }}
 
+        {{ template "removed-attorney-details" . }}
+
         {{ template "certificate-provider-details" . }}
 
         <div class="govuk-accordion__section">


### PR DESCRIPTION
This PR covers [VEGA-2886](https://opgtransform.atlassian.net/browse/VEGA-2886)

As discussed with Katie, it has been agreed to retain the same design (fields) for the Removed Attorney section as is for the current Attorneys and Replacement Attorneys to keep the design consistent. The updated design (updated labels) as per the attached screenshots in the ticket would be applied in a separate ticket covering all the attorney sections together.

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-2886]: https://opgtransform.atlassian.net/browse/VEGA-2886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ