### PR TITLE
VEGA-2985 : Added a check for task id to not be 0 #patch

### DIFF
--- a/internal/server/manage_restrictions.go
+++ b/internal/server/manage_restrictions.go
@@ -101,7 +101,7 @@ func ManageRestrictions(client ManageRestrictionsClient, tmpl template.Template)
 						return err
 					}
 
-					if data.SeveranceAction == "severance-application-not-required" {
+					if data.SeveranceAction == "severance-application-not-required" && taskID != 0 {
 						err := client.ClearTask(ctx, taskID)
 						if handleError(w, &data, err) {
 							return err


### PR DESCRIPTION
This PR fixes [VEGA-2985](https://opgtransform.atlassian.net/browse/VEGA-2985)

The bug occurs because the code was trying to clear a task with id as 0. The check prevents the function call.

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-2985]: https://opgtransform.atlassian.net/browse/VEGA-2985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ