### PR TITLE
VEGA-3122 : add static LPA download link

### DIFF
--- a/web/template/mlpa-details.gohtml
+++ b/web/template/mlpa-details.gohtml
@@ -237,4 +237,5 @@
         </div>
       </div>
     {{ end }}
+    <a class="govuk-link" id="download-static-lpa" href="{{ sirius (printf "/api/v1/lpas/%s/static" .CaseSummary.DigitalLpa.UID) }}" download>Download static LPA</a>
 {{ end }}


### PR DESCRIPTION
add link for static lpa.
fixes: [VEGA-3122](https://opgtransform.atlassian.net/browse/VEGA-3122)
