### PR TITLE
Vega 3072 displaying ra appointment type

### DIFF
--- a/internal/server/get_lpa_details.go
+++ b/internal/server/get_lpa_details.go
@@ -15,17 +15,18 @@ type GetLpaDetailsClient interface {
 }
 
 type getLpaDetails struct {
-	CaseSummary             sirius.CaseSummary
-	DigitalLpa              sirius.DigitalLpa
-	AnomalyDisplay          *sirius.AnomalyDisplay
-	ReviewRestrictions      bool
-	CheckedForSeverance     bool
-	SeveranceType           string
-	ReplacementAttorneys    []sirius.LpaStoreAttorney
-	NonReplacementAttorneys []sirius.LpaStoreAttorney
-	RemovedAttorneys        []sirius.LpaStoreAttorney
-	DecisionAttorneys       []sirius.LpaStoreAttorney
-	FlashMessage            FlashNotification
+	CaseSummary                   sirius.CaseSummary
+	DigitalLpa                    sirius.DigitalLpa
+	AnomalyDisplay                *sirius.AnomalyDisplay
+	ReviewRestrictions            bool
+	CheckedForSeverance           bool
+	SeveranceType                 string
+	ReplacementAttorneys          []sirius.LpaStoreAttorney
+	NonReplacementAttorneys       []sirius.LpaStoreAttorney
+	RemovedAttorneys              []sirius.LpaStoreAttorney
+	DecisionAttorneys             []sirius.LpaStoreAttorney
+	FlashMessage                  FlashNotification
+	ReplacementAttorneysDecisions string
 }
 
 func GetLpaDetails(client GetLpaDetailsClient, tmpl template.Template) Handler {
@@ -111,6 +112,11 @@ func GetLpaDetails(client GetLpaDetailsClient, tmpl template.Template) Handler {
 		data.NonReplacementAttorneys = nonReplacementAttorneys
 		data.RemovedAttorneys = removedAttorneys
 		data.DecisionAttorneys = decisionAttorneys
+		data.ReplacementAttorneysDecisions = data.CaseSummary.DigitalLpa.LpaStoreData.HowReplacementAttorneysMakeDecisions
+
+		if len(data.NonReplacementAttorneys) > 1 && len(data.ReplacementAttorneys) > 1 && data.ReplacementAttorneysDecisions == "" {
+			data.ReplacementAttorneysDecisions = data.CaseSummary.DigitalLpa.LpaStoreData.HowAttorneysMakeDecisions
+		}
 
 		return tmpl(w, data)
 	}

--- a/internal/server/get_lpa_details_test.go
+++ b/internal/server/get_lpa_details_test.go
@@ -144,6 +144,8 @@ func TestGetLpaDetailsSuccess(t *testing.T) {
 								},
 							},
 						},
+						HowAttorneysMakeDecisions:            "jointly",
+						HowReplacementAttorneysMakeDecisions: "",
 					},
 				},
 				TaskList: tc.taskList,
@@ -269,6 +271,7 @@ func TestGetLpaDetailsSuccess(t *testing.T) {
 							},
 						},
 					},
+					ReplacementAttorneysDecisions: "jointly",
 				}).
 				Return(nil)
 

--- a/internal/server/update_decisions.go
+++ b/internal/server/update_decisions.go
@@ -15,12 +15,13 @@ type UpdateDecisionsClient interface {
 }
 
 type updateDecisionsData struct {
-	XSRFToken           string
-	Success             bool
-	Error               sirius.ValidationError
-	Form                formDecisionsDetails
-	CaseSummary         sirius.CaseSummary
-	ActiveAttorneyCount int
+	XSRFToken                string
+	Success                  bool
+	Error                    sirius.ValidationError
+	Form                     formDecisionsDetails
+	CaseSummary              sirius.CaseSummary
+	ActiveAttorneyCount      int
+	ReplacementAttorneyCount int
 }
 
 type formDecisionsDetails struct {
@@ -66,6 +67,15 @@ func UpdateDecisions(client UpdateDecisionsClient, tmpl template.Template) Handl
 			if attorney.Status == shared.ActiveAttorneyStatus.String() {
 				data.ActiveAttorneyCount++
 			}
+
+			if attorney.AppointmentType == shared.ReplacementAppointmentType.String() &&
+				attorney.Status == shared.InactiveAttorneyStatus.String() {
+				data.ReplacementAttorneyCount++
+			}
+		}
+
+		if data.ActiveAttorneyCount > 1 && data.ReplacementAttorneyCount > 1 && data.Form.HowReplacementAttorneysMakeDecisions == "" {
+			data.Form.HowReplacementAttorneysMakeDecisions = data.Form.HowAttorneysMakeDecisions
 		}
 
 		if r.Method == http.MethodPost {

--- a/web/template/layout/decision-details.gohtml
+++ b/web/template/layout/decision-details.gohtml
@@ -12,6 +12,7 @@
     </div>
     {{ $rootAnomalies := $anomaliesForSection.GetAnomaliesForObject "" }}
     {{ $decisionFieldAnomalies := $rootAnomalies.GetAnomaliesForFieldWithStatus "howAttorneysMakeDecisions" "detected" }}
+    {{ $raDecisionFieldAnomalies := $rootAnomalies.GetAnomaliesForFieldWithStatus "howReplacementAttorneysMakeDecisions" "detected" }}
 
     <div id="accordion-default-content-3" class="govuk-accordion__section-content">
         <dl class="govuk-summary-list">
@@ -25,7 +26,7 @@
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Attorney appointment type</dt>
                 <dd class="govuk-summary-list__value{{ if gt (len $decisionFieldAnomalies) 0 }} govuk-form-group--error{{ end }}">
-                    {{ howAttorneysMakeDecisionsLongForm (eq (len .NonReplacementAttorneys) 1) .DigitalLpa.LpaStoreData.HowReplacementAttorneysMakeDecisions }}
+                    {{ howAttorneysMakeDecisionsLongForm (eq (len .NonReplacementAttorneys) 1) .DigitalLpa.LpaStoreData.HowAttorneysMakeDecisions }}
 
                     {{ if gt (len $decisionFieldAnomalies) 0 }}
                         <br><span class="govuk-error-message">Review how attorney's can make decisions</span>
@@ -78,8 +79,12 @@
             {{ end}}
             <div class="govuk-summary-list__row govuk-summary-list__row--no-border">
                 <dt class="govuk-summary-list__key">Replacement attorneys appointment type</dt>
-                <dd class="govuk-summary-list__value">
-                    {{ howAttorneysMakeDecisionsLongForm (eq (len .NonReplacementAttorneys) 1) .DigitalLpa.LpaStoreData.HowAttorneysMakeDecisions }}
+                <dd class="govuk-summary-list__value{{ if gt (len $raDecisionFieldAnomalies) 0 }} govuk-form-group--error{{ end }}">
+                    {{ howAttorneysMakeDecisionsLongForm (eq (len .ReplacementAttorneys) 1) .ReplacementAttorneysDecisions }}
+
+                    {{ if gt (len $raDecisionFieldAnomalies) 0 }}
+                        <br><span class="govuk-error-message">Review how replacement attorney's can make decisions</span>
+                    {{ end }}
                 </dd>
             </div>
         </dl>

--- a/web/template/mlpa-update-decisions.gohtml
+++ b/web/template/mlpa-update-decisions.gohtml
@@ -70,11 +70,15 @@
           ) }}
         {{ end }}
 
-        {{ if .Form.HowReplacementAttorneysMakeDecisions }}
-          <div class="govuk-form-group {{ if .Error.Field.howReplacementAttorneysMakeDecisions }}govuk-form-group--error{{ end }}">
-            <fieldset class="govuk-fieldset">
-              <legend class="govuk-fieldset__legend">How must replacement attorneys make decisions?</legend>
-              {{ template "errors" .Error.Field.howReplacementAttorneysMakeDecisions }}
+        <div class="govuk-form-group {{ if .Error.Field.howReplacementAttorneysMakeDecisions }}govuk-form-group--error{{ end }}">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend">How must replacement attorneys make decisions?</legend>
+            {{ template "errors" .Error.Field.howReplacementAttorneysMakeDecisions }}
+            {{ if eq .ReplacementAttorneyCount 1 }}
+              <div class="govuk-inset-text">
+                {{ howAttorneysMakeDecisionsLongForm true .Form.HowReplacementAttorneysMakeDecisions }}
+              </div>
+            {{ else }}
               <div class="govuk-radios" data-module="govuk-radios">
                 <div class="govuk-radios__item">
                   <input class="govuk-radios__input" id="f-howReplacementAttorneysMakeDecisions" name="howReplacementAttorneysMakeDecisions" type="radio" value="jointly" {{ if eq .Form.HowReplacementAttorneysMakeDecisions "jointly" }}checked{{ end }}>
@@ -98,9 +102,9 @@
                   </div>
                 </div>
               </div>
-            </fieldset>
-          </div>
-        {{ end }}
+            {{ end}}
+          </fieldset>
+        </div>
 
         {{ if .Form.HowReplacementAttorneysStepIn }}
           <div class="govuk-form-group {{ if .Error.Field.howReplacementAttorneysStepIn }}govuk-form-group--error{{ end }}">

--- a/web/template/mlpa-update-decisions.gohtml
+++ b/web/template/mlpa-update-decisions.gohtml
@@ -109,7 +109,7 @@
         {{ if .Form.HowReplacementAttorneysStepIn }}
           <div class="govuk-form-group {{ if .Error.Field.howReplacementAttorneysStepIn }}govuk-form-group--error{{ end }}">
             <fieldset class="govuk-fieldset">
-              <legend class="govuk-fieldset__legend">How must replacement attorneys make decisions?</legend>
+              <legend class="govuk-fieldset__legend">How must replacement attorneys step in?</legend>
               {{ template "errors" .Error.Field.howReplacementAttorneysStepIn }}
               <div class="govuk-radios" data-module="govuk-radios">
                 <div class="govuk-radios__item">


### PR DESCRIPTION
This PR covers [VEGA-3072](https://opgtransform.atlassian.net/browse/VEGA-3072)

Addiitionally, a label has been corrected in the Update Decisions screen for the section that shows how replacement attorneys can step in.

Also, in the Decisions section in the LPA details tab, the code was using incorrect variables to display the decisions type for active and replacement attorneys. This has been corrected.

## Checklist

- [X] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards
