### PR TITLE
Vega 2817 remove attorney reason

### DIFF
--- a/cypress/e2e/remove-an-attorney.cy.js
+++ b/cypress/e2e/remove-an-attorney.cy.js
@@ -244,6 +244,31 @@ describe("Remove an attorney", () => {
       },
     );
 
+    cy.addMock(
+      "/lpa-api/v1/reference-data/attorneyRemovedReason",
+      "GET",
+      {
+        status: 200,
+        body: [
+          {
+            "handle": "BANKRUPT",
+            "label": "Bankrupt",
+            "validSubTypes": [
+              "property-and-affairs"
+            ]
+          },
+          {
+            "handle": "DECEASED",
+            "label": "Deceased",
+            "validSubTypes": [
+                "property-and-affairs",
+                "personal-welfare"
+            ]
+          },
+        ],
+      },
+    );
+
     cy.visit("/lpa/M-1111-1111-1111/remove-an-attorney");
   });
 
@@ -282,11 +307,13 @@ describe("Remove an attorney", () => {
     cy.contains("Remove an attorney");
     cy.get('input[name="confirmRemoval"]').should("not.exist");
     cy.get("#f-activeAttorney-1").click();
+    cy.get("#f-removedReason-1").click();
     cy.get("#f-inactiveAttorney-1").click();
     cy.get("button").contains("Continue").click();
     cy.url().should("include", "/lpa/M-1111-1111-1111/remove-an-attorney");
     cy.contains("Confirm removal of attorney");
     cy.get(".govuk-summary-list__value").contains("Katheryn Collins");
+    cy.get(".govuk-summary-list__value").contains("Bankrupt");
     cy.get(".govuk-summary-list__value").contains("Barry Smith");
   });
 });

--- a/internal/sirius/change_attorney_status.go
+++ b/internal/sirius/change_attorney_status.go
@@ -5,8 +5,9 @@ import (
 )
 
 type AttorneyUpdatedStatus struct {
-	UID    string `json:"uid"`
-	Status string `json:"status"`
+	UID           string `json:"uid"`
+	Status        string `json:"status"`
+	RemovedReason string `json:"removedReason"`
 }
 
 type attorneyStatusRequest struct {

--- a/internal/sirius/change_attorney_status_test.go
+++ b/internal/sirius/change_attorney_status_test.go
@@ -3,11 +3,12 @@ package sirius
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"testing"
+
 	"github.com/pact-foundation/pact-go/v2/consumer"
 	"github.com/pact-foundation/pact-go/v2/matchers"
 	"github.com/stretchr/testify/assert"
-	"net/http"
-	"testing"
 )
 
 func TestChangeAttorneyStatus(t *testing.T) {
@@ -36,8 +37,9 @@ func TestChangeAttorneyStatus(t *testing.T) {
 						},
 						Body: map[string]interface{}{
 							"attorneyStatuses": []map[string]interface{}{{
-								"uid":    "cf128305-37c8-4ceb-bedf-89ed5f4ae661",
-								"status": "removed",
+								"uid":           "cf128305-37c8-4ceb-bedf-89ed5f4ae661",
+								"status":        "removed",
+								"removedReason": "BANKRUPT",
 							}},
 						},
 					}).
@@ -55,7 +57,7 @@ func TestChangeAttorneyStatus(t *testing.T) {
 			assert.Nil(t, pact.ExecuteTest(t, func(config consumer.MockServerConfig) error {
 				client := NewClient(http.DefaultClient, fmt.Sprintf("http://localhost:%d", config.Port))
 
-				err := client.ChangeAttorneyStatus(Context{Context: context.Background()}, "M-1234-9876-4567", []AttorneyUpdatedStatus{{UID: "cf128305-37c8-4ceb-bedf-89ed5f4ae661", Status: "removed"}})
+				err := client.ChangeAttorneyStatus(Context{Context: context.Background()}, "M-1234-9876-4567", []AttorneyUpdatedStatus{{UID: "cf128305-37c8-4ceb-bedf-89ed5f4ae661", Status: "removed", RemovedReason: "BANKRUPT"}})
 
 				if tc.expectedError == nil {
 					assert.Nil(t, err)

--- a/internal/sirius/ref_data.go
+++ b/internal/sirius/ref_data.go
@@ -5,18 +5,19 @@ import (
 )
 
 const (
-	PaymentSourceCategory      string = "paymentSource"
-	WarningTypeCategory        string = "warningType"
-	FeeReductionTypeCategory   string = "feeReductionType"
-	PaymentReferenceType       string = "paymentReferenceType"
-	DocumentTemplateIdCategory string = "documentTemplateId"
-	ComplainantCategory        string = "complainantCategory"
-	ComplaintOrigin            string = "complaintOrigin"
-	CompensationType           string = "compensationType"
-	ComplaintCategory          string = "complaintCategory"
-	CountryCategory            string = "country"
-	FeeDecisionTypeCategory    string = "feeDecisionType"
-	CaseStatusChangeReason     string = "caseChangeReason"
+	PaymentSourceCategory         string = "paymentSource"
+	WarningTypeCategory           string = "warningType"
+	FeeReductionTypeCategory      string = "feeReductionType"
+	PaymentReferenceType          string = "paymentReferenceType"
+	DocumentTemplateIdCategory    string = "documentTemplateId"
+	ComplainantCategory           string = "complainantCategory"
+	ComplaintOrigin               string = "complaintOrigin"
+	CompensationType              string = "compensationType"
+	ComplaintCategory             string = "complaintCategory"
+	CountryCategory               string = "country"
+	FeeDecisionTypeCategory       string = "feeDecisionType"
+	CaseStatusChangeReason        string = "caseChangeReason"
+	AttorneyRemovedReasonCategory string = "attorneyRemovedReason"
 )
 
 type RefDataItem struct {
@@ -25,6 +26,7 @@ type RefDataItem struct {
 	UserSelectable bool          `json:"userSelectable"`
 	Subcategories  []RefDataItem `json:"subcategories"`
 	ParentSources  []string      `json:"parentSources"`
+	ValidSubTypes  []string      `json:"validSubTypes"`
 }
 
 func (c *Client) RefDataByCategory(ctx Context, category string) ([]RefDataItem, error) {

--- a/internal/sirius/ref_data_test.go
+++ b/internal/sirius/ref_data_test.go
@@ -308,6 +308,35 @@ func TestRefDataByCategory(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "Attorney removed reason category",
+			category: AttorneyRemovedReasonCategory,
+			setup: func() {
+				pact.
+					AddInteraction().
+					UponReceiving("A request for attorney removed reason category ref data").
+					WithCompleteRequest(consumer.Request{
+						Method: http.MethodGet,
+						Path:   matchers.String(fmt.Sprintf("/lpa-api/v1/reference-data/%s", AttorneyRemovedReasonCategory)),
+					}).
+					WithCompleteResponse(consumer.Response{
+						Status: http.StatusOK,
+						Body: matchers.EachLike(map[string]interface{}{
+							"handle":        matchers.String("BANKRUPT"),
+							"label":         matchers.String("Bankrupt"),
+							"ValidSubTypes": matchers.EachLike("property-and-affairs", 1),
+						}, 1),
+						Headers: matchers.MapMatcher{"Content-Type": matchers.String("application/json")},
+					})
+			},
+			expectedResponse: []RefDataItem{
+				{
+					Handle:        "BANKRUPT",
+					Label:         "Bankrupt",
+					ValidSubTypes: []string{"property-and-affairs"},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/web/template/mlpa-confirm-attorney-removal.gohtml
+++ b/web/template/mlpa-confirm-attorney-removal.gohtml
@@ -20,6 +20,7 @@
           <input type="hidden" name="enabledAttorney" value="{{ $enabledAttUid }}"/>
         {{ end }}
         <input type="hidden" name="skipEnableAttorney" value="{{ .Form.SkipEnableAttorney }}"/>
+        <input type="hidden" name="removedReason" value="{{ .RemovedReason.Handle }}">
         <input type="hidden" name="confirmRemoval"/>
 
         <div class="govuk-form-group{{ if .Error.Field.removeAttorney }} govuk-form-group--error{{ end }}">
@@ -41,6 +42,13 @@
                   {{ if not (eq .RemovedAttorneysDetails.SelectedAttorneyDob "") }}
                     {{ parseAndFormatDate .RemovedAttorneysDetails.SelectedAttorneyDob "2006-01-02" "2 January 2006" }}
                   {{ end }}
+                </dd>
+              </div>
+
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Reason</dt>
+                <dd class="govuk-summary-list__value">
+                  {{ .RemovedReason.Label }}
                 </dd>
               </div>
             </dl>

--- a/web/template/mlpa-remove-attorney.gohtml
+++ b/web/template/mlpa-remove-attorney.gohtml
@@ -39,6 +39,25 @@
           </fieldset>
         </div>
 
+        <div class="govuk-form-group{{ if .Error.Field.removedReason }} govuk-form-group--error{{ end }}">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend"><strong>Select the reason for removing</strong></legend>
+            {{ template "errors" .Error.Field.removedReason }}
+
+            <div class="govuk-radios" data-module="govuk-radios">
+              {{ range $num, $removedReason := .RemovedReasons }}
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="f-removedReason-{{ plusN $num 1 }}" name="removedReason" type="radio" value="{{ $removedReason.Handle }}"
+                        {{ if eq $removedReason.Handle $.Form.RemovedReason }}checked{{ end }}>
+                  <label class="govuk-label govuk-radios__label" for="f-removedReason-{{ plusN $num 1 }}">
+                    {{ $removedReason.Label }}
+                  </label>
+                </div>
+              {{ end }}
+            </div>
+          </fieldset>
+        </div>
+
         <div class="govuk-form-group{{ if .Error.Field.enableAttorney }} govuk-form-group--error{{ end }}">
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend"><strong>Select replacement attorneys to step in</strong></legend>


### PR DESCRIPTION
fixes: [VEGA-2817](https://opgtransform.atlassian.net/browse/VEGA-2817)

adds radio buttons to remove-attorney page, pulling options from reference data. Updates call to `ChangeAttorneyStatus` to get this reason saved.

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards
