### PR TITLE
VEGA-3001 Implement XSRF protection for all post requests

### DIFF
--- a/internal/server/create_draft_test.go
+++ b/internal/server/create_draft_test.go
@@ -203,6 +203,7 @@ func TestPostCreateDraft(t *testing.T) {
 
 	r, _ := http.NewRequest(http.MethodPost, "/digital-lpa/create", strings.NewReader(form.Encode()))
 	r.Header.Add("Content-Type", formUrlEncoded)
+	_ = r.ParseMultipartForm(32 << 20)
 	w := httptest.NewRecorder()
 
 	err := CreateDraft(client, template.Func)(w, r)
@@ -238,6 +239,7 @@ func TestPostCreateDraftWhenAPIFails(t *testing.T) {
 
 	r, _ := http.NewRequest(http.MethodPost, "/digital-lpa/create", strings.NewReader(form.Encode()))
 	r.Header.Add("Content-Type", formUrlEncoded)
+	_ = r.ParseMultipartForm(32 << 20)
 	w := httptest.NewRecorder()
 
 	err := CreateDraft(client, template.Func)(w, r)
@@ -283,6 +285,7 @@ func TestPostCreateDraftWhenValidationError(t *testing.T) {
 
 	r, _ := http.NewRequest(http.MethodPost, "/digital-lpa/create", strings.NewReader(form.Encode()))
 	r.Header.Add("Content-Type", formUrlEncoded)
+	_ = r.ParseMultipartForm(32 << 20)
 	w := httptest.NewRecorder()
 
 	err := CreateDraft(client, template.Func)(w, r)

--- a/internal/server/mi_reporting.go
+++ b/internal/server/mi_reporting.go
@@ -115,6 +115,8 @@ func MiReporting(client MiReportingClient, tmpl template.Template) Handler {
 				}
 			}
 
+			form.Del("xsrfToken")
+
 			result, err := client.MiReport(ctx, form)
 			if err != nil {
 				return err

--- a/internal/server/mi_reporting.go
+++ b/internal/server/mi_reporting.go
@@ -21,6 +21,7 @@ type miReportingData struct {
 	Controls    []namedControl
 	ResultCount int
 	Download    string
+	XSRFToken   string
 }
 
 type namedControl struct {
@@ -46,7 +47,9 @@ var miLabels = map[string]string{
 func MiReporting(client MiReportingClient, tmpl template.Template) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		ctx := getContext(r)
-		data := miReportingData{}
+		data := miReportingData{
+			XSRFToken: ctx.XSRFToken,
+		}
 
 		switch r.Method {
 		case http.MethodGet:

--- a/internal/server/mi_reporting_test.go
+++ b/internal/server/mi_reporting_test.go
@@ -203,6 +203,7 @@ func TestPostMiReporting(t *testing.T) {
 
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
 	r.Header.Add("Content-Type", formUrlEncoded)
+	_ = r.ParseMultipartForm(32 << 20)
 	w := httptest.NewRecorder()
 
 	err := MiReporting(client, template.Func)(w, r)
@@ -220,6 +221,7 @@ func TestPostMiReportingWhenError(t *testing.T) {
 		Return(nil, errExample)
 
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(""))
+	_ = r.ParseMultipartForm(32 << 20)
 	r.Header.Add("Content-Type", formUrlEncoded)
 	w := httptest.NewRecorder()
 

--- a/internal/server/mock_server.go
+++ b/internal/server/mock_server.go
@@ -25,6 +25,8 @@ func newMockServer(route string, handler Handler) *MockServer {
 }
 
 func (s *MockServer) serve(req *http.Request) (*httptest.ResponseRecorder, error) {
+	_ = req.ParseMultipartForm(32 << 20)
+
 	resp := httptest.NewRecorder()
 	s.mux.ServeHTTP(resp, req)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -216,6 +216,7 @@ func xsrfHandler() func(next http.Handler) http.Handler {
 
 				if cookieToken != postToken {
 					http.Error(w, "Post request was not valid. Please refresh the page and try again.", http.StatusForbidden)
+					return
 				}
 			}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -182,6 +182,38 @@ func TestGetContextMissingXSRFToken(t *testing.T) {
 	assert.Equal("", ctx.XSRFToken)
 }
 
+func TestXsrfHandlerIncorrectXSRFToken(t *testing.T) {
+	xsrfMiddleware := xsrfHandler()
+
+	httpHandler := xsrfMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	req, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader("xsrfToken=xZKapp6sHWgRoXHJr5W3cy=="))
+	req.Header.Add("Content-Type", formUrlEncoded)
+	req.AddCookie(&http.Cookie{Name: "XSRF-TOKEN", Value: "cGoJkHDPgQyzRM8TPByxKT=="})
+
+	respRecorder := httptest.NewRecorder()
+	httpHandler.ServeHTTP(respRecorder, req)
+	res := respRecorder.Result()
+
+	assert.Equal(t, http.StatusForbidden, res.StatusCode)
+}
+
+func TestXsrfHandlerMatchesXSRFToken(t *testing.T) {
+	xsrfMiddleware := xsrfHandler()
+
+	httpHandler := xsrfMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	req, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader("xsrfToken=HEXyWv4XQyee6TMu7LRsn9=="))
+	req.Header.Add("Content-Type", formUrlEncoded)
+	req.AddCookie(&http.Cookie{Name: "XSRF-TOKEN", Value: "HEXyWv4XQyee6TMu7LRsn9=="})
+
+	respRecorder := httptest.NewRecorder()
+	httpHandler.ServeHTTP(respRecorder, req)
+	res := respRecorder.Result()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
 func TestPostFormString(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/?name=ignored", strings.NewReader("name=%20%20%09%0Ahello%0A%0A%20%20%09%09"))
 	r.Header.Add("Content-Type", formUrlEncoded)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -182,20 +182,6 @@ func TestGetContextMissingXSRFToken(t *testing.T) {
 	assert.Equal("", ctx.XSRFToken)
 }
 
-func TestGetContextForPostRequest(t *testing.T) {
-	assert := assert.New(t)
-
-	r, _ := http.NewRequest("POST", "/", strings.NewReader("xsrfToken=the-real-one"))
-	r.Header.Add("Content-Type", formUrlEncoded)
-	r.AddCookie(&http.Cookie{Name: "XSRF-TOKEN", Value: "z3tVRZ00yx4dHz3KWYv3boLWHZ4/RsCsVAKbvo2SBNc%3D"})
-	r.AddCookie(&http.Cookie{Name: "another", Value: "one"})
-
-	ctx := getContext(r)
-	assert.Equal(r.Context(), ctx.Context)
-	assert.Equal(r.Cookies(), ctx.Cookies)
-	assert.Equal("the-real-one", ctx.XSRFToken)
-}
-
 func TestPostFormString(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/?name=ignored", strings.NewReader("name=%20%20%09%0Ahello%0A%0A%20%20%09%09"))
 	r.Header.Add("Content-Type", formUrlEncoded)

--- a/web/template/mi_reporting.gohtml
+++ b/web/template/mi_reporting.gohtml
@@ -31,6 +31,7 @@
         <h2 class="govuk-heading-m">{{ .ReportName }}</h2>
 
         <form class="form" method="POST">
+          <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}">
           <input type="hidden" name="reportType" value="{{ .ReportType }}" />
 
           {{ range .Controls }}


### PR DESCRIPTION
[VEGA-3001](https://opgtransform.atlassian.net/browse/VEGA-3001) This PR adds XSRF middleware to check post requests have the XSRF token found in the XSRF token. Some of the server tests needed patching with a call to populate the `request.postForm` data as this was happening in the `getContext` `request.FormValue` method call previously. 

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-3001]: https://opgtransform.atlassian.net/browse/VEGA-3001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ