### PR TITLE
Upgrade frontend libraries

### DIFF
--- a/cypress/e2e/get-lpa-history.cy.js
+++ b/cypress/e2e/get-lpa-history.cy.js
@@ -474,17 +474,17 @@ describe("View LPA history timeline", () => {
       .then(($items) => {
         cy.wrap($items.eq(0))
           .should("contain.text", "EPA 7000-7000-7000")
-          .find(".colour-govuk-brown")
+          .find(".colour-sirius-brown")
           .should("exist");
 
         cy.wrap($items.eq(1))
           .should("contain.text", "PFA 7000-9000-7000")
-          .find(".colour-govuk-teal")
+          .find(".colour-sirius-teal")
           .should("exist");
 
         cy.wrap($items.eq(2))
           .should("contain.text", "HW 7000-9000-6000")
-          .find(".colour-govuk-grass-green")
+          .find(".colour-sirius-green")
           .should("exist");
 
         cy.wrap($items.eq(3))
@@ -871,7 +871,7 @@ describe("View LPA history timeline", () => {
 
         cy.wrap($items.eq(1))
           .should("contain.text", "EPA 7000-7000-7000")
-          .find(".colour-govuk-brown")
+          .find(".colour-sirius-brown")
           .should("exist");
       });
   });

--- a/cypress/e2e/get-lpa-history.cy.js
+++ b/cypress/e2e/get-lpa-history.cy.js
@@ -479,7 +479,7 @@ describe("View LPA history timeline", () => {
 
         cy.wrap($items.eq(1))
           .should("contain.text", "PFA 7000-9000-7000")
-          .find(".colour-govuk-turquoise")
+          .find(".colour-govuk-teal")
           .should("exist");
 
         cy.wrap($items.eq(2))

--- a/internal/shared/case_status.go
+++ b/internal/shared/case_status.go
@@ -41,7 +41,7 @@ type caseStatusMeta struct {
 
 var caseStatusMetadata = map[CaseStatus]caseStatusMeta{
 	CaseStatusTypeDraft:                  {"Draft", "draft", "purple"},
-	CaseStatusTypeInProgress:             {"In progress", "in-progress", "light-blue"},
+	CaseStatusTypeInProgress:             {"In progress", "in-progress", "blue"},
 	CaseStatusTypeStatutoryWaitingPeriod: {"Statutory waiting period", "statutory-waiting-period", "yellow"},
 	CaseStatusTypeDoNotRegister:          {"Do not register", "do-not-register", "red"},
 	CaseStatusTypeExpired:                {"Expired", "expired", "red"},
@@ -50,7 +50,7 @@ var caseStatusMetadata = map[CaseStatus]caseStatusMeta{
 	CaseStatusTypeCancelled:              {"Cancelled", "cancelled", "red"},
 	CaseStatusTypeDeRegistered:           {"De-registered", "de-registered", "red"},
 	CaseStatusTypeSuspended:              {"Suspended", "suspended", "red"},
-	CaseStatusTypePerfect:                {"Perfect", "", "turquoise"},
+	CaseStatusTypePerfect:                {"Perfect", "", "teal"},
 	CaseStatusTypePending:                {"Pending", "", "blue"},
 	CaseStatusTypePaymentPending:         {"Payment Pending", "", "blue"},
 	CaseStatusTypeReducedFeesPending:     {"Reduced Fees Pending", "", "blue"},

--- a/internal/shared/case_status_test.go
+++ b/internal/shared/case_status_test.go
@@ -53,9 +53,9 @@ func TestColour(t *testing.T) {
 		expected string
 	}{
 		{CaseStatusTypeRegistered, "green"},
-		{CaseStatusTypePerfect, "turquoise"},
+		{CaseStatusTypePerfect, "teal"},
 		{CaseStatusTypeStatutoryWaitingPeriod, "yellow"},
-		{CaseStatusTypeInProgress, "light-blue"},
+		{CaseStatusTypeInProgress, "blue"},
 		{CaseStatusTypeDraft, "purple"},
 		{CaseStatusTypeCancelled, "red"},
 		{CaseStatusTypeUnknown, "grey"},

--- a/internal/templatefn/fn.go
+++ b/internal/templatefn/fn.go
@@ -278,7 +278,7 @@ func All(siriusPublicURL, prefix, staticHash string) map[string]interface{} {
 			case "EPA":
 				return "colour-govuk-brown"
 			case "PFA":
-				return "colour-govuk-turquoise"
+				return "colour-govuk-teal"
 			case "HW":
 				return "colour-govuk-grass-green"
 			default:
@@ -423,7 +423,7 @@ func subtypeColour(subtype string) string {
 	case "personal-welfare":
 		return "light-green"
 	case "property-and-affairs":
-		return "turquoise"
+		return "teal"
 	default:
 		return ""
 	}

--- a/internal/templatefn/fn.go
+++ b/internal/templatefn/fn.go
@@ -276,11 +276,11 @@ func All(siriusPublicURL, prefix, staticHash string) map[string]interface{} {
 		"caseLabel": func(s string) string {
 			switch strings.ToUpper(s) {
 			case "EPA":
-				return "colour-govuk-brown"
+				return "colour-sirius-brown"
 			case "PFA":
-				return "colour-govuk-teal"
+				return "colour-sirius-teal"
 			case "HW":
-				return "colour-govuk-grass-green"
+				return "colour-sirius-green"
 			default:
 				return ""
 			}
@@ -421,7 +421,7 @@ func subtypeLongFormat(subtype string) string {
 func subtypeColour(subtype string) string {
 	switch strings.ToLower(subtype) {
 	case "personal-welfare":
-		return "light-green"
+		return "green"
 	case "property-and-affairs":
 		return "teal"
 	default:

--- a/internal/templatefn/fn_test.go
+++ b/internal/templatefn/fn_test.go
@@ -162,7 +162,7 @@ func TestResolutionOutcome(t *testing.T) {
 func TestCaseLabel(t *testing.T) {
 	expectations := map[string]string{
 		"EPA": "colour-govuk-brown",
-		"pfa": "colour-govuk-turquoise",
+		"pfa": "colour-govuk-teal",
 		"hw":  "colour-govuk-grass-green",
 		"":    "",
 		"foo": "",

--- a/internal/templatefn/fn_test.go
+++ b/internal/templatefn/fn_test.go
@@ -161,9 +161,9 @@ func TestResolutionOutcome(t *testing.T) {
 
 func TestCaseLabel(t *testing.T) {
 	expectations := map[string]string{
-		"EPA": "colour-govuk-brown",
-		"pfa": "colour-govuk-teal",
-		"hw":  "colour-govuk-grass-green",
+		"EPA": "colour-sirius-brown",
+		"pfa": "colour-sirius-teal",
+		"hw":  "colour-sirius-green",
 		"":    "",
 		"foo": "",
 	}
@@ -654,7 +654,7 @@ func TestSubtypeLongFormat(t *testing.T) {
 func TestSubtypeColour(t *testing.T) {
 	var val string
 	val = subtypeColour("personal-welfare")
-	assert.Equal(t, "light-green", val)
+	assert.Equal(t, "green", val)
 
 	val = subtypeColour("not-in-list")
 	assert.Equal(t, "", val)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@ministryofjustice/frontend": "^8.0.0",
+        "@ministryofjustice/frontend": "^9.0.0",
         "accessible-autocomplete": "^3.0.0",
         "cypress": "15.13.0",
-        "govuk-frontend": "^5.0.0",
+        "govuk-frontend": "^6.1.0",
         "hugerte": "https://github.com/ministryofjustice/opg-hugerte-dist#semver:v1.0.9",
         "opg-sirius-search-ui": "https://github.com/ministryofjustice/opg-sirius-search-ui#v1.78.38",
         "punycode": "^2.3.1"
@@ -514,15 +514,15 @@
       }
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-8.0.1.tgz",
-      "integrity": "sha512-IPgCcNe+XKV55I4J/SIoYAkfYp7mmUKjO1igXhzOtcF05+stWPbJuL9QzKORlRUxkwZtQ1jmiY7PZxMQzOXniw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-9.0.0.tgz",
+      "integrity": "sha512-R63EvHq//lONAhpUfZCMfxlUHoysDx5Hc6mi9EEV+sfVGm2spGV52PJAkYCYAc3bhTaTiJDtEM+PXgJm0iTWvQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       },
       "peerDependencies": {
-        "govuk-frontend": "^5.11.2",
+        "govuk-frontend": "^6.0.0",
         "moment": "2.30.1"
       }
     },
@@ -1856,9 +1856,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
-      "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.1.0.tgz",
+      "integrity": "sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "watch": "npm run build:js --watch=forever & npm run build:css --watch"
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "^8.0.0",
+    "@ministryofjustice/frontend": "^9.0.0",
     "accessible-autocomplete": "^3.0.0",
     "cypress": "15.13.0",
-    "govuk-frontend": "^5.0.0",
+    "govuk-frontend": "^6.1.0",
     "hugerte": "https://github.com/ministryofjustice/opg-hugerte-dist#semver:v1.0.9",
     "opg-sirius-search-ui": "https://github.com/ministryofjustice/opg-sirius-search-ui#v1.78.38",
     "punycode": "^2.3.1"

--- a/web/assets/dark.scss
+++ b/web/assets/dark.scss
@@ -22,7 +22,7 @@ $sirius-bg-color: #29292e;
   .govuk-caption-m,
   .govuk-caption-s,
   .govuk-caption-xs {
-    color: govuk-colour("light-grey");
+    color: govuk-colour("black", $variant: "tint-95");
   }
 
   h1,
@@ -47,19 +47,19 @@ $sirius-bg-color: #29292e;
   .govuk-details__summary-text,
   .govuk-link:link,
   .govuk-link--no-visited-state:visited {
-    color: lighten(govuk-colour("light-blue"), 20%);
+    color: lighten(govuk-colour("blue", $variant: "tint-25"), 20%);
   }
 
   .govuk-link:visited {
-    color: govuk-colour("light-pink");
+    color: govuk-colour("magenta", $variant: "tint-50");
   }
 
   .govuk-link:hover {
-    color: lighten(govuk-colour("light-blue"), 30%);
+    color: lighten(govuk-colour("blue", $variant: "tint-25"), 30%);
   }
 
   .govuk-link:active {
-    color: $govuk-link-active-colour;
+    color: govuk-functional-colour(link-active);
   }
 
   .govuk-label,
@@ -77,7 +77,7 @@ $sirius-bg-color: #29292e;
   }
 
   .govuk-hint {
-    color: govuk-colour("mid-grey");
+    color: govuk-colour("black", $variant: "tint-80");
   }
 
   .govuk-input,
@@ -102,11 +102,11 @@ $sirius-bg-color: #29292e;
   .govuk-pagination__item:hover,
   .govuk-pagination__next:hover,
   .govuk-pagination__prev:hover {
-    background-color: govuk-colour("dark-grey");
+    background-color: govuk-colour("black", $variant: "tint-25");
   }
 
   .govuk-pagination__icon {
-    color: govuk-colour("light-grey");
+    color: govuk-colour("black", $variant: "tint-95");
   }
 
   .moj-alert {
@@ -139,11 +139,7 @@ $sirius-bg-color: #29292e;
 
   .app-caseworker-summary,
   .app-caseworker-summary table {
-    background-color: #505a5f;
-  }
-
-  .govuk-header {
-    border-bottom: 10px solid govuk-colour("black");
+    background-color: govuk-colour("black", $variant: "tint-25");
   }
 
   .app-colour-text-lighter {

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -40,6 +40,12 @@ $govuk-assets-path: "../assets/";
   background-color: white;
 }
 
+@include govuk-media-query($until: tablet) {
+  .app-\!-html-class--embedded {
+    font-size: 0.75em;
+  }
+}
+
 .app-\!-full-width {
   width: 100%;
 }

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -1,6 +1,8 @@
 $govuk-page-width: 1220px;
 $moj-page-width: 1220px;
 
+$sirius-dark-blue: #00326e;
+
 $moj-assets-path: "../assets/";
 $govuk-assets-path: "../assets/";
 
@@ -297,8 +299,8 @@ $govuk-assets-path: "../assets/";
   color: #d9e2ee;
 }
 
-.colour-govuk-dark-blue {
-  background: govuk-colour("blue", $variant: "tint-50");
+.colour-sirius-dark-blue {
+  background: $sirius-dark-blue;
 }
 
 .colour-govuk-white {
@@ -404,7 +406,7 @@ $govuk-assets-path: "../assets/";
 
 .app-timeline-container {
   background: #d9e2ee;
-  border: 1px solid #00326e;
+  border: 1px solid $sirius-dark-blue;
   box-shadow: none;
   -moz-box-shadow: none;
   -webkit-box-shadow: none;

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -76,7 +76,7 @@ $govuk-assets-path: "../assets/";
 }
 
 .app-\!-moj-search__button {
-  background-color: $govuk-brand-colour;
+  background-color: govuk-functional-colour(brand);
   margin: 0;
   border: none;
   width: auto;
@@ -84,11 +84,11 @@ $govuk-assets-path: "../assets/";
 }
 
 .app-\!-moj-search__button:hover {
-  background-color: $govuk-link-hover-colour;
+  background-color: govuk-functional-colour(link-hover);
 }
 
 .app-moj-search__input {
-  border: 1px solid $govuk-border-colour;
+  border: 1px solid govuk-functional-colour(border);
 }
 
 .app-search-below-phase-banner {
@@ -128,11 +128,11 @@ $govuk-assets-path: "../assets/";
 }
 
 .app-\!-colour-text-light-green {
-  color: govuk-colour("light-green") !important;
+  color: govuk-colour("green", $variant: "tint-25") !important;
 }
 
-.app-\!-colour-text-turquoise {
-  color: govuk-colour("turquoise") !important;
+.app-\!-colour-text-teal {
+  color: govuk-colour("teal") !important;
 }
 
 .app-\!-pre-wrap {
@@ -170,7 +170,7 @@ $govuk-assets-path: "../assets/";
 }
 
 .app-colour-text-lighter {
-  color: govuk-colour("dark-grey") !important;
+  color: govuk-colour("black", $variant: "tint-25") !important;
 }
 
 .app-table--compact {
@@ -232,7 +232,7 @@ $govuk-assets-path: "../assets/";
   .app-\!-moj-header__navigation-item {
     display: list-item;
     padding: 10px 0;
-    border-bottom: 1px solid govuk-colour("dark-grey");
+    border-bottom: 1px solid govuk-colour("black", $variant: "tint-25");
   }
 }
 
@@ -279,40 +279,40 @@ $govuk-assets-path: "../assets/";
   max-width: 500px;
 }
 
-.colour-govuk-turquoise {
-  background: #28a197;
-  color: #000000;
+.colour-govuk-teal {
+  background: govuk-colour("teal");
+  color: govuk-colour("black");
 }
 .colour-govuk-grass-green {
-  background: #85994b;
-  color: #000000;
+  background: govuk-colour("green", $variant: "tint-25");
+  color: govuk-colour("black");
 }
 .colour-govuk-brown {
-  background: #b58840;
-  color: #000000;
+  background: govuk-colour("brown");
+  color: govuk-colour("black");
 }
 
 .color-govuk-black {
-  background: #000000;
+  background: govuk-colour("black");
   color: #d9e2ee;
 }
 
 .colour-govuk-dark-blue {
-  background: #003078;
+  background: govuk-colour("blue", $variant: "tint-50");
 }
 
 .colour-govuk-white {
-  color: #ffffff;
+  color: govuk-colour("white");
 }
 
 .background-govuk-white {
-  background: #ffffff;
+  background: govuk-colour("white");
 }
 
 .app-progress-indicator-icon[data-progress-indicator="not-started"] {
   [data-svg-elt="background"] {
-    stroke: govuk-colour("mid-grey");
-    fill: govuk-colour("mid-grey");
+    stroke: govuk-colour("black", $variant: "tint-80");
+    fill: govuk-colour("black", $variant: "tint-80");
   }
   [data-svg-elt="tick"],
   [data-svg-elt="border"] {
@@ -322,8 +322,8 @@ $govuk-assets-path: "../assets/";
 
 .app-progress-indicator-icon[data-progress-indicator="in-progress"] {
   [data-svg-elt="background"] {
-    stroke: $govuk-body-background-colour;
-    fill: $govuk-body-background-colour;
+    stroke: govuk-functional-colour(body-background);
+    fill: govuk-functional-colour(body-background);
   }
   [data-svg-elt="border"] {
     fill: govuk-colour("green");
@@ -335,8 +335,8 @@ $govuk-assets-path: "../assets/";
 
 .app-progress-indicator-icon[data-progress-indicator="complete"] {
   [data-svg-elt="background"] {
-    stroke: $govuk-body-background-colour;
-    fill: $govuk-body-background-colour;
+    stroke: govuk-functional-colour(body-background);
+    fill: govuk-functional-colour(body-background);
   }
   [data-svg-elt="border"],
   [data-svg-elt="tick"] {
@@ -345,7 +345,7 @@ $govuk-assets-path: "../assets/";
 }
 
 .govuk-information-colour {
-  color: #1d70b8;
+  color: govuk-functional-colour(brand);
 }
 
 .information-warning-header {
@@ -397,7 +397,7 @@ $govuk-assets-path: "../assets/";
 
 .app-document-compare__separator {
   @media (min-width: 40.0625em) {
-    border-right: 1px solid $govuk-border-colour;
+    border-right: 1px solid govuk-functional-colour(border);
     min-height: calc(100vh - 40px);
   }
 }
@@ -409,7 +409,7 @@ $govuk-assets-path: "../assets/";
   -moz-box-shadow: none;
   -webkit-box-shadow: none;
   border-radius: 5px;
-  color: #0b0c0c;
+  color: govuk-functional-colour(text);
 }
 
 .app-timeline-event p:last-of-type,

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -2,6 +2,9 @@ $govuk-page-width: 1220px;
 $moj-page-width: 1220px;
 
 $sirius-dark-blue: #00326e;
+$sirius-teal: #28a197;
+$sirius-green: #85994b;
+$sirius-brown: #b58840;
 
 $moj-assets-path: "../assets/";
 $govuk-assets-path: "../assets/";
@@ -135,12 +138,12 @@ $govuk-assets-path: "../assets/";
   color: govuk-colour("red") !important;
 }
 
-.app-\!-colour-text-light-green {
-  color: govuk-colour("green", $variant: "tint-25") !important;
+.app-\!-colour-text-green {
+  color: $sirius-green !important;
 }
 
 .app-\!-colour-text-teal {
-  color: govuk-colour("teal") !important;
+  color: $sirius-teal !important;
 }
 
 .app-\!-pre-wrap {
@@ -287,20 +290,22 @@ $govuk-assets-path: "../assets/";
   max-width: 500px;
 }
 
-.colour-govuk-teal {
-  background: govuk-colour("teal");
-  color: govuk-colour("black");
-}
-.colour-govuk-grass-green {
-  background: govuk-colour("green", $variant: "tint-25");
-  color: govuk-colour("black");
-}
-.colour-govuk-brown {
-  background: govuk-colour("brown");
+.colour-sirius-teal {
+  background: $sirius-teal;
   color: govuk-colour("black");
 }
 
-.color-govuk-black {
+.colour-sirius-green {
+  background: $sirius-green;
+  color: govuk-colour("black");
+}
+
+.colour-sirius-brown {
+  background: $sirius-brown;
+  color: govuk-colour("black");
+}
+
+.colour-govuk-black {
   background: govuk-colour("black");
   color: #d9e2ee;
 }

--- a/web/assets/wysiwyg.scss
+++ b/web/assets/wysiwyg.scss
@@ -37,7 +37,7 @@ body#hugerte {
 
   &#hugerte {
     .user-instruction {
-      color: lighten(govuk-colour("light-blue"), 20%);
+      color: lighten(govuk-colour("blue", $variant: "tint-25"), 20%);
     }
   }
 }

--- a/web/template/layout/header.gohtml
+++ b/web/template/layout/header.gohtml
@@ -1,7 +1,7 @@
 {{ define "header" }}
   <div class="app-!-embedded-hide">
-    <header role="banner" data-module="govuk-header" class="govuk-header">
-      <div class="govuk-header__container govuk-width-container app-align-service-name-center{{ block "container-classes" . }}{{ end }}">
+    <header role="banner" class="moj-header">
+      <div class="moj-header__container govuk-width-container app-align-service-name-center{{ block "container-classes" . }}{{ end }}">
         <div class="moj-header__logo">
           {{ template "moj-crest" }}
           <span class="moj-header__link moj-header__link--organisation-name">OPG</span>

--- a/web/template/lpa-history.gohtml
+++ b/web/template/lpa-history.gohtml
@@ -6,7 +6,7 @@
 
 {{ define "main" }}
     <div class="app-timeline-container">
-        <h2 class="govuk-heading-m colour-govuk-white colour-govuk-dark-blue govuk-!-padding-1 govuk-!-padding-left-2 govuk-!-margin-bottom-0">History</h2>
+        <h2 class="govuk-heading-m colour-govuk-white colour-sirius-dark-blue govuk-!-padding-1 govuk-!-padding-left-2 govuk-!-margin-bottom-0">History</h2>
         <div class="govuk-!-margin-4">
             <div class="app-align-items-end app-!-gap-2 govuk-!-margin-bottom-5">
                 <button class="govuk-button govuk-button govuk-!-margin-bottom-0" aria-controls="app-filters" data-filter-toggle>
@@ -23,7 +23,7 @@
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-one-quarter">
                     <div class="moj-filter moj-filter-layout__filter app-!-no-min-max-width" data-module="moj-filter">
-                        <div class="moj-filter__header govuk-!-padding-bottom-0 colour-govuk-dark-blue">
+                        <div class="moj-filter__header govuk-!-padding-bottom-0 colour-sirius-dark-blue">
                             <div class="moj-filter__header-title">
                                 <h2 class="govuk-heading-m colour-govuk-white">Filter</h2>
                                 <div class="govuk-body colour-govuk-white">
@@ -39,7 +39,7 @@
                             <div class="moj-filter__options">
                                 <form class="form" method="POST">
                                     <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
-                                    <button type="submit" class="govuk-button moj-filter__search-button" data-module="govuk-button" 
+                                    <button type="submit" class="govuk-button moj-filter__search-button" data-module="govuk-button"
                                             data-test-id="submit-button">
                                         Apply filters
                                     </button>
@@ -69,14 +69,14 @@
                                             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                                                 Type
                                             </legend>
-                                            <div class="govuk-checkboxes govuk-checkboxes--small" 
+                                            <div class="govuk-checkboxes govuk-checkboxes--small"
                                                  data-module="govuk-checkboxes">
                                                 {{ range .EventFilterData }}
                                                     <div class="govuk-checkboxes__item">
                                                         <input class="govuk-checkboxes__input" id="f-{{ .SourceType.Key }}"
                                                                 name="type" type="checkbox" value="{{ .SourceType.Key }}" data-module="app-auto-apply-filter"
                                                                 {{ if contains $.Form.Types .SourceType.Key }}checked{{ end }}>
-                                                        <label class="govuk-label govuk-checkboxes__label" 
+                                                        <label class="govuk-label govuk-checkboxes__label"
                                                                for="f-{{ .SourceType.Key }}">
                                                             {{ .SourceType.Translation }} ({{ .Total }})
                                                         </label>
@@ -215,7 +215,7 @@
                                                         {{ if .User.Deleted }}
                                                             deleted user
                                                         {{ else }}
-                                                            <a class="govuk-link" 
+                                                            <a class="govuk-link"
                                                                href="mailto:{{ .User.Email}}">{{ .User.DisplayName }}</a>
                                                             {{ if gt (len .User.Teams) 0 }}({{ (index .User.Teams 0).DisplayName }}){{ end }}
                                                             {{ if .User.PhoneNumber }} &ndash; {{ .User.PhoneNumber }}{{ end }}

--- a/web/template/lpa-history.gohtml
+++ b/web/template/lpa-history.gohtml
@@ -124,7 +124,7 @@
                                                             {{ end }}
                                                         </strong>
                                                     {{ end }}
-                                                    <div class="govuk-tag app-govuk-tag-bold color-govuk-black lpa-history__meta-timestamp">
+                                                    <div class="govuk-tag app-govuk-tag-bold colour-govuk-black lpa-history__meta-timestamp">
                                                         <time datetime="{{ .CreatedOn }}">{{ parseAndFormatDate .CreatedOn "2006-01-02T15:04:05+00:00" "2 January 2006 at 15:04" }}</time>
                                                         - #{{ .Hash }}
                                                     </div>


### PR DESCRIPTION
Upgrade govuk-frontend to v6, and @ministryofjustice/frontend to v9.

Replace `$govuk-XXX-colour` with `govuk-functional-colour(XXX)`

Update named colours:
- "turquoise" -> "teal"
- "light-pink" -> "magenta"
- Use the "blue" tag for in-progress cases: this is functionally identical to the old "light-blue" tag
- Replace removed colour names (light-grey, mid-grey, dark-grey, light-blue, light-green) with references to the new colour palette (per [the release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0#:~:text=Changes%20to%20colours%20in%20the%20GOV%2EUK%20web%20palette))

I kept the PFA/HW/EPA tag colours as custom "Sirius" branded colours, but updated the variable and class names to make it clearer that they weren't part of the gov.uk palette.

I also, where possible, moved hex values to use named/functional colours instead (e.g. `#FFFFFF` -> `govuk-colour(white)`)

Stop using `govuk-header` classes: mixing them is confusing and will break things, just use the MOJ header outright.

For VEGA-3810 #patch
