### PR TITLE
VEGA-3185 : Display Sirius DOB for donor if identify check was completed in Draft status #minor

### DIFF
--- a/internal/sirius/create_draft.go
+++ b/internal/sirius/create_draft.go
@@ -16,22 +16,23 @@ type DonorIdentityCheck struct {
 }
 
 type Draft struct {
-	CaseType                  []string              `json:"types"`
-	Source                    string                `json:"source"`
-	DonorFirstNames           string                `json:"donorFirstNames"`
-	DonorLastName             string                `json:"donorLastName"`
-	DonorDob                  DateString            `json:"donorDob"`
-	DonorAddress              Address               `json:"donorAddress"`
-	CorrespondentFirstNames   string                `json:"correspondentFirstNames,omitempty"`
-	CorrespondentLastName     string                `json:"correspondentLastName,omitempty"`
-	CorrespondentAddress      *Address              `json:"correspondentAddress,omitempty"`
-	PhoneNumber               string                `json:"donorPhone,omitempty"`
-	Email                     string                `json:"donorEmail,omitempty"`
-	CorrespondenceByWelsh     bool                  `json:"correspondenceByWelsh,omitempty"`
-	CorrespondenceLargeFormat bool                  `json:"correspondenceLargeFormat,omitempty"`
-	SeveranceStatus           string                `json:"severanceStatus,omitempty"`
-	SeveranceApplication      *SeveranceApplication `json:"severanceApplication,omitempty"`
-	DonorIdentityCheck        *DonorIdentityCheck   `json:"donorIdentityCheck,omitempty"`
+	CaseType                    []string              `json:"types"`
+	Source                      string                `json:"source"`
+	DonorFirstNames             string                `json:"donorFirstNames"`
+	DonorLastName               string                `json:"donorLastName"`
+	DonorDob                    DateString            `json:"donorDob"`
+	DonorAddress                Address               `json:"donorAddress"`
+	CorrespondentFirstNames     string                `json:"correspondentFirstNames,omitempty"`
+	CorrespondentLastName       string                `json:"correspondentLastName,omitempty"`
+	CorrespondentAddress        *Address              `json:"correspondentAddress,omitempty"`
+	PhoneNumber                 string                `json:"donorPhone,omitempty"`
+	Email                       string                `json:"donorEmail,omitempty"`
+	CorrespondenceByWelsh       bool                  `json:"correspondenceByWelsh,omitempty"`
+	CorrespondenceLargeFormat   bool                  `json:"correspondenceLargeFormat,omitempty"`
+	SeveranceStatus             string                `json:"severanceStatus,omitempty"`
+	SeveranceApplication        *SeveranceApplication `json:"severanceApplication,omitempty"`
+	DonorIdentityCheck          *DonorIdentityCheck   `json:"donorIdentityCheck,omitempty"`
+	DonorIdentityCheckWhenDraft bool                  `json:"donorIdentityCheckWhenDraft,omitempty"`
 }
 
 func (c *Client) CreateDraft(ctx Context, draft Draft) (map[string]string, error) {

--- a/internal/sirius/create_draft_test.go
+++ b/internal/sirius/create_draft_test.go
@@ -114,6 +114,7 @@ func TestCreateDraft(t *testing.T) {
 					CheckedAt: "2024-07-01T16:06:08Z",
 					Reference: "712254d5-4cf4-463c-96c1-67744b70043e",
 				},
+				DonorIdentityCheckWhenDraft: true,
 			},
 			setup: func() {
 				pact.
@@ -158,6 +159,7 @@ func TestCreateDraft(t *testing.T) {
 								"checkedAt": "2024-07-01T16:06:08Z",
 								"reference": "712254d5-4cf4-463c-96c1-67744b70043e",
 							},
+							"donorIdentityCheckWhenDraft": true,
 						},
 					}).
 					WithCompleteResponse(consumer.Response{

--- a/web/template/layout/donor-details.gohtml
+++ b/web/template/layout/donor-details.gohtml
@@ -49,14 +49,16 @@
                     </dd>
                 </div>
 
-                    <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">Date of birth</dt>
-                        <dd class="govuk-summary-list__value">
-                            {{ if not (eq .DigitalLpa.LpaStoreData.Donor.DateOfBirth "") }}
-                                {{ parseAndFormatDate .DigitalLpa.LpaStoreData.Donor.DateOfBirth "2006-01-02" "2 January 2006" }}
-                            {{ end }}
-                        </dd>
-                    </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Date of birth</dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ if and (not .DigitalLpa.SiriusData.Application.DonorIdentityCheckWhenDraft) (not (eq .DigitalLpa.LpaStoreData.Donor.DateOfBirth "")) }}
+                            {{ parseAndFormatDate .DigitalLpa.LpaStoreData.Donor.DateOfBirth "2006-01-02" "2 January 2006" }}
+                        {{ else if and (.DigitalLpa.SiriusData.Application.DonorIdentityCheckWhenDraft) (not (eq .DigitalLpa.SiriusData.Application.DonorDob "")) }}
+                            {{ (date .DigitalLpa.SiriusData.Application.DonorDob "2 January 2006") }}
+                        {{ end }}
+                    </dd>
+                </div>
 
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">Address</dt>


### PR DESCRIPTION
This PR covers [VEGA-3185](https://opgtransform.atlassian.net/browse/VEGA-3185).

As part of this PR, the display of Donor's DOB for a signed LPA uses the Sirius date if the donors identity check is completed when in Draft status or else it continues to show the LPA store DOB.

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-3185]: https://opgtransform.atlassian.net/browse/VEGA-3185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ