### PR TITLE
VEGA-2873 : Record court order dates for severance

### DIFF
--- a/cypress/e2e/manage-restrictions.cy.js
+++ b/cypress/e2e/manage-restrictions.cy.js
@@ -183,7 +183,7 @@ describe("Manage restrictions form", () => {
     cy.addMock("/lpa-api/v1/digital-lpas/M-6666-6666-6668", "GET", {
       status: 200,
       body: {
-        uId: "M-6666-6666-66688",
+        uId: "M-6666-6666-6668",
         "opg.poas.sirius": {
           id: 888,
           uId: "M-6666-6666-6668",
@@ -236,6 +236,71 @@ describe("Manage restrictions form", () => {
       cy.contains("No");
 
       cy.contains("Severance application is required");
+    });
+  });
+
+  it("can be visited from the LPA details manage restrictions link when donor has given consent", () => {
+    cy.addMock("/lpa-api/v1/digital-lpas/M-6666-6666-6669", "GET", {
+      status: 200,
+      body: {
+        uId: "M-6666-6666-6669",
+        "opg.poas.sirius": {
+          id: 888,
+          uId: "M-6666-6666-6669",
+          status: "in-progress",
+          caseSubtype: "personal-welfare",
+          createdDate: "31/10/2023",
+          investigationCount: 0,
+          complaintCount: 0,
+          taskCount: 0,
+          warningCount: 0,
+          donor: {
+            id: 88,
+          },
+          application: {
+            donorFirstNames: "James",
+            donorLastName: "Rubin",
+            donorDob: "22/02/1990",
+            severanceStatus: "REQUIRED",
+            severanceApplication: {
+              hasDonorConsented: true,
+            }
+          },
+        },
+      },
+    });
+
+    cases.warnings.empty("888");
+
+    cy.addMock("/lpa-api/v1/cases/888", "GET", {
+      status: 200,
+      body: {
+        id: 888,
+        uId: "M-6666-6666-6669",
+        caseType: "DIGITAL_LPA",
+        donor: {
+          id: 6,
+        },
+      },
+    });
+
+    cy.addMock(
+        "/lpa-api/v1/cases/888/tasks?filter=status%3ANot+started%2Cactive%3Atrue&limit=99&sort=duedate%3AASC",
+        "GET",
+        {
+          status: 200,
+          body: {
+            tasks: [],
+          },
+        },
+    );
+    cy.visit("/lpa/M-6666-6666-6669/manage-restrictions").then(() => {
+      cy.contains("Manage restrictions and conditions");
+      cy.url().should("contain", "/lpa/M-6666-6666-6669/manage-restrictions");
+      cy.contains("Manage restrictions and conditions");
+      cy.contains("Date court order made");
+      cy.contains("Date court order issued");
+      cy.contains("Has severance of the restrictions and conditions been ordered?");
     });
   });
 });

--- a/cypress/e2e/manage-restrictions.cy.js
+++ b/cypress/e2e/manage-restrictions.cy.js
@@ -264,7 +264,7 @@ describe("Manage restrictions form", () => {
             severanceStatus: "REQUIRED",
             severanceApplication: {
               hasDonorConsented: true,
-            }
+            },
           },
         },
       },
@@ -285,14 +285,14 @@ describe("Manage restrictions form", () => {
     });
 
     cy.addMock(
-        "/lpa-api/v1/cases/888/tasks?filter=status%3ANot+started%2Cactive%3Atrue&limit=99&sort=duedate%3AASC",
-        "GET",
-        {
-          status: 200,
-          body: {
-            tasks: [],
-          },
+      "/lpa-api/v1/cases/888/tasks?filter=status%3ANot+started%2Cactive%3Atrue&limit=99&sort=duedate%3AASC",
+      "GET",
+      {
+        status: 200,
+        body: {
+          tasks: [],
         },
+      },
     );
     cy.visit("/lpa/M-6666-6666-6669/manage-restrictions").then(() => {
       cy.contains("Manage restrictions and conditions");
@@ -300,7 +300,9 @@ describe("Manage restrictions form", () => {
       cy.contains("Manage restrictions and conditions");
       cy.contains("Date court order made");
       cy.contains("Date court order issued");
-      cy.contains("Has severance of the restrictions and conditions been ordered?");
+      cy.contains(
+        "Has severance of the restrictions and conditions been ordered?",
+      );
     });
   });
 });

--- a/internal/server/manage_restrictions.go
+++ b/internal/server/manage_restrictions.go
@@ -73,7 +73,7 @@ func ManageRestrictions(client ManageRestrictionsClient, tmpl template.Template)
 		if data.FormAction == "" && data.CaseSummary.DigitalLpa.SiriusData.Application.SeveranceStatus == "REQUIRED" {
 			data.FormAction = "donor-consent"
 
-			if data.CaseSummary.DigitalLpa.SiriusData.Application.SeveranceApplication != nil && *data.CaseSummary.DigitalLpa.SiriusData.Application.SeveranceApplication.HasDonorConsented == true {
+			if data.CaseSummary.DigitalLpa.SiriusData.Application.SeveranceApplication != nil && *data.CaseSummary.DigitalLpa.SiriusData.Application.SeveranceApplication.HasDonorConsented {
 				data.FormAction = "court-order"
 			}
 		}

--- a/internal/server/manage_restrictions.go
+++ b/internal/server/manage_restrictions.go
@@ -18,17 +18,17 @@ type ManageRestrictionsClient interface {
 }
 
 type manageRestrictionsData struct {
-	XSRFToken              string
-	Error                  sirius.ValidationError
-	CaseUID                string
-	CaseSummary            sirius.CaseSummary
-	SeveranceAction        string
-	DonorConsentGiven      string
-	CourtOrderedSeverance  string
-	CourtOrderDecisionDate sirius.DateString
-	CourtOrderReceivedDate sirius.DateString
-	FormAction             string
-	Success                bool
+	XSRFToken               string
+	Error                   sirius.ValidationError
+	CaseUID                 string
+	CaseSummary             sirius.CaseSummary
+	SeveranceAction         string
+	DonorConsentGiven       string
+	SeveranceOrderedByCourt string
+	CourtOrderDecisionDate  sirius.DateString
+	CourtOrderReceivedDate  sirius.DateString
+	FormAction              string
+	Success                 bool
 }
 
 func ManageRestrictions(client ManageRestrictionsClient, tmpl template.Template) Handler {
@@ -57,18 +57,16 @@ func ManageRestrictions(client ManageRestrictionsClient, tmpl template.Template)
 			return err
 		}
 
-		fmt.Println(fmt.Sprintf("%#v", cs))
-
 		data := manageRestrictionsData{
-			CaseSummary:            cs,
-			SeveranceAction:        postFormString(r, "severanceAction"),
-			DonorConsentGiven:      postFormString(r, "donorConsentGiven"),
-			CourtOrderedSeverance:  postFormString(r, "severanceOrdered"),
-			CourtOrderDecisionDate: postFormDateString(r, "courtOrderDecisionMade"),
-			CourtOrderReceivedDate: postFormDateString(r, "courtOrderReceived"),
-			XSRFToken:              ctx.XSRFToken,
-			Error:                  sirius.ValidationError{Field: sirius.FieldErrors{}},
-			CaseUID:                caseUID,
+			CaseSummary:             cs,
+			SeveranceAction:         postFormString(r, "severanceAction"),
+			DonorConsentGiven:       postFormString(r, "donorConsentGiven"),
+			SeveranceOrderedByCourt: postFormString(r, "severanceOrdered"),
+			CourtOrderDecisionDate:  postFormDateString(r, "courtOrderDecisionMade"),
+			CourtOrderReceivedDate:  postFormDateString(r, "courtOrderReceived"),
+			XSRFToken:               ctx.XSRFToken,
+			Error:                   sirius.ValidationError{Field: sirius.FieldErrors{}},
+			CaseUID:                 caseUID,
 		}
 
 		data.FormAction = r.FormValue("action")
@@ -156,10 +154,10 @@ func ManageRestrictions(client ManageRestrictionsClient, tmpl template.Template)
 					severanceApplication.CourtOrderReceived = data.CourtOrderReceivedDate
 				}
 
-				switch data.CourtOrderedSeverance {
+				switch data.SeveranceOrderedByCourt {
 				case "severance-ordered", "severance-not-ordered":
 					isSeveranceOrdered := true
-					if data.CourtOrderedSeverance == "severance-not-ordered" {
+					if data.SeveranceOrderedByCourt == "severance-not-ordered" {
 						isSeveranceOrdered = false
 					}
 

--- a/internal/server/manage_restrictions.go
+++ b/internal/server/manage_restrictions.go
@@ -14,18 +14,21 @@ type ManageRestrictionsClient interface {
 	CaseSummary(sirius.Context, string) (sirius.CaseSummary, error)
 	ClearTask(sirius.Context, int) error
 	UpdateSeveranceStatus(sirius.Context, string, sirius.SeveranceStatusData) error
-	EditSeveranceApplication(sirius.Context, string, sirius.SeveranceApplicationDetails) error
+	EditSeveranceApplication(sirius.Context, string, sirius.SeveranceApplication) error
 }
 
 type manageRestrictionsData struct {
-	XSRFToken         string
-	Error             sirius.ValidationError
-	CaseUID           string
-	CaseSummary       sirius.CaseSummary
-	SeveranceAction   string
-	DonorConsentGiven string
-	FormAction        string
-	Success           bool
+	XSRFToken              string
+	Error                  sirius.ValidationError
+	CaseUID                string
+	CaseSummary            sirius.CaseSummary
+	SeveranceAction        string
+	DonorConsentGiven      string
+	CourtOrderedSeverance  string
+	CourtOrderDecisionDate sirius.DateString
+	CourtOrderReceivedDate sirius.DateString
+	FormAction             string
+	Success                bool
 }
 
 func ManageRestrictions(client ManageRestrictionsClient, tmpl template.Template) Handler {
@@ -54,18 +57,27 @@ func ManageRestrictions(client ManageRestrictionsClient, tmpl template.Template)
 			return err
 		}
 
+		fmt.Println(fmt.Sprintf("%#v", cs))
+
 		data := manageRestrictionsData{
-			CaseSummary:       cs,
-			SeveranceAction:   postFormString(r, "severanceAction"),
-			DonorConsentGiven: postFormString(r, "donorConsentGiven"),
-			XSRFToken:         ctx.XSRFToken,
-			Error:             sirius.ValidationError{Field: sirius.FieldErrors{}},
-			CaseUID:           caseUID,
+			CaseSummary:            cs,
+			SeveranceAction:        postFormString(r, "severanceAction"),
+			DonorConsentGiven:      postFormString(r, "donorConsentGiven"),
+			CourtOrderedSeverance:  postFormString(r, "severanceOrdered"),
+			CourtOrderDecisionDate: postFormDateString(r, "courtOrderDecisionMade"),
+			CourtOrderReceivedDate: postFormDateString(r, "courtOrderReceived"),
+			XSRFToken:              ctx.XSRFToken,
+			Error:                  sirius.ValidationError{Field: sirius.FieldErrors{}},
+			CaseUID:                caseUID,
 		}
 
 		data.FormAction = r.FormValue("action")
 		if data.FormAction == "" && data.CaseSummary.DigitalLpa.SiriusData.Application.SeveranceStatus == "REQUIRED" {
 			data.FormAction = "donor-consent"
+
+			if data.CaseSummary.DigitalLpa.SiriusData.Application.SeveranceApplication != nil && *data.CaseSummary.DigitalLpa.SiriusData.Application.SeveranceApplication.HasDonorConsented == true {
+				data.FormAction = "court-order"
+			}
 		}
 
 		if r.Method == http.MethodPost {
@@ -116,8 +128,8 @@ func ManageRestrictions(client ManageRestrictionsClient, tmpl template.Template)
 						hasDonorConsented = false
 					}
 
-					err := client.EditSeveranceApplication(ctx, caseUID, sirius.SeveranceApplicationDetails{
-						HasDonorConsented: hasDonorConsented,
+					err := client.EditSeveranceApplication(ctx, caseUID, sirius.SeveranceApplication{
+						HasDonorConsented: &hasDonorConsented,
 					})
 					if handleError(w, &data, err) {
 						return err
@@ -131,6 +143,35 @@ func ManageRestrictions(client ManageRestrictionsClient, tmpl template.Template)
 						"reason": "Please select an option",
 					}
 				}
+			}
+
+			if data.FormAction == "court-order" {
+				severanceApplication := sirius.SeveranceApplication{}
+
+				if data.CourtOrderDecisionDate != "" {
+					severanceApplication.CourtOrderDecisionMade = data.CourtOrderDecisionDate
+				}
+
+				if data.CourtOrderReceivedDate != "" {
+					severanceApplication.CourtOrderReceived = data.CourtOrderReceivedDate
+				}
+
+				switch data.CourtOrderedSeverance {
+				case "severance-ordered", "severance-not-ordered":
+					isSeveranceOrdered := true
+					if data.CourtOrderedSeverance == "severance-not-ordered" {
+						isSeveranceOrdered = false
+					}
+
+					severanceApplication.SeveranceOrdered = &isSeveranceOrdered
+				}
+
+				err := client.EditSeveranceApplication(ctx, caseUID, severanceApplication)
+				if handleError(w, &data, err) {
+					return err
+				}
+
+				return handleSuccess(w, &data, caseUID)
 			}
 		}
 		return tmpl(w, data)

--- a/internal/server/manage_restrictions_test.go
+++ b/internal/server/manage_restrictions_test.go
@@ -30,7 +30,7 @@ func (m *mockManageRestrictionsClient) UpdateSeveranceStatus(ctx sirius.Context,
 	return args.Error(0)
 }
 
-func (m *mockManageRestrictionsClient) EditSeveranceApplication(ctx sirius.Context, caseUID string, severanceApplicationDetails sirius.SeveranceApplicationDetails) error {
+func (m *mockManageRestrictionsClient) EditSeveranceApplication(ctx sirius.Context, caseUID string, severanceApplicationDetails sirius.SeveranceApplication) error {
 	args := m.Called(ctx, caseUID, severanceApplicationDetails)
 	return args.Error(0)
 }
@@ -244,17 +244,17 @@ func TestPostManageRestrictionsWithSeveranceRequiredRedirects(t *testing.T) {
 	tests := []struct {
 		name               string
 		donorConsentAction string
-		severanceDetails   *sirius.SeveranceApplicationDetails
+		severanceDetails   *sirius.SeveranceApplication
 	}{
 		{
 			name:               "Donor consent given",
 			donorConsentAction: "donor-consent-given",
-			severanceDetails:   &sirius.SeveranceApplicationDetails{HasDonorConsented: true},
+			severanceDetails:   &sirius.SeveranceApplication{HasDonorConsented: true},
 		},
 		{
 			name:               "Donor refused severance",
 			donorConsentAction: "donor-consent-not-given",
-			severanceDetails:   &sirius.SeveranceApplicationDetails{HasDonorConsented: false},
+			severanceDetails:   &sirius.SeveranceApplication{HasDonorConsented: false},
 		},
 	}
 

--- a/internal/server/manage_restrictions_test.go
+++ b/internal/server/manage_restrictions_test.go
@@ -34,7 +34,7 @@ func (m *mockManageRestrictionsClient) EditSeveranceApplication(ctx sirius.Conte
 	return args.Error(0)
 }
 
-func convertToBool(b bool) *bool {
+func boolPointer(b bool) *bool {
 	return &b
 }
 
@@ -76,7 +76,7 @@ var restrictionsCaseSummaryWithDonorConsentGiven = sirius.CaseSummary{
 			Application: sirius.Draft{
 				SeveranceStatus: "REQUIRED",
 				SeveranceApplication: &sirius.SeveranceApplication{
-					HasDonorConsented: convertToBool(true),
+					HasDonorConsented: boolPointer(true),
 				},
 			},
 		},
@@ -280,12 +280,12 @@ func TestPostManageRestrictionsWithSeveranceRequiredRedirects(t *testing.T) {
 		{
 			name:               "Donor consent given",
 			donorConsentAction: "donor-consent-given",
-			severanceDetails:   &sirius.SeveranceApplication{HasDonorConsented: convertToBool(true)},
+			severanceDetails:   &sirius.SeveranceApplication{HasDonorConsented: boolPointer(true)},
 		},
 		{
 			name:               "Donor refused severance",
 			donorConsentAction: "donor-consent-not-given",
-			severanceDetails:   &sirius.SeveranceApplication{HasDonorConsented: convertToBool(false)},
+			severanceDetails:   &sirius.SeveranceApplication{HasDonorConsented: boolPointer(false)},
 		},
 	}
 
@@ -343,7 +343,7 @@ func TestPostManageRestrictionsWithDonorConsentGivenRedirects(t *testing.T) {
 			severanceDetails: &sirius.SeveranceApplication{
 				CourtOrderDecisionMade: "2025-04-05",
 				CourtOrderReceived:     "2025-04-10",
-				SeveranceOrdered:       convertToBool(true),
+				SeveranceOrdered:       boolPointer(true),
 			},
 		},
 	}

--- a/internal/sirius/create_draft.go
+++ b/internal/sirius/create_draft.go
@@ -10,20 +10,21 @@ type Address struct {
 }
 
 type Draft struct {
-	CaseType                  []string   `json:"types"`
-	Source                    string     `json:"source"`
-	DonorFirstNames           string     `json:"donorFirstNames"`
-	DonorLastName             string     `json:"donorLastName"`
-	DonorDob                  DateString `json:"donorDob"`
-	DonorAddress              Address    `json:"donorAddress"`
-	CorrespondentFirstNames   string     `json:"correspondentFirstNames,omitempty"`
-	CorrespondentLastName     string     `json:"correspondentLastName,omitempty"`
-	CorrespondentAddress      *Address   `json:"correspondentAddress,omitempty"`
-	PhoneNumber               string     `json:"donorPhone,omitempty"`
-	Email                     string     `json:"donorEmail,omitempty"`
-	CorrespondenceByWelsh     bool       `json:"correspondenceByWelsh,omitempty"`
-	CorrespondenceLargeFormat bool       `json:"correspondenceLargeFormat,omitempty"`
-	SeveranceStatus           string     `json:"severanceStatus,omitempty"`
+	CaseType                  []string              `json:"types"`
+	Source                    string                `json:"source"`
+	DonorFirstNames           string                `json:"donorFirstNames"`
+	DonorLastName             string                `json:"donorLastName"`
+	DonorDob                  DateString            `json:"donorDob"`
+	DonorAddress              Address               `json:"donorAddress"`
+	CorrespondentFirstNames   string                `json:"correspondentFirstNames,omitempty"`
+	CorrespondentLastName     string                `json:"correspondentLastName,omitempty"`
+	CorrespondentAddress      *Address              `json:"correspondentAddress,omitempty"`
+	PhoneNumber               string                `json:"donorPhone,omitempty"`
+	Email                     string                `json:"donorEmail,omitempty"`
+	CorrespondenceByWelsh     bool                  `json:"correspondenceByWelsh,omitempty"`
+	CorrespondenceLargeFormat bool                  `json:"correspondenceLargeFormat,omitempty"`
+	SeveranceStatus           string                `json:"severanceStatus,omitempty"`
+	SeveranceApplication      *SeveranceApplication `json:"severanceApplication,omitempty"`
 }
 
 func (c *Client) CreateDraft(ctx Context, draft Draft) (map[string]string, error) {

--- a/internal/sirius/edit_severance_application.go
+++ b/internal/sirius/edit_severance_application.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 )
 
-type SeveranceApplicationDetails struct {
-	HasDonorConsented      bool       `json:"hasDonorConsented"`
-	SeveranceOrdered       bool       `json:"severanceOrdered"`
-	CourtOrderDecisionMade DateString `json:"courtOrderDecisionMade"`
-	CourtOrderReceived     DateString `json:"courtOrderReceived"`
+type SeveranceApplication struct {
+	HasDonorConsented      *bool      `json:"hasDonorConsented,omitempty"`
+	SeveranceOrdered       *bool      `json:"severanceOrdered,omitempty"`
+	CourtOrderDecisionMade DateString `json:"courtOrderDecisionMade,omitempty"`
+	CourtOrderReceived     DateString `json:"courtOrderReceived,omitempty"`
 }
 
-func (c *Client) EditSeveranceApplication(ctx Context, caseUID string, severanceApplicationDetails SeveranceApplicationDetails) error {
-	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/severance", caseUID), severanceApplicationDetails, nil)
+func (c *Client) EditSeveranceApplication(ctx Context, caseUID string, severanceApplication SeveranceApplication) error {
+	return c.put(ctx, fmt.Sprintf("/lpa-api/v1/digital-lpas/%s/severance", caseUID), severanceApplication, nil)
 }

--- a/internal/sirius/edit_severance_application_test.go
+++ b/internal/sirius/edit_severance_application_test.go
@@ -51,35 +51,6 @@ func TestEditSeveranceApplication(t *testing.T) {
 					})
 			},
 		},
-		{
-			name: "Severance Ordered",
-			severanceApplication: SeveranceApplication{
-				SeveranceOrdered:       convertToBool(true),
-				CourtOrderDecisionMade: "2025-04-05",
-				CourtOrderReceived:     "2025-04-10",
-			},
-			setup: func() {
-				pact.
-					AddInteraction().
-					Given("A digital LPA exists").
-					UponReceiving("A request for editing severance application").
-					WithCompleteRequest(consumer.Request{
-						Method: http.MethodPut,
-						Path:   matchers.String("/lpa-api/v1/digital-lpas/M-1234-9876-4567/severance"),
-						Headers: matchers.MapMatcher{
-							"Content-Type": matchers.String("application/json"),
-						},
-						Body: map[string]interface{}{
-							"severanceOrdered":       true,
-							"courtOrderDecisionMade": "05/04/2025",
-							"courtOrderReceived":     "10/04/2025",
-						},
-					}).
-					WithCompleteResponse(consumer.Response{
-						Status: http.StatusNoContent,
-					})
-			},
-		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/sirius/edit_severance_application_test.go
+++ b/internal/sirius/edit_severance_application_test.go
@@ -17,14 +17,14 @@ func TestEditSeveranceApplication(t *testing.T) {
 	assert.NoError(t, err)
 
 	testCases := []struct {
-		name                        string
-		severanceApplicationDetails SeveranceApplicationDetails
-		setup                       func()
-		expectedError               func(int) error
+		name                 string
+		severanceApplication SeveranceApplication
+		setup                func()
+		expectedError        func(int) error
 	}{
 		{
 			name: "Donor consent given",
-			severanceApplicationDetails: SeveranceApplicationDetails{
+			severanceApplication: SeveranceApplication{
 				HasDonorConsented: true,
 			},
 			setup: func() {
@@ -59,7 +59,7 @@ func TestEditSeveranceApplication(t *testing.T) {
 			assert.Nil(t, pact.ExecuteTest(t, func(config consumer.MockServerConfig) error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://127.0.0.1:%d", config.Port))
 
-				err := client.EditSeveranceApplication(Context{Context: context.Background()}, "M-1234-9876-4567", tc.severanceApplicationDetails)
+				err := client.EditSeveranceApplication(Context{Context: context.Background()}, "M-1234-9876-4567", tc.severanceApplication)
 
 				if tc.expectedError == nil {
 					assert.Nil(t, err)

--- a/internal/sirius/edit_severance_application_test.go
+++ b/internal/sirius/edit_severance_application_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func convertToBool(b bool) *bool {
+func boolPointer(b bool) *bool {
 	return &b
 }
 
@@ -29,7 +29,7 @@ func TestEditSeveranceApplication(t *testing.T) {
 		{
 			name: "Donor consent given",
 			severanceApplication: SeveranceApplication{
-				HasDonorConsented: convertToBool(true),
+				HasDonorConsented: boolPointer(true),
 			},
 			setup: func() {
 				pact.

--- a/internal/sirius/edit_severance_application_test.go
+++ b/internal/sirius/edit_severance_application_test.go
@@ -10,6 +10,10 @@ import (
 	"testing"
 )
 
+func convertToBool(b bool) *bool {
+	return &b
+}
+
 func TestEditSeveranceApplication(t *testing.T) {
 	t.Parallel()
 
@@ -25,7 +29,7 @@ func TestEditSeveranceApplication(t *testing.T) {
 		{
 			name: "Donor consent given",
 			severanceApplication: SeveranceApplication{
-				HasDonorConsented: true,
+				HasDonorConsented: convertToBool(true),
 			},
 			setup: func() {
 				pact.
@@ -40,7 +44,7 @@ func TestEditSeveranceApplication(t *testing.T) {
 						},
 						Body: map[string]interface{}{
 							"hasDonorConsented":      true,
-							"severanceOrdered":       false,
+							"severanceOrdered":       nil,
 							"courtOrderDecisionMade": nil,
 							"courtOrderReceived":     nil,
 						},

--- a/internal/sirius/edit_severance_application_test.go
+++ b/internal/sirius/edit_severance_application_test.go
@@ -43,10 +43,36 @@ func TestEditSeveranceApplication(t *testing.T) {
 							"Content-Type": matchers.String("application/json"),
 						},
 						Body: map[string]interface{}{
-							"hasDonorConsented":      true,
-							"severanceOrdered":       nil,
-							"courtOrderDecisionMade": nil,
-							"courtOrderReceived":     nil,
+							"hasDonorConsented": true,
+						},
+					}).
+					WithCompleteResponse(consumer.Response{
+						Status: http.StatusNoContent,
+					})
+			},
+		},
+		{
+			name: "Severance Ordered",
+			severanceApplication: SeveranceApplication{
+				SeveranceOrdered:       convertToBool(true),
+				CourtOrderDecisionMade: "2025-04-05",
+				CourtOrderReceived:     "2025-04-10",
+			},
+			setup: func() {
+				pact.
+					AddInteraction().
+					Given("A digital LPA exists").
+					UponReceiving("A request for editing severance application").
+					WithCompleteRequest(consumer.Request{
+						Method: http.MethodPut,
+						Path:   matchers.String("/lpa-api/v1/digital-lpas/M-1234-9876-4567/severance"),
+						Headers: matchers.MapMatcher{
+							"Content-Type": matchers.String("application/json"),
+						},
+						Body: map[string]interface{}{
+							"severanceOrdered":       true,
+							"courtOrderDecisionMade": "05/04/2025",
+							"courtOrderReceived":     "10/04/2025",
 						},
 					}).
 					WithCompleteResponse(consumer.Response{

--- a/web/template/manage-restrictions.gohtml
+++ b/web/template/manage-restrictions.gohtml
@@ -43,6 +43,43 @@
                             </div>
                         </fieldset>
 
+                    {{ else if eq .FormAction "court-order" }}
+                        <fieldset class="govuk-fieldset">
+                            <h2 class="govuk-heading-m">Record court order instructions</h2>
+
+                            <div class="govuk-form-group">
+                                <label class="govuk-label" for="f-courtOrderDecisionMade">
+                                    <strong>Date court order made</strong>
+                                </label>
+                                <input class="govuk-input govuk-!-width-one-third " type="date" id="f-courtOrderDecisionMade" name="courtOrderDecisionMade">
+                            </div>
+
+                            <div class="govuk-form-group">
+                                <label class="govuk-label" for="f-courtOrderReceived">
+                                    <strong>Date court order issued</strong>
+                                </label>
+                                <input class="govuk-input govuk-!-width-one-third " type="date" id="f-courtOrderReceived" name="courtOrderReceived">
+                            </div>
+
+                            <div class="govuk-form-group">
+                                <legend class="govuk-fieldset__legend"><strong>Has severance of the restrictions and conditions been ordered?</strong></legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="f-severanceNotOrdered" name="severanceOrdered" type="radio" value="severance-not-ordered" {{ if eq "severance-ordered" .CourtOrderedSeverance }}checked{{ end }}>
+                                        <label class="govuk-label govuk-radios__label" for="f-severanceNotOrdered">
+                                            No
+                                        </label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="f-severanceOrdered" name="severanceOrdered" type="radio" value="severance-ordered" {{ if eq "severance-not-ordered" .CourtOrderedSeverance }}checked{{ end }}>
+                                        <label class="govuk-label govuk-radios__label" for="f-severanceOrdered">
+                                            Yes
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                        </fieldset>
+
                     {{ else if eq .FormAction "donor-consent" }}
                         <fieldset class="govuk-fieldset">
                             <legend class="govuk-fieldset__legend"><strong>Select an option:</strong></legend>
@@ -51,13 +88,13 @@
                             <div class="govuk-radios" data-module="govuk-radios">
                                 <div class="govuk-radios__item">
                                     <input class="govuk-radios__input" id="f-donorConsentGiven" name="donorConsentGiven" type="radio" value="donor-consent-given" {{ if eq "donor-consent-given" .DonorConsentGiven }}checked{{ end }}>
-                                    <label class="govuk-label govuk-radios__label" for="f-severanceActionRequired">
+                                    <label class="govuk-label govuk-radios__label" for="f-donorConsentGiven">
                                         Donor has provided consent to a severance application
                                     </label>
                                 </div>
                                 <div class="govuk-radios__item">
                                     <input class="govuk-radios__input" id="f-donorConsentNotGiven" name="donorConsentGiven" type="radio" value="donor-consent-not-given" {{ if eq "donor-consent-not-given" .DonorConsentGiven }}checked{{ end }}>
-                                    <label class="govuk-label govuk-radios__label" for="f-severanceActionNotRequired">
+                                    <label class="govuk-label govuk-radios__label" for="f-donorConsentNotGiven">
                                         Donor has refused severance of restriction and conditions
                                     </label>
                                 </div>
@@ -71,14 +108,14 @@
 
                             <div class="govuk-radios" data-module="govuk-radios">
                                 <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="f-severanceActionRequired" name="severanceAction" type="radio" value="severance-application-not-required" {{ if eq "severance-application-not-required" .SeveranceAction }}checked{{ end }}>
-                                    <label class="govuk-label govuk-radios__label" for="f-severanceActionRequired">
+                                    <input class="govuk-radios__input" id="f-severanceActionNotRequired" name="severanceAction" type="radio" value="severance-application-not-required" {{ if eq "severance-application-not-required" .SeveranceAction }}checked{{ end }}>
+                                    <label class="govuk-label govuk-radios__label" for="f-severanceActionNotRequired">
                                         Severance application is not required
                                     </label>
                                 </div>
                                 <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="f-severanceActionNotRequired" name="severanceAction" type="radio" value="severance-application-required" {{ if eq "severance-application-required" .SeveranceAction }}checked{{ end }}>
-                                    <label class="govuk-label govuk-radios__label" for="f-severanceActionNotRequired">
+                                    <input class="govuk-radios__input" id="f-severanceActionRequired" name="severanceAction" type="radio" value="severance-application-required" {{ if eq "severance-application-required" .SeveranceAction }}checked{{ end }}>
+                                    <label class="govuk-label govuk-radios__label" for="f-severanceActionRequired">
                                         Severance application is required
                                     </label>
                                 </div>

--- a/web/template/manage-restrictions.gohtml
+++ b/web/template/manage-restrictions.gohtml
@@ -65,13 +65,13 @@
                                 <legend class="govuk-fieldset__legend"><strong>Has severance of the restrictions and conditions been ordered?</strong></legend>
                                 <div class="govuk-radios" data-module="govuk-radios">
                                     <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="f-severanceNotOrdered" name="severanceOrdered" type="radio" value="severance-not-ordered" {{ if eq "severance-ordered" .CourtOrderedSeverance }}checked{{ end }}>
+                                        <input class="govuk-radios__input" id="f-severanceNotOrdered" name="severanceOrdered" type="radio" value="severance-not-ordered" {{ if eq "severance-not-ordered" .SeveranceOrderedByCourt }}checked{{ end }}>
                                         <label class="govuk-label govuk-radios__label" for="f-severanceNotOrdered">
                                             No
                                         </label>
                                     </div>
                                     <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="f-severanceOrdered" name="severanceOrdered" type="radio" value="severance-ordered" {{ if eq "severance-not-ordered" .CourtOrderedSeverance }}checked{{ end }}>
+                                        <input class="govuk-radios__input" id="f-severanceOrdered" name="severanceOrdered" type="radio" value="severance-ordered" {{ if eq "severance-ordered" .SeveranceOrderedByCourt }}checked{{ end }}>
                                         <label class="govuk-label govuk-radios__label" for="f-severanceOrdered">
                                             Yes
                                         </label>
@@ -125,11 +125,15 @@
                 </div>
 
                 <div class="govuk-button-group">
-                    {{ if eq .FormAction "donor-consent" }}
-                        <button class="govuk-button" data-module="govuk-button" type="submit">Save and exit</button>
-                    {{ else }}
-                        <button class="govuk-button" data-module="govuk-button" type="submit">Confirm</button>
-                    {{ end }}
+                    <button class="govuk-button" data-module="govuk-button" type="submit">
+                        {{ if eq .FormAction "court-order" }}
+                            Save and continue
+                        {{ else if eq .FormAction "donor-consent" }}
+                            Save and exit
+                        {{ else }}
+                            Confirm
+                        {{ end }}
+                    </button>
                     <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="{{ prefix (printf "/lpa/%s/lpa-details" .CaseUID )}}">Cancel</a>
                 </div>
             </form>


### PR DESCRIPTION
This PR covers [VEGA-2873](https://opgtransform.atlassian.net/browse/VEGA-2873)

I have updated the implementation of the severance flow as part of this ticket to allow the SeveranceApplication object and the bool fields `hasDonorConsented` and `severanceOrdered` to be treated as nil in Go when they are returned as empty from the API. 

In my testing I found that they are treated as empty object or false and so I changed the relevant fields in Go to pointers which then allows the object or the bool fields as nil.

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-2873]: https://opgtransform.atlassian.net/browse/VEGA-2873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ