### PR TITLE
Fix search label ID

### DIFF
--- a/web/template/layout/header.gohtml
+++ b/web/template/layout/header.gohtml
@@ -39,10 +39,10 @@
           <div class="govuk-grid-column-one-third app-search-inline-phase-banner">
             <form class="form" method="get" action="{{ prefix "/search" }}" data-module="search">
               <div class="govuk-input__wrapper">
-                <label class="govuk-label moj-search__label govuk-visually-hidden" for="search">
+                <label class="govuk-label moj-search__label govuk-visually-hidden" for="f-search-input">
                   Search
                 </label>
-                <input id="f-search-preview" class="govuk-input moj-search__input app-moj-search__input"
+                <input id="f-search-input" class="govuk-input moj-search__input app-moj-search__input"
                        data-module="sirius-search-preview"
                        data-sirius-search-preview-attach="#f-search-preview"
                        name="term" type="search" placeholder="Search for a case" aria-label="Search">
@@ -62,10 +62,10 @@
         <div class="govuk-grid-column-full govuk-input--width-30">
           <form class="form" method="get" action="{{ prefix "/search" }}" data-module="search">
             <div class="govuk-input__wrapper">
-              <label class="govuk-label moj-search__label govuk-visually-hidden" for="search">
+              <label class="govuk-label moj-search__label govuk-visually-hidden" for="f-search-input-below-phase-banner">
                 Search
               </label>
-              <input id="f-search-preview-below-phase-banner" class="govuk-input moj-search__input app-moj-search__input"
+              <input id="f-search-input-below-phase-banner" class="govuk-input moj-search__input app-moj-search__input"
                      data-module="sirius-search-preview"
                      data-sirius-search-preview-attach="#f-search-preview-below-phase-banner"
                      name="term" type="search" placeholder="Search for a case" aria-label="Search">


### PR DESCRIPTION
The search field and the label need to have matching IDs so that they're properly linked together for assistive tools.

#patch

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
  - N/A
- [x] I have added styling for Dark Mode
  - N/A
- [x] I have checked that my UI changes meet accessibility standards
