### PR TITLE
VEGA-3538 sortby documents list

### DIFF
--- a/cypress/e2e/document-list.cy.js
+++ b/cypress/e2e/document-list.cy.js
@@ -754,3 +754,329 @@ describe("View documents", () => {
     cy.contains("29/05/2022 LP1F - Finance Instrument");
   });
 });
+
+describe("sort by dropdown", () => {
+  beforeEach(() => {
+    cy.addMock("/lpa-api/v1/persons/1/cases", "GET", {
+      status: 200,
+      body: {
+        cases: [
+          {
+            caseType: "LPA",
+            caseSubtype: "pfa",
+            id: 34,
+            uId: "7000-1234-1234",
+          },
+          { caseType: "LPA", caseSubtype: "hw", id: 78, uId: "7000-5678-5678" },
+        ],
+      },
+    });
+
+    cy.addMock(
+      "/lpa-api/v1/persons/1/documents?filter=draft:0,preview:0,case:78&limit=999",
+      "GET",
+      {
+        status: 200,
+        body: {
+          limit: 999,
+          metadata: {
+            doctype: {
+              correspondence: 2,
+              order: 0,
+              report: 0,
+              visit: 0,
+              finance: 0,
+              other: 0,
+            },
+            direction: { Incoming: 1, Outgoing: 1, Internal: 0 },
+          },
+          pages: { current: 1, total: 1 },
+          total: 2,
+          documents: [
+            {
+              id: 201,
+              uuid: "3bb33aa0-1234-4891-8739-1aa0fbcdee01",
+              type: "Save",
+              friendlyDescription: "A Document",
+              createdDate: "02/09/2024 09:00:00",
+              direction: "Outgoing",
+              notifyStatus: "posted",
+              filename: "a.pdf",
+              mimeType: "application/pdf",
+              caseItems: [
+                { uId: "7000-5678-5678", caseSubtype: "hw", caseType: "LPA" },
+              ],
+              persons: [],
+              systemType: "A",
+            },
+            {
+              id: 202,
+              uuid: "7cc44bb0-5678-4891-8739-5bb1facdef02",
+              type: "Correspondence",
+              friendlyDescription: "Z Document",
+              createdDate: "01/09/2025 10:00:00",
+              direction: "Incoming",
+              filename: "z.pdf",
+              mimeType: "application/pdf",
+              caseItems: [
+                { uId: "7000-5678-5678", caseSubtype: "hw", caseType: "LPA" },
+              ],
+              persons: [],
+              subtype: "hw",
+            },
+          ],
+        },
+      },
+    );
+
+    cy.addMock(
+      "/lpa-api/v1/persons/1/documents?filter=draft:0,preview:0,case:34,case:78&limit=999",
+      "GET",
+      {
+        status: 200,
+        body: {
+          limit: 999,
+          metadata: {
+            doctype: {
+              correspondence: 3,
+              order: 0,
+              report: 0,
+              visit: 0,
+              finance: 0,
+              other: 0,
+            },
+            direction: { Incoming: 2, Outgoing: 1, Internal: 0 },
+          },
+          pages: { current: 1, total: 1 },
+          total: 4,
+          documents: [
+            {
+              id: 332,
+              uuid: "5b4f0ad3-1e4a-4a55-b4a7-3f8e3d2bc3b9",
+              type: "LPA",
+              friendlyDescription: "LP1F - Finance Instrument",
+              createdDate: "29/05/2022 10:07:38",
+              direction: "Incoming",
+              filename: "LP1F.pdf",
+              mimeType: "application/pdf",
+              caseItems: [
+                { uId: "7000-1234-1234", caseSubtype: "pfa", caseType: "LPA" },
+              ],
+              persons: [],
+              subtype: "pfa",
+            },
+            {
+              id: 443,
+              uuid: "c8e3a1df-7b9b-4d45-94d9-2b8fc0d9e0fd",
+              type: "LPA",
+              friendlyDescription: "LP1H - Health Instrument",
+              createdDate: "01/06/2022 15:39:01",
+              direction: "Incoming",
+              filename: "LP1H.pdf",
+              mimeType: "application/pdf",
+              caseItems: [
+                { uId: "7000-5678-5678", caseSubtype: "hw", caseType: "LPA" },
+              ],
+              subtype: "hw",
+            },
+            {
+              id: 639,
+              uuid: "31e6f4c2-5f8b-47c3-bc98-64b47c938e52",
+              type: "Save",
+              friendlyDescription: "Letter",
+              createdDate: "25/07/2022 14:17:13",
+              direction: "Outgoing",
+              filename: "LP-NA-3A.pdf",
+              mimeType: "application/pdf",
+              caseItems: [
+                { uId: "7000-5678-5678", caseSubtype: "hw", caseType: "LPA" },
+              ],
+              persons: [],
+              systemType: "LP-NA-3A",
+            },
+            {
+              id: 640,
+              uuid: "42e6f4c2-5f8b-47c3-bc98-64b47c938e52",
+              type: "Save",
+              friendlyDescription: "Letter",
+              createdDate: "26/08/2022 08:11:27",
+              direction: "Outgoing",
+              notifyStatus: "posted",
+              filename: "LP-WHAT.pdf",
+              mimeType: "application/pdf",
+              caseItems: [
+                { uId: "7000-5678-5678", caseSubtype: "hw", caseType: "LPA" },
+              ],
+              persons: [],
+              systemType: "LP-WHAT",
+            },
+          ],
+        },
+      },
+    );
+  });
+
+  it("renders the dropdown with a default placeholder and all expected options", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-5678-5678");
+    cy.get("[data-document-sort]").should("exist");
+    cy.get("[data-document-sort] option[value='']").should(
+      "have.text",
+      "Select an option",
+    );
+    const expectedOptions = [
+      "date-new-old",
+      "date-old-new",
+      "direction-incoming",
+      "direction-outgoing",
+      "type-az",
+      "type-za",
+      "name-az",
+      "name-za",
+    ];
+    expectedOptions.forEach((value) => {
+      cy.get(`[data-document-sort] option[value='${value}']`).should("exist");
+    });
+  });
+
+  it("does not show case number sort options when viewing a single case", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-5678-5678");
+    cy.get("[data-document-sort] option[value='case-low-high']").should(
+      "not.exist",
+    );
+    cy.get("[data-document-sort] option[value='case-high-low']").should(
+      "not.exist",
+    );
+  });
+
+  it("shows case number sort options when viewing multiple cases", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-1234-1234&uid[]=7000-5678-5678");
+    cy.get("[data-document-sort] option[value='case-low-high']").should(
+      "exist",
+    );
+    cy.get("[data-document-sort] option[value='case-high-low']").should(
+      "exist",
+    );
+  });
+
+  it("sorts by name A-Z", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-5678-5678");
+    cy.get("[data-document-sort]").select("name-az");
+    cy.get("tbody tr td:nth-child(2) a").then(($links) => {
+      const names = [...$links].map((el) => el.textContent.trim());
+      expect(names).to.deep.equal(["A Document", "Z Document"]);
+    });
+  });
+
+  it("sorts by name Z-A", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-5678-5678");
+    cy.get("[data-document-sort]").select("name-za");
+    cy.get("tbody tr td:nth-child(2) a").then(($links) => {
+      const names = [...$links].map((el) => el.textContent.trim());
+      expect(names).to.deep.equal(["Z Document", "A Document"]);
+    });
+  });
+
+  it("sorts by date created new to old", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-5678-5678");
+    cy.get("[data-document-sort]").select("date-new-old");
+    cy.get("tbody tr [data-sort-type='date']").then(($cells) => {
+      const dates = [...$cells].map((el) => el.textContent.trim());
+      expect(dates).to.deep.equal([
+        "01/09/2025 10:00:00",
+        "02/09/2024 09:00:00",
+      ]);
+    });
+  });
+
+  it("sorts by date created old to new", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-5678-5678");
+    cy.get("[data-document-sort]").select("date-old-new");
+    cy.get("tbody tr [data-sort-type='date']").then(($cells) => {
+      const dates = [...$cells].map((el) => el.textContent.trim());
+      expect(dates).to.deep.equal([
+        "02/09/2024 09:00:00",
+        "01/09/2025 10:00:00",
+      ]);
+    });
+  });
+
+  it("sorts by direction with incoming first", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-5678-5678");
+    cy.get("[data-document-sort]").select("direction-incoming");
+
+    cy.get("tbody tr td:nth-child(2) a").then(($links) => {
+      const names = [...$links].map((el) => el.textContent.trim());
+      expect(names).to.deep.equal(["Z Document", "A Document"]);
+    });
+  });
+
+  it("sorts by direction with outgoing first", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-5678-5678");
+    cy.get("[data-document-sort]").select("direction-outgoing");
+
+    cy.get("tbody tr td:nth-child(2) a").then(($links) => {
+      const names = [...$links].map((el) => el.textContent.trim());
+      expect(names).to.deep.equal(["A Document", "Z Document"]);
+    });
+  });
+
+  it("sorts by document type A-Z", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-5678-5678");
+    cy.get("[data-document-sort]").select("type-az");
+
+    cy.get("tbody tr td:nth-child(2) a").then(($links) => {
+      const names = [...$links].map((el) => el.textContent.trim());
+      expect(names).to.deep.equal(["A Document", "Z Document"]);
+    });
+  });
+
+  it("sorts by document type Z-A", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-5678-5678");
+    cy.get("[data-document-sort]").select("type-za");
+    cy.get("tbody tr td:nth-child(2) a").then(($links) => {
+      const names = [...$links].map((el) => el.textContent.trim());
+      expect(names).to.deep.equal(["Z Document", "A Document"]);
+    });
+  });
+
+  it("sorts by case number low to high", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-1234-1234&uid[]=7000-5678-5678");
+    cy.get("[data-document-sort]").select("case-low-high");
+
+    cy.get("tbody tr [data-sort-type='case']").then(($cells) => {
+      const uids = [...$cells].map((el) => el.dataset.sortValue);
+      expect(uids[0]).to.equal("7000-1234-1234");
+    });
+  });
+
+  it("sorts by case number high to low", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-1234-1234&uid[]=7000-5678-5678");
+    cy.get("[data-document-sort]").select("case-high-low");
+    cy.get("tbody tr [data-sort-type='case']").then(($cells) => {
+      const uids = [...$cells].map((el) => el.dataset.sortValue);
+      expect(uids[0]).to.equal("7000-5678-5678");
+    });
+  });
+
+  it("resets any checked document selections when sort is changed", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-5678-5678");
+    cy.get('input[name="document"]').first().check({ force: true });
+    cy.get('input[name="document"]').first().should("be.checked");
+    cy.get("[data-document-sort]").select("name-az");
+    cy.get('input[name="document"]').each(($checkbox) => {
+      cy.wrap($checkbox).should("not.be.checked");
+    });
+  });
+
+  it("resets column header aria-sort indicators when sort dropdown is used", () => {
+    cy.visit("/donor/1/documents?uid[]=7000-5678-5678");
+
+    cy.contains("th", "Name").find("button").click();
+    cy.contains("th", "Name").should("have.attr", "aria-sort", "ascending");
+
+    cy.get("[data-document-sort]").select("name-az");
+    cy.get("th[aria-sort]").each(($th) => {
+      cy.wrap($th).should("have.attr", "aria-sort", "none");
+    });
+  });
+});

--- a/web/assets/document-list-sort.js
+++ b/web/assets/document-list-sort.js
@@ -1,0 +1,75 @@
+export default function documentListSort() {
+  const select = document.querySelector("[data-document-sort]");
+  if (!select) return;
+
+  select.addEventListener("change", function () {
+    const value = this.value;
+    if (!value) return;
+
+    const table = document.querySelector('[data-module="moj-sortable-table"]');
+    if (!table) return;
+
+    const tbody = table.querySelector(".govuk-table__body");
+    if (!tbody) return;
+
+    // Reset all checkbox selections
+    table.querySelectorAll('input[type="checkbox"]').forEach((cb) => {
+      cb.checked = false;
+    });
+
+    // Reset column header sort indicators
+    table.querySelectorAll("th[aria-sort]").forEach((th) => {
+      th.setAttribute("aria-sort", "none");
+    });
+
+    const rows = Array.from(tbody.querySelectorAll("tr.govuk-table__row"));
+
+    rows.sort((a, b) => {
+      switch (value) {
+        case "date-new-old":
+          return getSortValue(b, "date").localeCompare(getSortValue(a, "date"));
+        case "date-old-new":
+          return getSortValue(a, "date").localeCompare(getSortValue(b, "date"));
+        case "direction-incoming":
+          // "incoming" < "outgoing" alphabetically, so ascending puts Incoming first
+          return getDirection(a).localeCompare(getDirection(b));
+        case "direction-outgoing":
+          return getDirection(b).localeCompare(getDirection(a));
+        case "type-az":
+          return getSortValue(a, "type").localeCompare(getSortValue(b, "type"));
+        case "type-za":
+          return getSortValue(b, "type").localeCompare(getSortValue(a, "type"));
+        case "name-az":
+          return getSortValue(a, "name").localeCompare(getSortValue(b, "name"));
+        case "name-za":
+          return getSortValue(b, "name").localeCompare(getSortValue(a, "name"));
+        case "case-low-high":
+          return normaliseUID(getSortValue(a, "case")).localeCompare(
+            normaliseUID(getSortValue(b, "case")),
+          );
+        case "case-high-low":
+          return normaliseUID(getSortValue(b, "case")).localeCompare(
+            normaliseUID(getSortValue(a, "case")),
+          );
+        default:
+          return 0;
+      }
+    });
+
+    rows.forEach((row) => tbody.appendChild(row));
+  });
+}
+
+function getSortValue(row, type) {
+  const cell = row.querySelector(`[data-sort-type="${type}"]`);
+  if (!cell) return "";
+  return (cell.dataset.sortValue || cell.textContent).trim().toLowerCase();
+}
+
+function getDirection(row) {
+  return (row.dataset.direction || "").toLowerCase();
+}
+
+function normaliseUID(uid) {
+  return uid.replace(/-/g, "");
+}

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -18,6 +18,7 @@ import addressFinder from "./address-finder";
 import autoApplyFilter from "./auto-apply-filter";
 import showHideCaseSummary from "./show-hide-case-summary";
 import disableAfterClick from "./disable-after-click";
+import documentListSort from "./document-list-sort";
 
 const prefix = document.body.getAttribute("data-prefix");
 
@@ -40,6 +41,7 @@ addressFinder(prefix);
 autoApplyFilter();
 showHideCaseSummary();
 disableAfterClick();
+documentListSort();
 
 if (window.self !== window.parent) {
   const success = document.querySelector('[data-app-reload~="page"]');

--- a/web/template/layout/document-list.gohtml
+++ b/web/template/layout/document-list.gohtml
@@ -44,6 +44,27 @@
                     <input type="hidden" name="comparing" value="true">
                 {{ end }}
 
+                <div class="govuk-!-text-align-right govuk-!-margin-bottom-2">
+                    <label class="govuk-label govuk-!-display-inline govuk-!-margin-right-2" for="document-sort">
+                        Sort by
+                    </label>
+                    <select class="govuk-select" id="document-sort" data-document-sort>
+                        <option value="">Select an option</option>
+                        <option value="date-new-old">Date Created (New-Old)</option>
+                        <option value="date-old-new">Date Created (Old-New)</option>
+                        <option value="direction-incoming">Direction (Incoming)</option>
+                        <option value="direction-outgoing">Direction (Outgoing)</option>
+                        <option value="type-az">Document Type (A-Z)</option>
+                        <option value="type-za">Document Type (Z-A)</option>
+                        <option value="name-az">Name (A-Z)</option>
+                        <option value="name-za">Name (Z-A)</option>
+                        {{ if $multiCaseSelected }}
+                            <option value="case-low-high">Case number (Low-High)</option>
+                            <option value="case-high-low">Case number (High-Low)</option>
+                        {{ end }}
+                    </select>
+                </div>
+
                 <table class="govuk-table" data-module="moj-sortable-table">
                     <caption class="govuk-table__caption">
                         Documents ({{ .DocumentList.Total }})
@@ -79,7 +100,7 @@
 
                     <tbody class="govuk-table__body">
                     {{ range .DocumentList.Documents }}
-                        <tr class="govuk-table__row">
+                        <tr class="govuk-table__row" data-direction="{{ .Direction.Key }}">
                             <td class="govuk-table__cell">
                                 {{ if eq .MimeType "application/pdf" }}
                                     <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
@@ -97,7 +118,7 @@
                                     </div>
                                 {{ end }}
                             </td>
-                            <td class="govuk-table__cell" data-sort-value="{{ .FriendlyDescription }}">[{{ .Direction.Translation }}{{ if .NotifyStatus}} - {{ camelcaseToSentence .NotifyStatus }}{{end}}]
+                            <td class="govuk-table__cell" data-sort-type="name" data-sort-value="{{ .FriendlyDescription }}">[{{ .Direction.Translation }}{{ if .NotifyStatus}} - {{ camelcaseToSentence .NotifyStatus }}{{end}}]
                                 <br>
                                 {{ if eq .MimeType "application/pdf"}}
                                     {{ if eq $.Comparing true }}
@@ -110,15 +131,15 @@
                                 {{ end }}
                             </td>
                             {{ if $multiCaseSelected }}
-                                <td class="govuk-table__cell">
+                                <td class="govuk-table__cell" data-sort-type="case"{{ if gt (len .CaseItems) 0 }} data-sort-value="{{ (index .CaseItems 0).UID }}"{{ end }}>
                                     {{ if gt (len .CaseItems) 0 -}}
                                         {{ $case := index .CaseItems 0 -}}
                                         {{ template "CaseLabel" $case }}
                                     {{ end -}}
                                 </td>
                             {{ end }}
-                            <td class="govuk-table__cell" data-sort-value="{{ parseAndFormatDate .CreatedDate "02/01/2006 15:04:05" "2006-01-02 15:04:05" }}">{{ .CreatedDate }}</td>
-                            <td class="govuk-table__cell">
+                            <td class="govuk-table__cell" data-sort-type="date" data-sort-value="{{ parseAndFormatDate .CreatedDate "02/01/2006 15:04:05" "2006-01-02 15:04:05" }}">{{ .CreatedDate }}</td>
+                            <td class="govuk-table__cell" data-sort-type="type" data-sort-value="{{ if eq .Direction.Key `Outgoing` }}{{ .SystemType }}{{ else if eq .Direction.Key `Incoming` }}{{ .Type }}{{ if .SubType }} - {{ ToUpper .SubType }}{{ end }}{{ else if eq .Type `Correspondence` }}{{ .SubType }}{{ end }}">
                                 {{ if eq .Direction.Key "Outgoing" }}
                                     {{ .SystemType }}
                                 {{ else if eq .Direction.Key "Incoming" }}


### PR DESCRIPTION
## VEGA-3538 — Allow sort by via dropdown in document list

Adds a sort by dropdown to the document list, complementing the existing column header sorting.

### Changes
- `document-list.gohtml` — added sort by select element above the table; added `data-direction`, `data-sort-type`, and `data-sort-value` attributes to rows and cells
- `document-list-sort.js` — new JS module handling client-side sort on dropdown change, resetting checkboxes and column header `aria-sort` indicators
- `main.js` — imports and initialises the new module
- `document-list.cy.js` — Cypress tests covering all sort options, checkbox reset, and aria-sort reset behaviour

### Notes
- Case number sort options only render when multiple cases are selected
- Selecting from the dropdown resets any checked documents and clears column header sort state