### PR TITLE
VEGA-3862 - Update error message when creating epa without receipt date

### DIFF
--- a/internal/server/create_epa.go
+++ b/internal/server/create_epa.go
@@ -97,6 +97,13 @@ func CreateEpa(client CreateEpaClient, tmpl template.Template) Handler {
 			if ve, ok := err.(sirius.ValidationError); ok {
 				w.WriteHeader(http.StatusBadRequest)
 				data.Error = ve
+				if data.Error.Field["receiptDate"] != nil {
+					if r.FormValue("addAttorney") != "" || r.FormValue("addCorrespondent") != "" {
+						data.Error.Field["receiptDate"]["receiptDate"] = "Enter or select a receipt date to continue to step 3"
+					} else {
+						data.Error.Field["receiptDate"]["receiptDate"] = "Enter or select a receipt date to save and exit"
+					}
+				}
 				return tmpl(w, data)
 			} else if err != nil {
 				return err

--- a/internal/server/create_epa_test.go
+++ b/internal/server/create_epa_test.go
@@ -493,3 +493,136 @@ func TestPostCreateEpaWhenValidationError(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	mock.AssertExpectationsForObjects(t, client, template)
 }
+
+func TestPostCreateEpaWhenValidationErrorOnReceiptDate(t *testing.T) {
+	returnedError := sirius.ValidationError{
+		Field: sirius.FieldErrors{"receiptDate": {"receiptDate": "problem"}},
+	}
+	expectedError := sirius.ValidationError{
+		Field: sirius.FieldErrors{"receiptDate": {"receiptDate": "Enter or select a receipt date to save and exit"}},
+	}
+
+	truePtr := shared.BoolPtr(true)
+	falsePtr := shared.BoolPtr(false)
+	dateString := "2022-04-05"
+	epa := sirius.Epa{
+		EpaDonorSignatureDate:   sirius.DateString(dateString),
+		EpaDonorNoticeGivenDate: sirius.DateString(dateString),
+		DonorHasOtherEpas:       truePtr,
+		OtherEpaInfo:            "More info",
+		Case: sirius.Case{
+			CaseAttorneySingular:            truePtr,
+			CaseAttorneyJointlyAndSeverally: falsePtr,
+			CaseAttorneyJointly:             falsePtr,
+			PaymentByCheque:                 falsePtr,
+			PaymentExemption:                truePtr,
+			PaymentDate:                     sirius.DateString(dateString),
+		},
+	}
+
+	client := &mockCreateEpaClient{}
+	client.
+		On("CreateEpa", mock.Anything, 123, epa).
+		Return(sirius.Epa{}, returnedError)
+
+	template := &mockTemplate{}
+	template.
+		On("Func", mock.Anything, createEpaData{
+			Title:           "Create an EPA",
+			Success:         false,
+			Error:           expectedError,
+			AppointmentType: "singular",
+		}).
+		Return(nil)
+
+	form := url.Values{
+		"epaDonorSignatureDate":   {dateString},
+		"epaDonorNoticeGivenDate": {dateString},
+		"donorHasOtherEpas":       {"true"},
+		"otherEpaInfo":            {"More info"},
+		"caseAttorney":            {"singular"},
+		"paymentByCheque":         {"false"},
+		"paymentExemption":        {"true"},
+		"paymentDate":             {dateString},
+	}
+
+	r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
+	r.Header.Add("Content-Type", formUrlEncoded)
+	w := httptest.NewRecorder()
+
+	err := CreateEpa(client, template.Func)(w, r)
+	resp := w.Result()
+
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	mock.AssertExpectationsForObjects(t, client, template)
+}
+
+func TestPostCreateEpaAddActorValidationErrorOnReceiptDate(t *testing.T) {
+	for _, actorType := range []string{"addAttorney", "addCorrespondent"} {
+		t.Run(actorType, func(t *testing.T) {
+			returnedError := sirius.ValidationError{
+				Field: sirius.FieldErrors{"receiptDate": {"receiptDate": "problem"}},
+			}
+			expectedError := sirius.ValidationError{
+				Field: sirius.FieldErrors{"receiptDate": {"receiptDate": "Enter or select a receipt date to continue to step 3"}},
+			}
+
+			truePtr := shared.BoolPtr(true)
+			falsePtr := shared.BoolPtr(false)
+			dateString := "2022-04-05"
+			epa := sirius.Epa{
+				EpaDonorSignatureDate:   sirius.DateString(dateString),
+				EpaDonorNoticeGivenDate: sirius.DateString(dateString),
+				DonorHasOtherEpas:       truePtr,
+				OtherEpaInfo:            "More info",
+				Case: sirius.Case{
+					CaseAttorneySingular:            truePtr,
+					CaseAttorneyJointlyAndSeverally: falsePtr,
+					CaseAttorneyJointly:             falsePtr,
+					PaymentByCheque:                 falsePtr,
+					PaymentExemption:                truePtr,
+					PaymentDate:                     sirius.DateString(dateString),
+				},
+			}
+
+			client := &mockCreateEpaClient{}
+			client.
+				On("CreateEpa", mock.Anything, 123, epa).
+				Return(sirius.Epa{}, returnedError)
+
+			template := &mockTemplate{}
+			template.
+				On("Func", mock.Anything, createEpaData{
+					Title:           "Create an EPA",
+					Success:         false,
+					Error:           expectedError,
+					AppointmentType: "singular",
+				}).
+				Return(nil)
+
+			form := url.Values{
+				"epaDonorSignatureDate":   {dateString},
+				"epaDonorNoticeGivenDate": {dateString},
+				"donorHasOtherEpas":       {"true"},
+				"otherEpaInfo":            {"More info"},
+				"caseAttorney":            {"singular"},
+				"paymentByCheque":         {"false"},
+				"paymentExemption":        {"true"},
+				"paymentDate":             {dateString},
+				actorType:                 {"true"},
+			}
+
+			r, _ := http.NewRequest(http.MethodPost, "/?id=123", strings.NewReader(form.Encode()))
+			r.Header.Add("Content-Type", formUrlEncoded)
+			w := httptest.NewRecorder()
+
+			err := CreateEpa(client, template.Func)(w, r)
+			resp := w.Result()
+
+			assert.Nil(t, err)
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			mock.AssertExpectationsForObjects(t, client, template)
+		})
+	}
+}

--- a/internal/server/create_epa_test.go
+++ b/internal/server/create_epa_test.go
@@ -528,6 +528,7 @@ func TestPostCreateEpaWhenValidationErrorOnReceiptDate(t *testing.T) {
 	template := &mockTemplate{}
 	template.
 		On("Func", mock.Anything, createEpaData{
+			DonorId:         123,
 			Title:           "Create an EPA",
 			Success:         false,
 			Error:           expectedError,
@@ -594,6 +595,7 @@ func TestPostCreateEpaAddActorValidationErrorOnReceiptDate(t *testing.T) {
 			template := &mockTemplate{}
 			template.
 				On("Func", mock.Anything, createEpaData{
+					DonorId:         123,
 					Title:           "Create an EPA",
 					Success:         false,
 					Error:           expectedError,


### PR DESCRIPTION
Fixes [VEGA-3862](https://opgtransform.atlassian.net/browse/VEGA-3862), [VEGA-3846](https://opgtransform.atlassian.net/browse/VEGA-3846)

- Updates the error message when creating an EPA without entering a receiptDate
- Updates the error message when adding an actor to an EPA without entering a receiptDate
- Adds tests


[VEGA-3862]: https://opgtransform.atlassian.net/browse/VEGA-3862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[VEGA-3846]: https://opgtransform.atlassian.net/browse/VEGA-3846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ