### PR TITLE
Replace Chi with native Go router

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/ministryofjustice/opg-sirius-lpa-frontend
 go 1.24.1
 
 require (
-	github.com/go-chi/chi/v5 v5.2.1
 	github.com/go-playground/form/v4 v4.2.1
 	github.com/ministryofjustice/opg-go-common v1.84.0
 	github.com/pact-foundation/pact-go/v2 v2.4.1

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
-github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/server/change_attorney_details.go
+++ b/internal/server/change_attorney_details.go
@@ -2,12 +2,12 @@ package server
 
 import (
 	"fmt"
-	"github.com/go-chi/chi/v5"
+	"net/http"
+
 	"github.com/go-playground/form/v4"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 	"golang.org/x/sync/errgroup"
-	"net/http"
 )
 
 type ChangeAttorneyDetailsClient interface {
@@ -43,8 +43,8 @@ func ChangeAttorneyDetails(client ChangeAttorneyDetailsClient, tmpl template.Tem
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) error {
-		caseUID := chi.URLParam(r, "uid")
-		attorneyUID := chi.URLParam(r, "attorneyUID")
+		caseUID := r.PathValue("uid")
+		attorneyUID := r.PathValue("attorneyUID")
 
 		ctx := getContext(r)
 

--- a/internal/server/change_certificate_provider_details.go
+++ b/internal/server/change_certificate_provider_details.go
@@ -2,12 +2,12 @@ package server
 
 import (
 	"fmt"
-	"github.com/go-chi/chi/v5"
+	"net/http"
+
 	"github.com/go-playground/form/v4"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 	"golang.org/x/sync/errgroup"
-	"net/http"
 )
 
 type ChangeCertificateProviderDetailsClient interface {
@@ -40,7 +40,7 @@ func ChangeCertificateProviderDetails(client ChangeCertificateProviderDetailsCli
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) error {
-		caseUid := chi.URLParam(r, "uid")
+		caseUid := r.PathValue("uid")
 		ctx := getContext(r)
 		caseSummary, err := client.CaseSummary(ctx, caseUid)
 

--- a/internal/server/change_draft.go
+++ b/internal/server/change_draft.go
@@ -2,12 +2,12 @@ package server
 
 import (
 	"fmt"
-	"github.com/go-chi/chi/v5"
+	"net/http"
+
 	"github.com/go-playground/form/v4"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 	"golang.org/x/sync/errgroup"
-	"net/http"
 )
 
 type ChangeDraftClient interface {
@@ -40,7 +40,7 @@ func ChangeDraft(client ChangeDraftClient, tmpl template.Template) Handler {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) error {
-		caseUID := chi.URLParam(r, "uid")
+		caseUID := r.PathValue("uid")
 		ctx := getContext(r)
 
 		var countries []sirius.RefDataItem

--- a/internal/server/create_document_digital_lpa.go
+++ b/internal/server/create_document_digital_lpa.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 	"strconv"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/shared"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
@@ -40,7 +39,7 @@ func CreateDocumentDigitalLpa(client CreateDocumentDigitalLpaClient, tmpl templa
 		}
 		ctx := getContext(r)
 
-		uid := chi.URLParam(r, "uid")
+		uid := r.PathValue("uid")
 
 		data := createDocumentDigitalLpaData{
 			XSRFToken: ctx.XSRFToken,

--- a/internal/server/get_application_progress.go
+++ b/internal/server/get_application_progress.go
@@ -3,7 +3,6 @@ package server
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 
 	"github.com/ministryofjustice/opg-go-common/template"
@@ -32,7 +31,7 @@ func GetApplicationProgressDetails(client GetApplicationProgressClient, tmpl tem
 	return func(w http.ResponseWriter, r *http.Request) error {
 		var data getApplicationProgressDetails
 
-		uid := chi.URLParam(r, "uid")
+		uid := r.PathValue("uid")
 		ctx := getContext(r)
 
 		var cpName string

--- a/internal/server/get_documents.go
+++ b/internal/server/get_documents.go
@@ -3,8 +3,6 @@ package server
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 )
@@ -26,7 +24,7 @@ func GetDocuments(client GetDocumentsClient, tmpl template.Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		var err error
 
-		uid := chi.URLParam(r, "uid")
+		uid := r.PathValue("uid")
 		ctx := getContext(r)
 
 		data := getDocumentsData{

--- a/internal/server/get_history.go
+++ b/internal/server/get_history.go
@@ -3,7 +3,6 @@ package server
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 
 	"github.com/ministryofjustice/opg-go-common/template"
@@ -21,7 +20,7 @@ type getHistory struct {
 
 func GetHistory(client GetHistoryClient, tmpl template.Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
-		uid := chi.URLParam(r, "uid")
+		uid := r.PathValue("uid")
 		ctx := getContext(r)
 
 		caseSummary, err := client.CaseSummary(ctx, uid)

--- a/internal/server/get_lpa_details.go
+++ b/internal/server/get_lpa_details.go
@@ -3,7 +3,6 @@ package server
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/shared"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
@@ -28,7 +27,7 @@ type getLpaDetails struct {
 
 func GetLpaDetails(client GetLpaDetailsClient, tmpl template.Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
-		uid := chi.URLParam(r, "uid")
+		uid := r.PathValue("uid")
 		ctx := getContext(r)
 
 		var err error

--- a/internal/server/get_payments.go
+++ b/internal/server/get_payments.go
@@ -1,10 +1,10 @@
 package server
 
 import (
-	"github.com/go-chi/chi/v5"
-	"golang.org/x/sync/errgroup"
 	"net/http"
 	"strconv"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
@@ -49,7 +49,7 @@ func GetPayments(client GetPaymentsClient, tmpl template.Template) Handler {
 		var caseID int
 		var err error
 
-		uid := chi.URLParam(r, "uid")
+		uid := r.PathValue("uid")
 		if uid != "" {
 			data.CaseSummary, err = client.CaseSummary(ctx, uid)
 			if err != nil {
@@ -57,7 +57,7 @@ func GetPayments(client GetPaymentsClient, tmpl template.Template) Handler {
 			}
 			caseID = data.CaseSummary.DigitalLpa.SiriusData.ID
 		} else {
-			caseID, err = strconv.Atoi(chi.URLParam(r, "id"))
+			caseID, err = strconv.Atoi(r.PathValue("id"))
 			if err != nil {
 				return err
 			}

--- a/internal/server/manage_attorneys.go
+++ b/internal/server/manage_attorneys.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"github.com/go-chi/chi/v5"
 	"net/http"
 
 	"github.com/ministryofjustice/opg-go-common/template"
@@ -23,7 +22,7 @@ type manageAttorneysData struct {
 
 func ManageAttorneys(client ManageAttorneysClient, tmpl template.Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
-		uid := chi.URLParam(r, "uid")
+		uid := r.PathValue("uid")
 		ctx := getContext(r)
 
 		caseSummary, err := client.CaseSummary(ctx, uid)

--- a/internal/server/manage_restrictions.go
+++ b/internal/server/manage_restrictions.go
@@ -2,12 +2,12 @@ package server
 
 import (
 	"fmt"
-	"github.com/go-chi/chi/v5"
+	"net/http"
+
 	"github.com/go-playground/form/v4"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 	"golang.org/x/sync/errgroup"
-	"net/http"
 )
 
 type ManageRestrictionsClient interface {
@@ -34,7 +34,7 @@ func ManageRestrictions(client ManageRestrictionsClient, tmpl template.Template)
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) error {
-		caseUID := chi.URLParam(r, "uid")
+		caseUID := r.PathValue("uid")
 		ctx := getContext(r)
 
 		var cs sirius.CaseSummary

--- a/internal/server/mock_server.go
+++ b/internal/server/mock_server.go
@@ -3,17 +3,15 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
-
-	"github.com/go-chi/chi/v5"
 )
 
 type MockServer struct {
-	mux *chi.Mux
+	mux *http.ServeMux
 	err error
 }
 
 func newMockServer(route string, handler Handler) *MockServer {
-	mux := chi.NewRouter()
+	mux := http.NewServeMux()
 	server := MockServer{
 		mux: mux,
 		err: nil,

--- a/internal/server/remove_an_attorney.go
+++ b/internal/server/remove_an_attorney.go
@@ -2,10 +2,10 @@ package server
 
 import (
 	"fmt"
-	"github.com/go-playground/form/v4"
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
+	"github.com/go-playground/form/v4"
+
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/shared"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
@@ -45,7 +45,7 @@ func RemoveAnAttorney(client RemoveAnAttorneyClient, removeTmpl template.Templat
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) error {
-		uid := chi.URLParam(r, "uid")
+		uid := r.PathValue("uid")
 		ctx := getContext(r)
 
 		caseSummary, err := client.CaseSummary(ctx, uid)

--- a/internal/server/update_decisions.go
+++ b/internal/server/update_decisions.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/go-playground/form/v4"
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
@@ -40,7 +39,7 @@ func UpdateDecisions(client UpdateDecisionsClient, tmpl template.Template) Handl
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) error {
-		caseUID := chi.URLParam(r, "uid")
+		caseUID := r.PathValue("uid")
 		ctx := getContext(r)
 
 		cs, err := client.CaseSummary(ctx, caseUID)


### PR DESCRIPTION
Since 1.22, Go's built-in router provides all the functionality we need

Fixes VEGA-2473 #patch
