### PR TITLE
VEGA-3869 - Copy to clipboard button POC

### DIFF
--- a/web/assets/copy-to-clipboard.js
+++ b/web/assets/copy-to-clipboard.js
@@ -27,5 +27,5 @@ export default async function copyToClipboard() {
 
       copyButton.blur();
     }
-  })
+  });
 }

--- a/web/assets/copy-to-clipboard.js
+++ b/web/assets/copy-to-clipboard.js
@@ -1,16 +1,15 @@
 export default async function copyToClipboard() {
-  const copyButtons = document.querySelectorAll(
-    "button[data-copy-to-clipboard]",
-  );
-
-  copyButtons.forEach((copyButton) => {
-    copyButton.addEventListener("click", (e) => {
+  document.addEventListener("click", (e) => {
+    if (e.target.matches("button[data-copy-to-clipboard]")) {
       e.preventDefault();
+
+      const copyButton = e.target;
 
       navigator.clipboard.writeText(copyButton.dataset.copyToClipboard);
 
       const originalButtonText = copyButton.innerText;
       copyButton.classList.add("disable-click");
+      copyButton.inert = true;
       copyButton.textContent = "Copied";
 
       const screenReaderAlert = document.createElement("span");
@@ -21,11 +20,12 @@ export default async function copyToClipboard() {
 
       setTimeout(() => {
         copyButton.classList.remove("disable-click");
+        copyButton.inert = false;
         copyButton.textContent = originalButtonText;
         copyButton.parentElement.removeChild(screenReaderAlert);
       }, 4000);
 
       copyButton.blur();
-    });
-  });
+    }
+  })
 }

--- a/web/assets/copy-to-clipboard.js
+++ b/web/assets/copy-to-clipboard.js
@@ -1,5 +1,7 @@
 export default async function copyToClipboard() {
-  const copyButtons = document.querySelectorAll("button[data-copy-to-clipboard]");
+  const copyButtons = document.querySelectorAll(
+    "button[data-copy-to-clipboard]",
+  );
 
   copyButtons.forEach((copyButton) => {
     copyButton.addEventListener("click", (e) => {

--- a/web/assets/copy-to-clipboard.js
+++ b/web/assets/copy-to-clipboard.js
@@ -1,0 +1,29 @@
+export default async function copyToClipboard() {
+  const copyButtons = document.querySelectorAll("button[data-copy-to-clipboard]");
+
+  copyButtons.forEach((copyButton) => {
+    copyButton.addEventListener("click", (e) => {
+      e.preventDefault();
+
+      navigator.clipboard.writeText(copyButton.dataset.copyToClipboard);
+
+      const originalButtonText = copyButton.innerText;
+      copyButton.classList.add("disable-click");
+      copyButton.textContent = "Copied";
+
+      const screenReaderAlert = document.createElement("span");
+      screenReaderAlert.classList.add("govuk-visually-hidden");
+      screenReaderAlert.ariaLive = "polite";
+      screenReaderAlert.textContent = "Copied to clipboard";
+      copyButton.parentElement.appendChild(screenReaderAlert);
+
+      setTimeout(() => {
+        copyButton.classList.remove("disable-click");
+        copyButton.textContent = originalButtonText;
+        copyButton.parentElement.removeChild(screenReaderAlert);
+      }, 4000);
+
+      copyButton.blur();
+    });
+  });
+}

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -19,6 +19,7 @@ import autoApplyFilter from "./auto-apply-filter";
 import showHideCaseSummary from "./show-hide-case-summary";
 import disableAfterClick from "./disable-after-click";
 import documentListSort from "./document-list-sort";
+import copyToClipboard from "./copy-to-clipboard";
 
 const prefix = document.body.getAttribute("data-prefix");
 
@@ -42,6 +43,7 @@ autoApplyFilter();
 showHideCaseSummary();
 disableAfterClick();
 documentListSort();
+copyToClipboard();
 
 if (window.self !== window.parent) {
   const success = document.querySelector('[data-app-reload~="page"]');

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -468,3 +468,9 @@ $govuk-assets-path: "../assets/";
   width: 75px;
   vertical-align: top;
 }
+
+.disable-click {
+  pointer-events: none;
+  background-color: transparent;
+  box-shadow: none;
+}

--- a/web/template/lpa-history.gohtml
+++ b/web/template/lpa-history.gohtml
@@ -124,6 +124,7 @@
                                                             {{ end }}
                                                         </strong>
                                                     {{ end }}
+                                                    <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-copy-to-clipboard="{{ .OwningCase.UID }}">Copy</button>
                                                     <div class="govuk-tag app-govuk-tag-bold colour-govuk-black lpa-history__meta-timestamp">
                                                         <time datetime="{{ .CreatedOn }}">{{ parseAndFormatDate .CreatedOn "2006-01-02T15:04:05+00:00" "2 January 2006 at 15:04" }}</time>
                                                         - #{{ .Hash }}


### PR DESCRIPTION
Fixes [VEGA-3869](https://opgtransform.atlassian.net/browse/VEGA-3869)

- Adds a javascript function for copying text to the clipboard. The function copies the given string, adds a hidden screen reader alert, and changes the copy button to a non-interactive element that reads `Copied`. After 4 seconds, the copy button reverts back to it's original state.
- Adds the copy button to the case id in the timeline event just as an example. It can be used anywhere.
  

[VEGA-3869]: https://opgtransform.atlassian.net/browse/VEGA-3869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ