### PR TITLE
VEGA-3788 - Add inline option to radios template

### DIFF
--- a/internal/templatefn/fn.go
+++ b/internal/templatefn/fn.go
@@ -38,7 +38,6 @@ func All(siriusPublicURL, prefix, staticHash string) map[string]interface{} {
 		},
 		"field":                 field,
 		"radios":                radios,
-		"inlineRadios":          inlineRadios,
 		"item":                  item,
 		"fieldID":               fieldID,
 		"select":                select_,
@@ -499,25 +498,14 @@ type radiosData struct {
 	Inline bool
 }
 
-func radios(name, label string, value interface{}, errors map[string]string, items ...itemData) radiosData {
+func radios(name, label string, value interface{}, errors map[string]string, inline bool, items ...itemData) radiosData {
 	return radiosData{
 		Name:   name,
 		Label:  label,
 		Value:  value,
 		Errors: errors,
 		Items:  items,
-		Inline: false,
-	}
-}
-
-func inlineRadios(name, label string, value interface{}, errors map[string]string, items ...itemData) radiosData {
-	return radiosData{
-		Name:   name,
-		Label:  label,
-		Value:  value,
-		Errors: errors,
-		Items:  items,
-		Inline: true,
+		Inline: inline,
 	}
 }
 

--- a/internal/templatefn/fn_test.go
+++ b/internal/templatefn/fn_test.go
@@ -320,7 +320,7 @@ func TestField(t *testing.T) {
 func TestRadios(t *testing.T) {
 	items := []itemData{{Value: "foo", Label: "Foo"}}
 	fns := All("", "", "")
-	fn := fns["radios"].(func(string, string, interface{}, map[string]string, ...itemData) radiosData)
+	fn := fns["radios"].(func(string, string, interface{}, map[string]string, bool, ...itemData) radiosData)
 	expected := radiosData{
 		Name:  "name",
 		Label: "Name",
@@ -332,26 +332,7 @@ func TestRadios(t *testing.T) {
 		Inline: false,
 	}
 
-	val := fn("name", "Name", "testing", map[string]string{"username": "required"}, items...)
-	assert.Equal(t, expected, val)
-}
-
-func TestInlineRadios(t *testing.T) {
-	items := []itemData{{Value: "foo", Label: "Foo"}}
-	fns := All("", "", "")
-	fn := fns["inlineRadios"].(func(string, string, interface{}, map[string]string, ...itemData) radiosData)
-	expected := radiosData{
-		Name:  "name",
-		Label: "Name",
-		Value: "testing",
-		Errors: map[string]string{
-			"username": "required",
-		},
-		Items:  items,
-		Inline: true,
-	}
-
-	val := fn("name", "Name", "testing", map[string]string{"username": "required"}, items...)
+	val := fn("name", "Name", "testing", map[string]string{"username": "required"}, false, items...)
 	assert.Equal(t, expected, val)
 }
 

--- a/web/template/add_complaint.gohtml
+++ b/web/template/add_complaint.gohtml
@@ -19,7 +19,7 @@
       <form class="form" method="POST">
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
 
-        {{ template "radios" (radios "severity" "Severity" .Complaint.Severity.Translation .Error.Field.severity
+        {{ template "radios" (radios "severity" "Severity" .Complaint.Severity.Translation .Error.Field.severity false
           (item "Minor" "Minor")
           (item "Major" "Major")
           (item "Security Breach" "Security Breach")

--- a/web/template/change-donor-details.gohtml
+++ b/web/template/change-donor-details.gohtml
@@ -52,11 +52,11 @@
                 {{ template "date" (field "lpaSignedOn" "LPA signed on" .Form.LpaSignedOn .Error.Field.LpaSignedOn) }}
 
                 {{ template "input" (field "authorisedSignatory" "Name of the person who signed on behalf of the donor" .Form.AuthorisedSignatory .Error.Field.AuthorisedSignatory) }}
-                {{ template "radios" (radios "signedByWitnessOne" "Signed by witness 1 (certificate provider)" .Form.SignedByWitnessOne .Error.Field.SignedByWitnessOne
+                {{ template "radios" (radios "signedByWitnessOne" "Signed by witness 1 (certificate provider)" .Form.SignedByWitnessOne .Error.Field.SignedByWitnessOne false
                 (item "Yes" "Yes")
                 (item "No" "No")
                 ) }}
-                {{ template "radios" (radios "signedByWitnessTwo" .SignedByWitnessTwoLabel .Form.SignedByWitnessTwo .Error.Field.SignedByWitnessTwo
+                {{ template "radios" (radios "signedByWitnessTwo" .SignedByWitnessTwoLabel .Form.SignedByWitnessTwo .Error.Field.SignedByWitnessTwo false
                 (item "Yes" "Yes")
                 (item "No" "No")
                 ) }}

--- a/web/template/create-epa.gohtml
+++ b/web/template/create-epa.gohtml
@@ -31,7 +31,7 @@
               {{ template "input-date" (field "epaDonorNoticeGivenDate" "Latest notification date" .Case.EpaDonorNoticeGivenDate .Error.Field.epaDonorNoticeGivenDate) }}
               {{ template "input-date" (field "receiptDate" "Receipt date" .Case.ReceiptDate .Error.Field.receiptDate "max" today) }}
 
-              {{ template "radios" (inlineRadios "donorHasOtherEpas" "Has the donor made any other EPAs?" (stringifyBoolPointer .Case.DonorHasOtherEpas) .Error.Field.donorHasOtherEpas
+              {{ template "radios" (radios "donorHasOtherEpas" "Has the donor made any other EPAs?" (stringifyBoolPointer .Case.DonorHasOtherEpas) .Error.Field.donorHasOtherEpas true
               (item "true" "Yes")
               (item "false" "No")
               ) }}
@@ -49,7 +49,7 @@
               </h2>
             </div>
             <div id="accordion-create-epa-content-2" class="govuk-accordion__section-content">
-              {{ template "radios" (radios "caseAttorney" "Select one option" .AppointmentType .Error.Field.appointmentType
+              {{ template "radios" (radios "caseAttorney" "Select one option" .AppointmentType .Error.Field.appointmentType false
               (item "singular" "Only one attorney is appointed")
               (item "jointly-and-severally" "Jointly and severally")
               (item "jointly" "Jointly")
@@ -82,12 +82,12 @@
               </h2>
             </div>
             <div id="accordion-create-epa-content-4" class="govuk-accordion__section-content">
-              {{ template "radios" (inlineRadios "paymentByCheque" "Cheque enclosed" (stringifyBoolPointer .Case.PaymentByCheque) .Error.Field.paymentByCheque
+              {{ template "radios" (radios "paymentByCheque" "Cheque enclosed" (stringifyBoolPointer .Case.PaymentByCheque) .Error.Field.paymentByCheque true
               (item "true" "Yes")
               (item "false" "No")
               ) }}
         
-              {{ template "radios" (inlineRadios "paymentExemption" "Application for postponement, exemption or remission of the fee" (stringifyBoolPointer .Case.PaymentExemption) .Error.Field.paymentExemption
+              {{ template "radios" (radios "paymentExemption" "Application for postponement, exemption or remission of the fee" (stringifyBoolPointer .Case.PaymentExemption) .Error.Field.paymentExemption true
               (item "true" "Yes")
               (item "false" "No")
               ) }}

--- a/web/template/create_document.gohtml
+++ b/web/template/create_document.gohtml
@@ -65,7 +65,7 @@
                 {{ template "input" (field "town" "City/town" nil .Error.Field.town) }}
                 {{ template "input" (field "county" "County" nil .Error.Field.county) }}
                 {{ template "input" (field "postcode" "Postcode" nil .Error.Field.postcode) }}
-                {{ template "radios" (radios "isAirmailRequired" "Is airmail required" nil .Error.Field.isAirmailRequired
+                {{ template "radios" (radios "isAirmailRequired" "Is airmail required" nil .Error.Field.isAirmailRequired false
                 (item "Yes" "Yes")
                 (item "No" "No")
                 ) }}

--- a/web/template/create_investigation.gohtml
+++ b/web/template/create_investigation.gohtml
@@ -23,7 +23,7 @@
 
                 {{ template "textarea" (field "information" "Information" .Investigation.Information .Error.Field.additionalInformation) }}
 
-                {{ template "radios" (radios "type" "Type" .Investigation.Type .Error.Field.type
+                {{ template "radios" (radios "type" "Type" .Investigation.Type .Error.Field.type false
                   (item "Aspect" "Aspect")
                   (item "Normal" "Normal")
                   (item "Priority" "Priority")

--- a/web/template/edit_complaint.gohtml
+++ b/web/template/edit_complaint.gohtml
@@ -17,7 +17,7 @@
       <form class="form" method="POST">
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
 
-        {{ template "radios" (radios "severity" "Severity" .Complaint.Severity.Translation .Error.Field.severity
+        {{ template "radios" (radios "severity" "Severity" .Complaint.Severity.Translation .Error.Field.severity false
           (item "Minor" "Minor")
           (item "Major" "Major")
           (item "Security Breach" "Security Breach")
@@ -107,7 +107,7 @@
           </div>
         </div>
 
-        {{ template "radios" (radios "resolution" "Resolution state" .Complaint.Resolution .Error.Field.resolution
+        {{ template "radios" (radios "resolution" "Resolution state" .Complaint.Resolution .Error.Field.resolution false
           (item "complaint upheld" "Complaint Upheld")
           (item "complaint partially upheld" "Complaint Partially Upheld")
           (item "complaint not upheld" "Complaint Not Upheld")

--- a/web/template/edit_investigation.gohtml
+++ b/web/template/edit_investigation.gohtml
@@ -21,7 +21,7 @@
 
                 {{ template "textarea" (field "information" "Information" .Investigation.Information .Error.Field.additionalInformation) }}
 
-                {{ template "radios" (radios "type" "Type" .Investigation.Type .Error.Field.type
+                {{ template "radios" (radios "type" "Type" .Investigation.Type .Error.Field.type false
                   (item "Aspect" "Aspect")
                   (item "Normal" "Normal")
                   (item "Priority" "Priority")

--- a/web/template/investigation_hold.gohtml
+++ b/web/template/investigation_hold.gohtml
@@ -51,7 +51,7 @@
                 </table>
 
                 {{ if not .Investigation.IsOnHold }}
-                    {{ template "radios" (radios "reason" "Reason" .Reason .Error.Field.reason
+                    {{ template "radios" (radios "reason" "Reason" .Reason .Error.Field.reason false
                     (item "Police Investigation" "Police Investigation")
                     (item "LA Investigation" "Local Authority Investigation")
                     ) }}

--- a/web/template/mlpa-update-decisions.gohtml
+++ b/web/template/mlpa-update-decisions.gohtml
@@ -57,14 +57,14 @@
         </div>
 
         {{ if (eq .CaseSummary.DigitalLpa.SiriusData.Subtype "personal-welfare")}}
-          {{ template "radios" (radios "lifeSustainingTreatmentOption" "Can attorneys make decisions about life sustaining treatment?" .Form.LifeSustainingTreatmentOption $.Error.Field.lifeSustainingTreatmentOption
+          {{ template "radios" (radios "lifeSustainingTreatmentOption" "Can attorneys make decisions about life sustaining treatment?" .Form.LifeSustainingTreatmentOption $.Error.Field.lifeSustainingTreatmentOption false
             (item "option-a" "Attorneys can make decisions about life sustaining treatment")
             (item "option-b" "Attorneys cannot make decisions about life sustaining treatment")
           ) }}
         {{ end }}
 
         {{ if (eq .CaseSummary.DigitalLpa.SiriusData.Subtype "property-and-affairs")}}
-          {{ template "radios" (radios "whenTheLpaCanBeUsed" "When can attorneys use the LPA?" .Form.WhenTheLpaCanBeUsed $.Error.Field.whenTheLpaCanBeUsed
+          {{ template "radios" (radios "whenTheLpaCanBeUsed" "When can attorneys use the LPA?" .Form.WhenTheLpaCanBeUsed $.Error.Field.whenTheLpaCanBeUsed false
             (item "when-has-capacity" "When it is registered")
             (item "when-capacity-lost" "When the donor has lost capacity")
           ) }}


### PR DESCRIPTION
Fixes [VEGA-3788](https://opgtransform.atlassian.net/browse/VEGA-3788)

- Add `inline` option to radios template
- Update all existing uses of the radio template to preserve existing behaviour
- Use inline option for some radios in the create EPA form