### PR TITLE
Fix accessibility issues in search

### DIFF
--- a/web/template/layout/header.gohtml
+++ b/web/template/layout/header.gohtml
@@ -40,12 +40,12 @@
             <form class="form" method="get" action="{{ prefix "/search" }}" data-module="search">
               <div class="govuk-input__wrapper">
                 <label class="govuk-label moj-search__label govuk-visually-hidden" for="f-search-input">
-                  Search
+                  Search for a case
                 </label>
                 <input id="f-search-input" class="govuk-input moj-search__input app-moj-search__input"
                        data-module="sirius-search-preview"
                        data-sirius-search-preview-attach="#f-search-preview"
-                       name="term" type="search" placeholder="Search for a case" aria-label="Search">
+                       name="term" type="search" placeholder="Search for a case" required>
                 <button class="govuk-button govuk-input__suffix app-!-moj-search__button" data-module="govuk-button">
                   <span class="govuk-visually-hidden">Search</span>
                   <svg class="app-svg-icon" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22" fill="none">


### PR DESCRIPTION
- Add `required` to the search input to prevent submission with enter
- Remove unnecessary `aria=label` (it already has a real label)
- Update label to match placeholder

This stops two things on the page (the search box and the search button) having the same label text ("Search"), which will hopefully make the page easier to navigate with voice control.

My expectation is that voice control users should be able to say "Click Search for a case" to get to the input (matching what they can see on screen). But they could also say "Click Search" and it will try to submit the form, fail because the required field is empty, and focus on the input field.

This is hard to test, because each operating system/browser/tool handles things slightly differently, but I've had relatively positive results on Voice Control for Mac.

#patch

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [x] I have added styling for Dark Mode
- [x] I have checked that my UI changes meet accessibility standards
  - Works well in Voice Over with Chrome, fallback approach works with Firefox and Safari (though they report multiple "Search"-labelled items)
