### PR TITLE
VEGA-2590 : dont show correspondent address when there is no correspondent

### DIFF
--- a/web/template/mlpa-details.gohtml
+++ b/web/template/mlpa-details.gohtml
@@ -281,12 +281,18 @@
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Last name</dt>
-                <dd class="govuk-summary-list__value">{{ .DigitalLpa.SiriusData.Application.CorrespondentLastName }}</dd>
+                <dd class="govuk-summary-list__value">
+                  {{ if (ne .DigitalLpa.SiriusData.Application.CorrespondentFirstNames "")}}
+                    {{ .DigitalLpa.SiriusData.Application.CorrespondentLastName }}
+                  {{ end }}
+                </dd>
               </div>
               <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
                 <dt class="govuk-summary-list__key">Address</dt>
                 <dd class="govuk-summary-list__value">
-                  {{ template "mlpa-address" .DigitalLpa.SiriusData.Application.CorrespondentAddress }}
+                  {{ if (ne .DigitalLpa.SiriusData.Application.CorrespondentFirstNames "")}}
+                    {{ template "mlpa-address" .DigitalLpa.SiriusData.Application.CorrespondentAddress }}
+                  {{ end }}
                 </dd>
               </div>
             </dl>


### PR DESCRIPTION
fixes last part of [VEGA-2590](https://opgtransform.atlassian.net/browse/VEGA-2590)


[VEGA-2590]: https://opgtransform.atlassian.net/browse/VEGA-2590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ