### PR TITLE
VEGA-2871 : Logic for capturing the donor consent for severance

### DIFF
--- a/cypress/e2e/manage-restrictions.cy.js
+++ b/cypress/e2e/manage-restrictions.cy.js
@@ -120,9 +120,7 @@ describe("Manage restrictions form", () => {
 
   it("can go back to changing the severance required option", () => {
     cy.contains("Change").click();
-    cy.url().should("contain", "/lpa/M-6666-6666-6666/lpa-details");
-    cy.contains("Manage restrictions and conditions");
-    cy.url().should("contain", "/lpa/M-6666-6666-6666/manage-restrictions");
+    cy.url().should("contain", "/lpa/M-6666-6666-6666/manage-restrictions?action=change-severance-required");
     cy.contains("Manage restrictions and conditions");
     cy.contains("Select an option");
     cy.contains("Severance application is not required");

--- a/cypress/e2e/manage-restrictions.cy.js
+++ b/cypress/e2e/manage-restrictions.cy.js
@@ -113,9 +113,20 @@ describe("Manage restrictions form", () => {
       cy.url().should("contain", "/lpa/M-6666-6666-6666/manage-restrictions");
       cy.contains("Manage restrictions and conditions");
       cy.contains("Select an option");
-      cy.contains("Severance application is not required");
-      cy.contains("Severance application is required");
+      cy.contains("Donor has provided consent to a severance application");
+      cy.contains("Donor has refused severance of restriction and conditions");
     });
+  });
+
+  it("can go back to changing the severance required option", () => {
+    cy.contains("Change").click();
+    cy.url().should("contain", "/lpa/M-6666-6666-6666/lpa-details");
+    cy.contains("Manage restrictions and conditions");
+    cy.url().should("contain", "/lpa/M-6666-6666-6666/manage-restrictions");
+    cy.contains("Manage restrictions and conditions");
+    cy.contains("Select an option");
+    cy.contains("Severance application is not required");
+    cy.contains("Severance application is required");
   });
 
   it("can go Back to LPA details", () => {
@@ -129,7 +140,7 @@ describe("Manage restrictions form", () => {
   });
 
   it("errors when submitting without selecting an option", () => {
-    cy.contains("Confirm").click();
+    cy.contains("Save and exit").click();
     cy.contains("Please select an option");
   });
 
@@ -144,6 +155,7 @@ describe("Manage restrictions form", () => {
         status: 204,
       },
     );
+    cy.contains("Change").click();
     cy.contains("Severance application is not required").click();
     cy.contains("Confirm").click();
     cy.url().should("contain", "/lpa/M-6666-6666-6666/lpa-details");
@@ -157,6 +169,7 @@ describe("Manage restrictions form", () => {
         status: 204,
       },
     );
+    cy.contains("Change").click();
     cy.contains("Severance application is required").click();
     cy.contains("Confirm").click();
     cy.url().should("contain", "/lpa/M-6666-6666-6666/lpa-details");

--- a/cypress/e2e/manage-restrictions.cy.js
+++ b/cypress/e2e/manage-restrictions.cy.js
@@ -120,7 +120,8 @@ describe("Manage restrictions form", () => {
 
   it("can go back to changing the severance required option", () => {
     cy.contains("Change").click();
-    cy.url().should("contain", "/lpa/M-6666-6666-6666/manage-restrictions?action=change-severance-required");
+    cy.url().should("contain", "/lpa/M-6666-6666-6666/manage-restrictions");
+    cy.url().should("contain", "action=change-severance-required");
     cy.contains("Manage restrictions and conditions");
     cy.contains("Select an option");
     cy.contains("Severance application is not required");

--- a/internal/server/manage_restrictions.go
+++ b/internal/server/manage_restrictions.go
@@ -18,13 +18,14 @@ type ManageRestrictionsClient interface {
 }
 
 type manageRestrictionsData struct {
-	XSRFToken       string
-	Error           sirius.ValidationError
-	CaseUID         string
-	CaseSummary     sirius.CaseSummary
-	SeveranceAction string
-	FormAction      string
-	Success         bool
+	XSRFToken         string
+	Error             sirius.ValidationError
+	CaseUID           string
+	CaseSummary       sirius.CaseSummary
+	SeveranceAction   string
+	DonorConsentGiven string
+	FormAction        string
+	Success           bool
 }
 
 func ManageRestrictions(client ManageRestrictionsClient, tmpl template.Template) Handler {
@@ -54,14 +55,18 @@ func ManageRestrictions(client ManageRestrictionsClient, tmpl template.Template)
 		}
 
 		data := manageRestrictionsData{
-			CaseSummary:     cs,
-			SeveranceAction: postFormString(r, "severanceAction"),
-			XSRFToken:       ctx.XSRFToken,
-			Error:           sirius.ValidationError{Field: sirius.FieldErrors{}},
-			CaseUID:         caseUID,
+			CaseSummary:       cs,
+			SeveranceAction:   postFormString(r, "severanceAction"),
+			DonorConsentGiven: postFormString(r, "donorConsentGiven"),
+			XSRFToken:         ctx.XSRFToken,
+			Error:             sirius.ValidationError{Field: sirius.FieldErrors{}},
+			CaseUID:           caseUID,
 		}
 
 		data.FormAction = r.FormValue("action")
+		if data.FormAction == "" && data.CaseSummary.DigitalLpa.SiriusData.Application.SeveranceStatus == "REQUIRED" {
+			data.FormAction = "donor-consent"
+		}
 
 		if r.Method == http.MethodPost {
 			taskList := data.CaseSummary.TaskList
@@ -72,55 +77,59 @@ func ManageRestrictions(client ManageRestrictionsClient, tmpl template.Template)
 				}
 			}
 
-			switch data.SeveranceAction {
-			case "donor-consent-given", "donor-consent-not-given":
-				hasDonorConsented := true
-				if data.SeveranceAction == "donor-consent-not-given" {
-					hasDonorConsented = false
-				}
-
-				err := client.EditSeveranceApplication(ctx, caseUID, sirius.SeveranceApplicationDetails{
-					HasDonorConsented: hasDonorConsented,
-				})
-				if handleError(w, &data, err) {
-					return err
-				}
-
-				data.Success = true
-				SetFlash(w, FlashNotification{
-					Title: "Update saved",
-				})
-				return RedirectError(fmt.Sprintf("/lpa/%s/lpa-details", caseUID))
-
-			case "severance-application-required", "severance-application-not-required":
-				severanceStatus := "REQUIRED"
-				if data.SeveranceAction == "severance-application-not-required" {
-					severanceStatus = "NOT_REQUIRED"
-				}
-				err = client.UpdateSeveranceStatus(ctx, caseUID, sirius.SeveranceStatusData{
-					SeveranceStatus: severanceStatus,
-				})
-				if handleError(w, &data, err) {
-					return err
-				}
-
-				if data.SeveranceAction == "severance-application-not-required" {
-					err := client.ClearTask(ctx, taskID)
+			if data.FormAction == "" || data.FormAction == "change-severance-required" {
+				switch data.SeveranceAction {
+				case "severance-application-required", "severance-application-not-required":
+					severanceStatus := "REQUIRED"
+					if data.SeveranceAction == "severance-application-not-required" {
+						severanceStatus = "NOT_REQUIRED"
+					}
+					err = client.UpdateSeveranceStatus(ctx, caseUID, sirius.SeveranceStatusData{
+						SeveranceStatus: severanceStatus,
+					})
 					if handleError(w, &data, err) {
 						return err
 					}
+
+					if data.SeveranceAction == "severance-application-not-required" {
+						err := client.ClearTask(ctx, taskID)
+						if handleError(w, &data, err) {
+							return err
+						}
+					}
+
+					return handleSuccess(w, &data, caseUID)
+
+				default:
+					w.WriteHeader(http.StatusBadRequest)
+					data.Error.Field["severanceAction"] = map[string]string{
+						"reason": "Please select an option",
+					}
 				}
+			}
 
-				data.Success = true
-				SetFlash(w, FlashNotification{
-					Title: "Update saved",
-				})
-				return RedirectError(fmt.Sprintf("/lpa/%s/lpa-details", caseUID))
+			if data.FormAction == "donor-consent" {
+				switch data.DonorConsentGiven {
+				case "donor-consent-given", "donor-consent-not-given":
+					hasDonorConsented := true
+					if data.DonorConsentGiven == "donor-consent-not-given" {
+						hasDonorConsented = false
+					}
 
-			default:
-				w.WriteHeader(http.StatusBadRequest)
-				data.Error.Field["severanceAction"] = map[string]string{
-					"reason": "Please select an option",
+					err := client.EditSeveranceApplication(ctx, caseUID, sirius.SeveranceApplicationDetails{
+						HasDonorConsented: hasDonorConsented,
+					})
+					if handleError(w, &data, err) {
+						return err
+					}
+
+					return handleSuccess(w, &data, caseUID)
+
+				default:
+					w.WriteHeader(http.StatusBadRequest)
+					data.Error.Field["donorConsentAction"] = map[string]string{
+						"reason": "Please select an option",
+					}
 				}
 			}
 		}
@@ -138,4 +147,12 @@ func handleError(w http.ResponseWriter, data *manageRestrictionsData, err error)
 		return true
 	}
 	return true
+}
+
+func handleSuccess(w http.ResponseWriter, data *manageRestrictionsData, caseUID string) RedirectError {
+	data.Success = true
+	SetFlash(w, FlashNotification{
+		Title: "Update saved",
+	})
+	return RedirectError(fmt.Sprintf("/lpa/%s/lpa-details", caseUID))
 }

--- a/internal/sirius/edit_severance_application.go
+++ b/internal/sirius/edit_severance_application.go
@@ -1,0 +1,16 @@
+package sirius
+
+import (
+	"fmt"
+)
+
+type SeveranceApplicationDetails struct {
+	HasDonorConsented      bool       `json:"hasDonorConsented"`
+	SeveranceOrdered       bool       `json:"severanceOrdered"`
+	CourtOrderDecisionMade DateString `json:"courtOrderDecisionMade"`
+	CourtOrderReceived     DateString `json:"courtOrderReceived"`
+}
+
+func (c *Client) EditSeveranceApplication(ctx Context, caseUID string, severanceApplicationDetails SeveranceApplicationDetails) error {
+	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/severance", caseUID), severanceApplicationDetails, nil)
+}

--- a/internal/sirius/edit_severance_application_test.go
+++ b/internal/sirius/edit_severance_application_test.go
@@ -40,7 +40,7 @@ func TestEditSeveranceApplication(t *testing.T) {
 						},
 						Body: map[string]interface{}{
 							"hasDonorConsented":      true,
-							"severanceOrdered":       nil,
+							"severanceOrdered":       false,
 							"courtOrderDecisionMade": nil,
 							"courtOrderReceived":     nil,
 						},

--- a/internal/sirius/edit_severance_application_test.go
+++ b/internal/sirius/edit_severance_application_test.go
@@ -1,0 +1,73 @@
+package sirius
+
+import (
+	"context"
+	"fmt"
+	"github.com/pact-foundation/pact-go/v2/consumer"
+	"github.com/pact-foundation/pact-go/v2/matchers"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestEditSeveranceApplication(t *testing.T) {
+	t.Parallel()
+
+	pact, err := newPact()
+	assert.NoError(t, err)
+
+	testCases := []struct {
+		name                        string
+		severanceApplicationDetails SeveranceApplicationDetails
+		setup                       func()
+		expectedError               func(int) error
+	}{
+		{
+			name: "Donor consent given",
+			severanceApplicationDetails: SeveranceApplicationDetails{
+				HasDonorConsented: true,
+			},
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("A digital LPA exists").
+					UponReceiving("A request for editing severance application").
+					WithCompleteRequest(consumer.Request{
+						Method: http.MethodPut,
+						Path:   matchers.String("/lpa-api/v1/digital-lpas/M-1234-9876-4567/severance"),
+						Headers: matchers.MapMatcher{
+							"Content-Type": matchers.String("application/json"),
+						},
+						Body: map[string]interface{}{
+							"hasDonorConsented":      true,
+							"severanceOrdered":       "",
+							"courtOrderDecisionMade": "",
+							"courtOrderReceived":     "",
+						},
+					}).
+					WithCompleteResponse(consumer.Response{
+						Status: http.StatusNoContent,
+					})
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+
+			assert.Nil(t, pact.ExecuteTest(t, func(config consumer.MockServerConfig) error {
+				client := NewClient(http.DefaultClient, fmt.Sprintf("http://127.0.0.1:%d", config.Port))
+
+				err := client.EditSeveranceApplication(Context{Context: context.Background()}, "M-1234-9876-4567", tc.severanceApplicationDetails)
+
+				if tc.expectedError == nil {
+					assert.Nil(t, err)
+				} else {
+					assert.Equal(t, tc.expectedError(config.Port), err)
+				}
+				return nil
+			}))
+		})
+	}
+}

--- a/internal/sirius/edit_severance_application_test.go
+++ b/internal/sirius/edit_severance_application_test.go
@@ -40,9 +40,9 @@ func TestEditSeveranceApplication(t *testing.T) {
 						},
 						Body: map[string]interface{}{
 							"hasDonorConsented":      true,
-							"severanceOrdered":       "",
-							"courtOrderDecisionMade": "",
-							"courtOrderReceived":     "",
+							"severanceOrdered":       nil,
+							"courtOrderDecisionMade": nil,
+							"courtOrderReceived":     nil,
 						},
 					}).
 					WithCompleteResponse(consumer.Response{

--- a/web/template/manage-restrictions.gohtml
+++ b/web/template/manage-restrictions.gohtml
@@ -23,48 +23,76 @@
                             <strong>Severance application required:</strong>
                             {{ severanceRequiredLabel .CaseSummary.DigitalLpa.SiriusData.Application.SeveranceStatus }}
                         </p>
+                        <p class="govuk-body">
+                            <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/lpa/%s/manage-restrictions?action=changeSeveranceRequired" .CaseUID )}}">Change</a>
+                        </p>
                     {{ end }}
 
                     {{ if eq .CaseSummary.DigitalLpa.SiriusData.Application.SeveranceStatus "NOT_REQUIRED" }}
-                    <fieldset class="govuk-fieldset">
-                        <legend class="govuk-fieldset__legend"><strong>Select an option:</strong></legend>
-                        {{ template "errors" .Error.Field.severanceAction }}
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend"><strong>Select an option:</strong></legend>
+                            {{ template "errors" .Error.Field.severanceAction }}
 
-                        <div class="govuk-radios" data-module="govuk-radios">
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="f-severanceActionNotRequired" name="severanceAction" type="radio" value="severance-application-required" {{ if eq "severance-application-required" .SeveranceAction }}checked{{ end }}>
-                                <label class="govuk-label govuk-radios__label" for="f-severanceActionNotRequired">
-                                    Severance application is required
-                                </label>
+                            <div class="govuk-radios" data-module="govuk-radios">
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="f-severanceActionNotRequired" name="severanceAction" type="radio" value="severance-application-required" {{ if eq "severance-application-required" .SeveranceAction }}checked{{ end }}>
+                                    <label class="govuk-label govuk-radios__label" for="f-severanceActionNotRequired">
+                                        Severance application is required
+                                    </label>
+                                </div>
                             </div>
-                        </div>
-                    </fieldset>
+                        </fieldset>
+
+                    {{ else if and (eq .CaseSummary.DigitalLpa.SiriusData.Application.SeveranceStatus "REQUIRED") (eq .FormAction "") }}
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend"><strong>Select an option:</strong></legend>
+                            {{ template "errors" .Error.Field.donorConsentAction }}
+
+                            <div class="govuk-radios" data-module="govuk-radios">
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="f-donorConsentGiven" name="severanceAction" type="radio" value="donor-consent-given" {{ if eq "donor-consent-given" .SeveranceAction }}checked{{ end }}>
+                                    <label class="govuk-label govuk-radios__label" for="f-severanceActionRequired">
+                                        Donor has provided consent to a severance application
+                                    </label>
+                                </div>
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="f-donorConsentNotGiven" name="severanceAction" type="radio" value="donor-consent-not-given" {{ if eq "donor-consent-not-given" .SeveranceAction }}checked{{ end }}>
+                                    <label class="govuk-label govuk-radios__label" for="f-severanceActionNotRequired">
+                                        Donor has refused severance of restriction and conditions
+                                    </label>
+                                </div>
+                            </div>
+                        </fieldset>
 
                     {{ else }}
-                    <fieldset class="govuk-fieldset">
-                        <legend class="govuk-fieldset__legend"><strong>Select an option:</strong></legend>
-                        {{ template "errors" .Error.Field.severanceAction }}
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend"><strong>Select an option:</strong></legend>
+                            {{ template "errors" .Error.Field.severanceAction }}
 
-                        <div class="govuk-radios" data-module="govuk-radios">
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="f-severanceActionRequired" name="severanceAction" type="radio" value="severance-application-not-required" {{ if eq "severance-application-not-required" .SeveranceAction }}checked{{ end }}>
-                                <label class="govuk-label govuk-radios__label" for="f-severanceActionRequired">
-                                    Severance application is not required
-                                </label>
+                            <div class="govuk-radios" data-module="govuk-radios">
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="f-severanceActionRequired" name="severanceAction" type="radio" value="severance-application-not-required" {{ if eq "severance-application-not-required" .SeveranceAction }}checked{{ end }}>
+                                    <label class="govuk-label govuk-radios__label" for="f-severanceActionRequired">
+                                        Severance application is not required
+                                    </label>
+                                </div>
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="f-severanceActionNotRequired" name="severanceAction" type="radio" value="severance-application-required" {{ if eq "severance-application-required" .SeveranceAction }}checked{{ end }}>
+                                    <label class="govuk-label govuk-radios__label" for="f-severanceActionNotRequired">
+                                        Severance application is required
+                                    </label>
+                                </div>
                             </div>
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="f-severanceActionNotRequired" name="severanceAction" type="radio" value="severance-application-required" {{ if eq "severance-application-required" .SeveranceAction }}checked{{ end }}>
-                                <label class="govuk-label govuk-radios__label" for="f-severanceActionNotRequired">
-                                    Severance application is required
-                                </label>
-                            </div>
-                        </div>
-                    </fieldset>
+                        </fieldset>
                     {{ end }}
                 </div>
 
                 <div class="govuk-button-group">
-                    <button class="govuk-button" data-module="govuk-button" type="submit">Confirm</button>
+                    {{ if and (eq .CaseSummary.DigitalLpa.SiriusData.Application.SeveranceStatus "REQUIRED") (eq .FormAction "") }}
+                        <button class="govuk-button" data-module="govuk-button" type="submit">Save and exit</button>
+                    {{ else }}
+                        <button class="govuk-button" data-module="govuk-button" type="submit">Confirm</button>
+                    {{ end }}
                     <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/lpa/%s/lpa-details" .CaseUID )}}">Cancel</a>
                 </div>
             </form>

--- a/web/template/manage-restrictions.gohtml
+++ b/web/template/manage-restrictions.gohtml
@@ -24,7 +24,7 @@
                             {{ severanceRequiredLabel .CaseSummary.DigitalLpa.SiriusData.Application.SeveranceStatus }}
                         </p>
                         <p class="govuk-body">
-                            <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/lpa/%s/manage-restrictions?action=changeSeveranceRequired" .CaseUID )}}">Change</a>
+                            <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/lpa/%s/manage-restrictions?action=change-severance-required" .CaseUID )}}">Change</a>
                         </p>
                     {{ end }}
 
@@ -43,20 +43,20 @@
                             </div>
                         </fieldset>
 
-                    {{ else if and (eq .CaseSummary.DigitalLpa.SiriusData.Application.SeveranceStatus "REQUIRED") (eq .FormAction "") }}
+                    {{ else if eq .FormAction "donor-consent" }}
                         <fieldset class="govuk-fieldset">
                             <legend class="govuk-fieldset__legend"><strong>Select an option:</strong></legend>
                             {{ template "errors" .Error.Field.donorConsentAction }}
 
                             <div class="govuk-radios" data-module="govuk-radios">
                                 <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="f-donorConsentGiven" name="severanceAction" type="radio" value="donor-consent-given" {{ if eq "donor-consent-given" .SeveranceAction }}checked{{ end }}>
+                                    <input class="govuk-radios__input" id="f-donorConsentGiven" name="donorConsentGiven" type="radio" value="donor-consent-given" {{ if eq "donor-consent-given" .DonorConsentGiven }}checked{{ end }}>
                                     <label class="govuk-label govuk-radios__label" for="f-severanceActionRequired">
                                         Donor has provided consent to a severance application
                                     </label>
                                 </div>
                                 <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="f-donorConsentNotGiven" name="severanceAction" type="radio" value="donor-consent-not-given" {{ if eq "donor-consent-not-given" .SeveranceAction }}checked{{ end }}>
+                                    <input class="govuk-radios__input" id="f-donorConsentNotGiven" name="donorConsentGiven" type="radio" value="donor-consent-not-given" {{ if eq "donor-consent-not-given" .DonorConsentGiven }}checked{{ end }}>
                                     <label class="govuk-label govuk-radios__label" for="f-severanceActionNotRequired">
                                         Donor has refused severance of restriction and conditions
                                     </label>
@@ -88,7 +88,7 @@
                 </div>
 
                 <div class="govuk-button-group">
-                    {{ if and (eq .CaseSummary.DigitalLpa.SiriusData.Application.SeveranceStatus "REQUIRED") (eq .FormAction "") }}
+                    {{ if eq .FormAction "donor-consent" }}
                         <button class="govuk-button" data-module="govuk-button" type="submit">Save and exit</button>
                     {{ else }}
                         <button class="govuk-button" data-module="govuk-button" type="submit">Confirm</button>


### PR DESCRIPTION
This PR covers [VEGA-2871](https://opgtransform.atlassian.net/browse/VEGA-2871)

As part of this PR, there has been some refactoring done to merge in the Donor consent changes with the Severance required changes under a single route and template.

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-2871]: https://opgtransform.atlassian.net/browse/VEGA-2871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ