### PR TITLE
VEGA-3052 : Manage decisions when there is a single active attorney #minor

### DIFF
--- a/internal/server/update_decisions.go
+++ b/internal/server/update_decisions.go
@@ -15,12 +15,12 @@ type UpdateDecisionsClient interface {
 }
 
 type updateDecisionsData struct {
-	XSRFToken       string
-	Success         bool
-	Error           sirius.ValidationError
-	Form            formDecisionsDetails
-	CaseSummary     sirius.CaseSummary
-	ActiveAttorneys []sirius.LpaStoreAttorney
+	XSRFToken           string
+	Success             bool
+	Error               sirius.ValidationError
+	Form                formDecisionsDetails
+	CaseSummary         sirius.CaseSummary
+	ActiveAttorneyCount int
 }
 
 type formDecisionsDetails struct {
@@ -62,14 +62,11 @@ func UpdateDecisions(client UpdateDecisionsClient, tmpl template.Template) Handl
 			},
 		}
 
-		var activeAttorneys []sirius.LpaStoreAttorney
 		for _, attorney := range lpaStoreData.Attorneys {
 			if attorney.Status == shared.ActiveAttorneyStatus.String() {
-				activeAttorneys = append(activeAttorneys, attorney)
+				data.ActiveAttorneyCount++
 			}
 		}
-
-		data.ActiveAttorneys = activeAttorneys
 
 		if r.Method == http.MethodPost {
 			if err := decoder.Decode(&data.Form, r.PostForm); err != nil {

--- a/internal/server/update_decisions_test.go
+++ b/internal/server/update_decisions_test.go
@@ -74,28 +74,6 @@ var updateDecisionsCaseSummary = sirius.CaseSummary{
 	},
 }
 
-var updateDecisionsActiveAttorneys = []sirius.LpaStoreAttorney{
-	{
-		LpaStorePerson: sirius.LpaStorePerson{
-			Uid:        "302b05c7-896c-4290-904e-2005e4f1e81e",
-			FirstNames: "Jack",
-			LastName:   "Black",
-			Address: sirius.LpaStoreAddress{
-				Line1:    "9 Mount Pleasant Drive",
-				Town:     "East Harling",
-				Postcode: "NR16 2GB",
-				Country:  "UK",
-			},
-		},
-		DateOfBirth:     "1990-02-22",
-		Status:          shared.ActiveAttorneyStatus.String(),
-		AppointmentType: shared.OriginalAppointmentType.String(),
-		Email:           "a@example.com",
-		Mobile:          "077577575757",
-		SignedAt:        "2024-01-12T10:09:09Z",
-	},
-}
-
 func TestGetUpdateDecisionsGet(t *testing.T) {
 	client := &mockUpdateDecisionsClient{}
 	client.
@@ -106,9 +84,9 @@ func TestGetUpdateDecisionsGet(t *testing.T) {
 	template.
 		On("Func", mock.Anything,
 			updateDecisionsData{
-				CaseSummary:     updateDecisionsCaseSummary,
-				Form:            formDecisionsDetails{},
-				ActiveAttorneys: updateDecisionsActiveAttorneys,
+				CaseSummary:         updateDecisionsCaseSummary,
+				Form:                formDecisionsDetails{},
+				ActiveAttorneyCount: 1,
 			}).
 		Return(errExample)
 

--- a/web/template/mlpa-update-decisions.gohtml
+++ b/web/template/mlpa-update-decisions.gohtml
@@ -24,7 +24,7 @@
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend">How must attorneys make decisions?</legend>
             {{ template "errors" .Error.Field.howAttorneysMakeDecisions }}
-            {{ if eq (len .ActiveAttorneys) 1 }}
+            {{ if eq .ActiveAttorneyCount 1 }}
               <div class="govuk-inset-text">
                 {{ howAttorneysMakeDecisionsLongForm true .Form.HowAttorneysMakeDecisions }}
               </div>


### PR DESCRIPTION
This PR covers [VEGA-3052](https://opgtransform.atlassian.net/browse/VEGA-3052)

If there is a single active attorney, instead of showing a new radio button option, the system will display an Inset text.

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-3052]: https://opgtransform.atlassian.net/browse/VEGA-3052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ