### PR TITLE
Handle bad request to `/allocate-cases` as 404

### DIFF
--- a/internal/server/allocate_cases.go
+++ b/internal/server/allocate_cases.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -35,17 +34,23 @@ func AllocateCases(client AllocateCasesClient, tmpl template.Template) Handler {
 			return err
 		}
 
+		errNotFound := sirius.StatusError{Code: http.StatusNotFound}
+
 		var caseIDs []int
 		for _, id := range r.Form["id"] {
+			if id == "" {
+				return errNotFound
+			}
+
 			caseID, err := strconv.Atoi(id)
 			if err != nil {
-				return err
+				return errNotFound
 			}
 			caseIDs = append(caseIDs, caseID)
 		}
 
 		if len(caseIDs) == 0 {
-			return errors.New("no cases selected")
+			return errNotFound
 		}
 
 		ctx := getContext(r)

--- a/internal/server/allocate_cases_test.go
+++ b/internal/server/allocate_cases_test.go
@@ -97,6 +97,7 @@ func TestGetAllocateCasesMultiple(t *testing.T) {
 func TestGetAllocateCasesBadQueryString(t *testing.T) {
 	testCases := map[string]string{
 		"no-id":      "/",
+		"empty-id":   "/?id=",
 		"bad-id":     "/?id=what",
 		"one-bad-id": "/?id=1&id=bad&id=2",
 	}
@@ -108,7 +109,7 @@ func TestGetAllocateCasesBadQueryString(t *testing.T) {
 
 			err := AllocateCases(nil, nil)(w, r)
 
-			assert.NotNil(t, err)
+			assert.Equal(t, err, sirius.StatusError{Code: 404})
 		})
 	}
 }


### PR DESCRIPTION
If a bad ID is passed to `/allocate-cases`, or it's given no IDs, return a 404 response rather than a 500.

#patch

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [x] I have added styling for Dark Mode
  - N/A
- [x] I have checked that my UI changes meet accessibility standards
  - N/A