### PR TITLE
VEGA-3818 remove title validation

### DIFF
--- a/cypress/e2e/add-complaint.cy.js
+++ b/cypress/e2e/add-complaint.cy.js
@@ -7,7 +7,7 @@ describe("Add a complaint", () => {
     cy.contains("Add Complaint");
     cy.contains("LPA 7000-0000-0000");
     cy.get(".moj-alert").should("not.exist");
-    cy.contains(".govuk-radios__label", "Major").click();
+    cy.contains(".govuk-radios__label", "Complaint").click();
     cy.get("#f-investigatingOfficer").type("Test Officer");
     cy.get("#f-complainantName").type("Someones name");
     cy.get("#f-summary").type("A title");

--- a/internal/shared/complaint_severity.go
+++ b/internal/shared/complaint_severity.go
@@ -10,14 +10,20 @@ const (
 	ComplaintSeverityMinor ComplaintSeverity = iota
 	ComplaintSeverityMajor
 	ComplaintSeveritySecurityBreach
+	ComplaintSeverityComplaint
+	ComplaintSeverityComplaintsCorrespondence
+	ComplaintSeverityTier1
 	ComplaintSeverityNotRecognised
 )
 
 var complaintSeverityMap = map[string]ComplaintSeverity{
-	"Minor":           ComplaintSeverityMinor,
-	"Major":           ComplaintSeverityMajor,
-	"Security Breach": ComplaintSeveritySecurityBreach,
-	"NotRecognised":   ComplaintSeverityNotRecognised,
+	"Minor":                     ComplaintSeverityMinor,
+	"Major":                     ComplaintSeverityMajor,
+	"Security Breach":           ComplaintSeveritySecurityBreach,
+	"Complaint":                 ComplaintSeverityComplaint,
+	"Complaints Correspondence": ComplaintSeverityComplaintsCorrespondence,
+	"Tier 1+":                   ComplaintSeverityTier1,
+	"NotRecognised":             ComplaintSeverityNotRecognised,
 }
 
 func (d ComplaintSeverity) Translation() string {
@@ -28,6 +34,12 @@ func (d ComplaintSeverity) Translation() string {
 		return "Major"
 	case ComplaintSeveritySecurityBreach:
 		return "Security Breach"
+	case ComplaintSeverityComplaint:
+		return "Complaint"
+	case ComplaintSeverityComplaintsCorrespondence:
+		return "Complaints Correspondence"
+	case ComplaintSeverityTier1:
+		return "Tier 1+"
 	default:
 		return "complaint severity NOT RECOGNISED"
 	}

--- a/internal/shared/complaint_severity_test.go
+++ b/internal/shared/complaint_severity_test.go
@@ -13,6 +13,9 @@ func TestParseComplaintSeverity(t *testing.T) {
 		{"Minor", ComplaintSeverityMinor},
 		{"Major", ComplaintSeverityMajor},
 		{"Security Breach", ComplaintSeveritySecurityBreach},
+		{"Complaint", ComplaintSeverityComplaint},
+		{"Complaints Correspondence", ComplaintSeverityComplaintsCorrespondence},
+		{"Tier 1+", ComplaintSeverityTier1},
 		{"NotRecognised", ComplaintSeverityNotRecognised},
 		{"unknown-severity", ComplaintSeverityNotRecognised},
 	}
@@ -33,6 +36,9 @@ func TestComplaintSeverityUnmarshalJSON(t *testing.T) {
 		{`"Minor"`, ComplaintSeverityMinor},
 		{`"Major"`, ComplaintSeverityMajor},
 		{`"Security Breach"`, ComplaintSeveritySecurityBreach},
+		{`"Complaint"`, ComplaintSeverityComplaint},
+		{`"Complaints Correspondence"`, ComplaintSeverityComplaintsCorrespondence},
+		{`"Tier 1+"`, ComplaintSeverityTier1},
 		{`"NotRecognised"`, ComplaintSeverityNotRecognised},
 		{`"Invalid"`, ComplaintSeverityNotRecognised},
 	}
@@ -57,6 +63,9 @@ func TestComplaintSeverityMarshalJSON(t *testing.T) {
 		{ComplaintSeverityMinor, `"Minor"`},
 		{ComplaintSeverityMajor, `"Major"`},
 		{ComplaintSeveritySecurityBreach, `"Security Breach"`},
+		{ComplaintSeverityComplaint, `"Complaint"`},
+		{ComplaintSeverityComplaintsCorrespondence, `"Complaints Correspondence"`},
+		{ComplaintSeverityTier1, `"Tier 1+"`},
 		{ComplaintSeverityNotRecognised, `"complaint severity NOT RECOGNISED"`},
 	}
 
@@ -79,6 +88,9 @@ func TestComplaintSeverityTranslation(t *testing.T) {
 		{ComplaintSeverityMinor, "Minor"},
 		{ComplaintSeverityMajor, "Major"},
 		{ComplaintSeveritySecurityBreach, "Security Breach"},
+		{ComplaintSeverityComplaint, "Complaint"},
+		{ComplaintSeverityComplaintsCorrespondence, "Complaints Correspondence"},
+		{ComplaintSeverityTier1, "Tier 1+"},
 		{ComplaintSeverityNotRecognised, "complaint severity NOT RECOGNISED"},
 	}
 
@@ -89,4 +101,3 @@ func TestComplaintSeverityTranslation(t *testing.T) {
 		}
 	}
 }
-

--- a/internal/sirius/complaint.go
+++ b/internal/sirius/complaint.go
@@ -18,7 +18,7 @@ type Complaint struct {
 	Origin               string                   `json:"origin"`
 	CompensationType     string                   `json:"compensationType,omitempty"`
 	CompensationAmount   string                   `json:"compensationAmount,omitempty"`
-	Summary              string                   `json:"summary"`
+	Summary              string                   `json:"summary,omitempty"`
 	Resolution           string                   `json:"resolution,omitempty"`
 	ResolutionInfo       string                   `json:"resolutionInfo,omitempty"`
 	ResolutionDate       DateString               `json:"resolutionDate,omitempty"`

--- a/web/template/add_complaint.gohtml
+++ b/web/template/add_complaint.gohtml
@@ -19,7 +19,7 @@
       <form class="form" method="POST">
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
 
-        {{ template "radios" (radios "severity" "Severity" .Complaint.Severity.Translation .Error.Field.severity false
+        {{ template "radios" (radios "severity" "Type" .Complaint.Severity.Translation .Error.Field.severity false
           (item "Complaint" "Complaint")
           (item "Complaints Correspondence" "Complaints Correspondence")
           (item "Security Breach" "Security Breach")

--- a/web/template/add_complaint.gohtml
+++ b/web/template/add_complaint.gohtml
@@ -30,7 +30,7 @@
 
         {{ template "input" (field "complainantName" "Complainant name" .Complaint.ComplainantName .Error.Field.complainantName) }}
 
-        {{ template "input" (field "summary" "Title" .Complaint.Summary .Error.Field.summary) }}
+        {{ template "input" (field "summary" "Title (optional)" .Complaint.Summary .Error.Field.summary) }}
 
         {{ template "textarea" (field "description" "Description" .Complaint.Description .Error.Field.description) }}
 

--- a/web/template/add_complaint.gohtml
+++ b/web/template/add_complaint.gohtml
@@ -20,9 +20,10 @@
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
 
         {{ template "radios" (radios "severity" "Severity" .Complaint.Severity.Translation .Error.Field.severity false
-          (item "Minor" "Minor")
-          (item "Major" "Major")
+          (item "Complaint" "Complaint")
+          (item "Complaints Correspondence" "Complaints Correspondence")
           (item "Security Breach" "Security Breach")
+          (item "Tier 1+" "Tier 1+")
         ) }}
 
         {{ template "input" (field "investigatingOfficer" "Investigating officer" .Complaint.InvestigatingOfficer .Error.Field.investigatingOfficer) }}

--- a/web/template/edit_complaint.gohtml
+++ b/web/template/edit_complaint.gohtml
@@ -17,7 +17,7 @@
       <form class="form" method="POST">
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
 
-        {{ template "radios" (radios "severity" "Severity" .Complaint.Severity.Translation .Error.Field.severity false
+        {{ template "radios" (radios "severity" "Type" .Complaint.Severity.Translation .Error.Field.severity false
           (item "Complaint" "Complaint")
           (item "Complaints Correspondence" "Complaints Correspondence")
           (item "Minor" "Minor")

--- a/web/template/edit_complaint.gohtml
+++ b/web/template/edit_complaint.gohtml
@@ -30,7 +30,7 @@
 
         {{ template "input" (field "complainantName" "Complainant name" .Complaint.ComplainantName .Error.Field.complainantName) }}
 
-        {{ template "input" (field "summary" "Title" .Complaint.Summary .Error.Field.summary) }}
+        {{ template "input" (field "summary" "Title (optional)" .Complaint.Summary .Error.Field.summary) }}
 
         {{ template "textarea" (field "description" "Description" .Complaint.Description .Error.Field.description) }}
 

--- a/web/template/edit_complaint.gohtml
+++ b/web/template/edit_complaint.gohtml
@@ -18,9 +18,12 @@
         <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
 
         {{ template "radios" (radios "severity" "Severity" .Complaint.Severity.Translation .Error.Field.severity false
+          (item "Complaint" "Complaint")
+          (item "Complaints Correspondence" "Complaints Correspondence")
           (item "Minor" "Minor")
           (item "Major" "Major")
           (item "Security Breach" "Security Breach")
+          (item "Tier 1+" "Tier 1+")
         ) }}
 
         {{ template "input" (field "investigatingOfficer" "Investigating officer" .Complaint.InvestigatingOfficer .Error.Field.investigatingOfficer) }}


### PR DESCRIPTION
PR that makes title field optional

PR also includes VEGA-3764 changes to change Severity field name to Type in add complain form, edit complaint form and updates complaint types allowed on forms.

Fixes [VEGA-3818](https://opgtransform.atlassian.net/browse/VEGA-3818)

#patch

## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-3818]: https://opgtransform.atlassian.net/browse/VEGA-3818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ