### PR TITLE
VEGA-3875 - Fix HTMX inline styles CSP violation POC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "accessible-autocomplete": "^3.0.0",
         "cypress": "15.13.0",
         "govuk-frontend": "^6.1.0",
+        "htmx.org": "^2.0.10",
         "hugerte": "https://github.com/ministryofjustice/opg-hugerte-dist#semver:v1.0.9",
         "opg-sirius-search-ui": "https://github.com/ministryofjustice/opg-sirius-search-ui#v1.79.0",
         "punycode": "^2.3.1"
@@ -1514,6 +1515,7 @@
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -1860,6 +1862,7 @@
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.1.0.tgz",
       "integrity": "sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -1933,6 +1936,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/htmx.org": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.10.tgz",
+      "integrity": "sha512-kdeJe7ZVwaS6QMz/ebBIVtZdpwen6L0OQ5GOhPV9MKBb196TCZeZu4yA7ZIQsaLKv7EpXz+So7KSXNuHXhj7Cw==",
+      "license": "0BSD"
     },
     "node_modules/http-signature": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "accessible-autocomplete": "^3.0.0",
     "cypress": "15.13.0",
     "govuk-frontend": "^6.1.0",
+    "htmx.org": "^2.0.10",
     "hugerte": "https://github.com/ministryofjustice/opg-hugerte-dist#semver:v1.0.9",
     "opg-sirius-search-ui": "https://github.com/ministryofjustice/opg-sirius-search-ui#v1.79.0",
     "punycode": "^2.3.1"

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -45,7 +45,7 @@ disableAfterClick();
 documentListSort();
 
 window.htmx = htmx;
-// Don't include indicator styles as CSP Policy blocks inline styles
+// Don't include indicator styles as CSP blocks inline styles
 htmx.config.includeIndicatorStyles = false;
 
 if (window.self !== window.parent) {

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -19,6 +19,7 @@ import autoApplyFilter from "./auto-apply-filter";
 import showHideCaseSummary from "./show-hide-case-summary";
 import disableAfterClick from "./disable-after-click";
 import documentListSort from "./document-list-sort";
+import htmx from "htmx.org/dist/htmx.esm";
 
 const prefix = document.body.getAttribute("data-prefix");
 
@@ -42,6 +43,10 @@ autoApplyFilter();
 showHideCaseSummary();
 disableAfterClick();
 documentListSort();
+
+window.htmx = htmx;
+// Don't include indicator styles as CSP Policy blocks inline styles
+htmx.config.includeIndicatorStyles = false;
 
 if (window.self !== window.parent) {
   const success = document.querySelector('[data-app-reload~="page"]');

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -44,7 +44,7 @@ showHideCaseSummary();
 disableAfterClick();
 documentListSort();
 
-window.htmx = htmx;
+globalThis.htmx = htmx;
 // Don't include indicator styles as CSP blocks inline styles
 htmx.config.includeIndicatorStyles = false;
 

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -23,14 +23,14 @@ $govuk-assets-path: "../assets/";
 
 // Define HTMX indicator styles here to avoid inline styles which are blocked by CSP Policy
 .htmx-indicator {
-    opacity: 0;
-    visibility: hidden;
+  opacity: 0;
+  visibility: hidden;
 }
 .htmx-request .htmx-indicator,
 .htmx-request.htmx-indicator {
-    opacity: 1;
-    visibility: visible;
-    transition: opacity 200ms ease-in;
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 200ms ease-in;
 }
 
 .app-\!-embedded .app-\!-embedded-hide {

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -21,7 +21,7 @@ $govuk-assets-path: "../assets/";
 @import "./dark.scss";
 @import "./wysiwyg.scss";
 
-// Define HTMX indicator styles here to avoid inline styles which are blocked by CSP Policy
+// Define HTMX indicator styles here to avoid inline styles which are blocked by CSP
 .htmx-indicator {
   opacity: 0;
   visibility: hidden;

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -21,6 +21,18 @@ $govuk-assets-path: "../assets/";
 @import "./dark.scss";
 @import "./wysiwyg.scss";
 
+// Define HTMX indicator styles here to avoid inline styles which are blocked by CSP Policy
+.htmx-indicator {
+    opacity: 0;
+    visibility: hidden;
+}
+.htmx-request .htmx-indicator,
+.htmx-request.htmx-indicator {
+    opacity: 1;
+    visibility: visible;
+    transition: opacity 200ms ease-in;
+}
+
 .app-\!-embedded .app-\!-embedded-hide {
   display: none;
 }


### PR DESCRIPTION
Fixes [VEGA-3875](https://opgtransform.atlassian.net/browse/VEGA-3875)

HTMX applies inline style attributes during swap animations which is blocked by our content security policy. This POC shows a simple way in which we can avoid this problem altogether, without the need to loosen the CSP.

- Don't include the indicator styles in requests.
- Instead we add our own indicator styles from a trusted css source.

This also has the added benefit of allowing us to customise indicator styles in the future if required.






[VEGA-3875]: https://opgtransform.atlassian.net/browse/VEGA-3875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ