### PR TITLE
VEGA-2983 : Update the CSP header to allow images from AWS S3 #patch

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -320,7 +320,7 @@ func translateRefData(types []sirius.RefDataItem, tmplHandle string) string {
 
 func setCSPHeader(h http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Security-Policy", "default-src 'self'; img-src 'self' data:")
+		w.Header().Set("Content-Security-Policy", "default-src 'self'; img-src 'self' data: s3.eu-west-1.amazonaws.com")
 
 		h.ServeHTTP(w, r)
 	}


### PR DESCRIPTION
This PR covers [VEGA-2983](https://opgtransform.atlassian.net/browse/VEGA-2983) which is part of [VEGA-2982](https://opgtransform.atlassian.net/browse/VEGA-2982)

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-2983]: https://opgtransform.atlassian.net/browse/VEGA-2983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VEGA-2982]: https://opgtransform.atlassian.net/browse/VEGA-2982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ