### PR TITLE
VEGA-3167 : Update the criteria for the missing fields to display them correctly #minor

### DIFF
--- a/web/template/mlpa-update-decisions.gohtml
+++ b/web/template/mlpa-update-decisions.gohtml
@@ -56,15 +56,15 @@
           </fieldset>
         </div>
 
-        {{ with .Form.LifeSustainingTreatmentOption }}
-          {{ template "radios" (radios "lifeSustainingTreatmentOption" "Can attorneys make decisions about life sustaining treatment?" . $.Error.Field.lifeSustainingTreatmentOption
+        {{ if (eq .CaseSummary.DigitalLpa.SiriusData.Subtype "personal-welfare")}}
+          {{ template "radios" (radios "lifeSustainingTreatmentOption" "Can attorneys make decisions about life sustaining treatment?" .Form.LifeSustainingTreatmentOption $.Error.Field.lifeSustainingTreatmentOption
             (item "option-a" "Attorneys can make decisions about life sustaining treatment")
             (item "option-b" "Attorneys cannot make decisions about life sustaining treatment")
           ) }}
         {{ end }}
 
-        {{ with .Form.WhenTheLpaCanBeUsed }}
-          {{ template "radios" (radios "whenTheLpaCanBeUsed" "When can attorneys used the LPA?" . $.Error.Field.whenTheLpaCanBeUsed
+        {{ if (eq .CaseSummary.DigitalLpa.SiriusData.Subtype "property-and-affairs")}}
+          {{ template "radios" (radios "whenTheLpaCanBeUsed" "When can attorneys use the LPA?" .Form.WhenTheLpaCanBeUsed $.Error.Field.whenTheLpaCanBeUsed
             (item "when-has-capacity" "When it is registered")
             (item "when-capacity-lost" "When the donor has lost capacity")
           ) }}


### PR DESCRIPTION
This PR covers [VEGA-3167](https://opgtransform.atlassian.net/browse/VEGA-3167) and [VEGA-3168](https://opgtransform.atlassian.net/browse/VEGA-3168).

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-3167]: https://opgtransform.atlassian.net/browse/VEGA-3167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VEGA-3168]: https://opgtransform.atlassian.net/browse/VEGA-3168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ