### PR TITLE
VEGA-3850: axe cypress template changes

### DIFF
--- a/cypress/e2e/anomaly.cy.js
+++ b/cypress/e2e/anomaly.cy.js
@@ -12,6 +12,12 @@ describe("View and edit anomalies for a digital LPA", () => {
           uId: "M-DIGI-QQQQ-1111",
           status: "Processing",
           caseSubtype: "property-and-affairs",
+          application: {
+            donorFirstNames: "Steven",
+            donorLastName: "Munnell",
+            donorDob: "17/06/1982",
+            donorAddress: { postcode: "EH6 18J" },
+          },
         },
         "opg.poas.lpastore": {
           channel: "online",
@@ -172,6 +178,12 @@ describe("View and edit anomalies for a digital LPA", () => {
           uId: "M-DIGI-TTTT-3333",
           status: "Processing",
           caseSubtype: "property-and-affairs",
+          application: {
+            donorFirstNames: "Steven",
+            donorLastName: "Munnell",
+            donorDob: "17/06/1982",
+            donorAddress: { postcode: "EH6 18J" },
+          },
         },
         "opg.poas.lpastore": {
           channel: "online",
@@ -226,6 +238,12 @@ describe("View and edit anomalies for a digital LPA", () => {
           uId: "M-DIGI-SSSS-3333",
           status: "Processing",
           caseSubtype: "personal-welfare",
+          application: {
+            donorFirstNames: "Steven",
+            donorLastName: "Munnell",
+            donorDob: "17/06/1982",
+            donorAddress: { postcode: "EH6 18J" },
+          },
         },
         "opg.poas.lpastore": {
           channel: "online",

--- a/cypress/e2e/compare-document.cy.js
+++ b/cypress/e2e/compare-document.cy.js
@@ -75,7 +75,7 @@ describe("Compare documents", () => {
   it("shows document alongside document list when first selecting compare", () => {
     cy.visit("/compare/33/34?pane1=dfef6714-b4fe-44c2-b26e-90dfe3663e95");
     cy.contains("7001-0000-5678");
-    cy.get("#main-content > :nth-child(1) > .govuk-button")
+    cy.get(".app-document-compare__separator > .govuk-button")
       .contains("Back to list")
       .should("have.attr", "href")
       .and("include", "/compare/33/34");
@@ -101,7 +101,7 @@ describe("Compare documents", () => {
   it("shows document not linked to a case alongside document list when first selecting compare", () => {
     //need to revisit this
     cy.visit("/compare/33/34?pane1=e5b5acd1-c11c-41fe-a921-7fdd07e8f670");
-    cy.get("#main-content > :nth-child(1) > .govuk-button")
+    cy.get(".app-document-compare__separator > .govuk-button")
       .contains("Back to list")
       .should("have.attr", "href")
       .and("include", "/compare/33/34");
@@ -130,21 +130,21 @@ describe("Compare documents", () => {
     );
     cy.contains("7001-0000-5678");
     cy.contains("A document not linked to case");
-    cy.get("#main-content > :nth-child(1) > .govuk-button")
+    cy.get(".app-document-compare__separator > .govuk-button")
       .contains("Back to list")
       .should("have.attr", "href")
       .and(
         "include",
         "/compare/33/34?pane2=e5b5acd1-c11c-41fe-a921-7fdd07e8f670",
       );
-    cy.get("#main-content > :nth-child(2) > .govuk-button")
+    cy.get(".govuk-grid-column-one-half:not(.app-document-compare__separator) > .govuk-button")
       .contains("Back to list")
       .should("have.attr", "href")
       .and(
         "include",
         "/compare/33/34?pane1=dfef6714-b4fe-44c2-b26e-90dfe3663e95",
       );
-    cy.get("#main-content > :nth-child(1)").within(() => {
+    cy.get(".app-document-compare__separator").within(() => {
       cy.get("button, a")
         .contains("Close")
         .should("exist")
@@ -160,7 +160,7 @@ describe("Compare documents", () => {
           }
         });
     });
-    cy.get("#main-content > :nth-child(2)").within(() => {
+    cy.get(".govuk-grid-column-one-half:not(.app-document-compare__separator)").within(() => {
       cy.get("button, a")
         .contains("Close")
         .should("exist")
@@ -183,11 +183,11 @@ describe("Compare documents", () => {
     cy.visit("compare/33/34?pane2=e5b5acd1-c11c-41fe-a921-7fdd07e8f670");
     cy.contains("7001-0000-5678");
     cy.contains("A document not linked to case");
-    cy.get("#main-content > :nth-child(2) > .govuk-button")
+    cy.get(".govuk-grid-column-one-half:not(.app-document-compare__separator) > .govuk-button")
       .contains("Back to list")
       .should("have.attr", "href")
       .and("include", "/compare/33/34");
-    cy.get("#main-content > :nth-child(2)").within(() => {
+    cy.get(".govuk-grid-column-one-half:not(.app-document-compare__separator)").within(() => {
       cy.get("button, a")
         .contains("Close")
         .should("exist")

--- a/cypress/e2e/compare-document.cy.js
+++ b/cypress/e2e/compare-document.cy.js
@@ -137,7 +137,9 @@ describe("Compare documents", () => {
         "include",
         "/compare/33/34?pane2=e5b5acd1-c11c-41fe-a921-7fdd07e8f670",
       );
-    cy.get(".govuk-grid-column-one-half:not(.app-document-compare__separator) > .govuk-button")
+    cy.get(
+      ".govuk-grid-column-one-half:not(.app-document-compare__separator) > .govuk-button",
+    )
       .contains("Back to list")
       .should("have.attr", "href")
       .and(
@@ -160,7 +162,9 @@ describe("Compare documents", () => {
           }
         });
     });
-    cy.get(".govuk-grid-column-one-half:not(.app-document-compare__separator)").within(() => {
+    cy.get(
+      ".govuk-grid-column-one-half:not(.app-document-compare__separator)",
+    ).within(() => {
       cy.get("button, a")
         .contains("Close")
         .should("exist")
@@ -183,11 +187,15 @@ describe("Compare documents", () => {
     cy.visit("compare/33/34?pane2=e5b5acd1-c11c-41fe-a921-7fdd07e8f670");
     cy.contains("7001-0000-5678");
     cy.contains("A document not linked to case");
-    cy.get(".govuk-grid-column-one-half:not(.app-document-compare__separator) > .govuk-button")
+    cy.get(
+      ".govuk-grid-column-one-half:not(.app-document-compare__separator) > .govuk-button",
+    )
       .contains("Back to list")
       .should("have.attr", "href")
       .and("include", "/compare/33/34");
-    cy.get(".govuk-grid-column-one-half:not(.app-document-compare__separator)").within(() => {
+    cy.get(
+      ".govuk-grid-column-one-half:not(.app-document-compare__separator)",
+    ).within(() => {
       cy.get("button, a")
         .contains("Close")
         .should("exist")

--- a/web/assets/show-hide-case-summary.js
+++ b/web/assets/show-hide-case-summary.js
@@ -24,7 +24,6 @@ export default function showHideCaseSummary(prefix) {
             "govuk-accordion-nav__chevron--down",
           );
           caseSummary.hidden = true;
-          caseSummary.ariaExpanded = "false";
         } else {
           buttonText.innerText = "Hide";
           buttonIcon.classList.replace(
@@ -32,7 +31,6 @@ export default function showHideCaseSummary(prefix) {
             "govuk-accordion-nav__chevron--up",
           );
           caseSummary.hidden = false;
-          caseSummary.ariaExpanded = "true";
         }
       });
     }

--- a/web/template/add_fee_decision.gohtml
+++ b/web/template/add_fee_decision.gohtml
@@ -17,7 +17,7 @@
                 {{ template "select" (select "decisionType" "Type of decision" .DecisionType .Error.Field.decisionType (options .DecisionTypes "filterSelectable" false)) }}
 
                 <div class="govuk-form-group {{ if .Error.Field.amount }}govuk-form-group--error{{ end }}">
-                    <label class="govuk-label" for="f-decision-reason">
+                    <label class="govuk-label" for="f-decisionReason">
                         Reason for decision
                     </label>
                     {{ template "errors" .Error.Field.decisionReason }}

--- a/web/template/compare-docs.gohtml
+++ b/web/template/compare-docs.gohtml
@@ -3,6 +3,7 @@
 {{ define "container-classes" }} app-!-max-full-width{{ end }}
 
 {{ define "main" }}
+    <h1 class="govuk-visually-hidden">Compare documents</h1>
     <div class="govuk-grid-column-one-half app-document-compare__separator">
         {{ if eq .Pane1 "doc" }}
             {{ template "viewingDocument" .View1 }}

--- a/web/template/create_additional_draft.gohtml
+++ b/web/template/create_additional_draft.gohtml
@@ -4,6 +4,7 @@
 
 {{ define "main" }}
 	{{ if .Success }}
+		<h1 class="govuk-visually-hidden">Draft LPA created</h1>
     {{ template "create_lpa_success_banner" . }}
 	{{ else }}
 		<a href="{{ prefix (printf "/lpa/%s" (index .Donor.Cases 0).UID )}}" class="govuk-back-link">Back</a>

--- a/web/template/create_draft.gohtml
+++ b/web/template/create_draft.gohtml
@@ -4,6 +4,7 @@
 
 {{ define "main" }}
   {{ if .Success }}
+    <h1 class="govuk-visually-hidden">Draft LPA created</h1>
       {{ template "create_lpa_success_banner" . }}
   {{ else }}
     <div class="govuk-grid-row">
@@ -53,9 +54,9 @@
           <div class="govuk-form-group {{ if .Error.Field.donorDob }}govuk-form-group--error{{ end }}" id="f-donorDob">
             <fieldset class="govuk-fieldset" role="group" aria-describedby="f-dob-hint">
               <legend class="govuk-fieldset__legend">
-                <h1 class="govuk-fieldset__heading">
+                <span class="govuk-fieldset__heading">
                   Donor’s date of birth
-                </h1>
+                </span>
               </legend>
               <div id="f-dob-hint" class="govuk-hint">
                 For example, 12 01 1967.

--- a/web/template/delete-document.gohtml
+++ b/web/template/delete-document.gohtml
@@ -7,14 +7,15 @@
                 {{ range .Document.CaseItems }}
                     {{ template "CaseLabel" . }}
                 {{ end }}
-                <strong>
+                <h1 class="govuk-heading-m">
                     Are you sure you want to delete: <br>
                     {{ (parseAndFormatDate .Document.CreatedDate "02/01/2006 15:04:05" "02/01/2006") }} {{ .Document.FriendlyDescription }}?
-                </strong>
+                </h1>
             </div>
 
             <iframe
                     class="document-viewer-container"
+                    title="Document viewer"
                     src="/lpa-api/v1/documents/{{ .Document.UUID }}/file"
             >
             </iframe>

--- a/web/template/documents.gohtml
+++ b/web/template/documents.gohtml
@@ -5,5 +5,6 @@
 {{ define "container-classes" }} app-!-max-full-width{{ end }}
 
 {{ define "main" }}
+    <h1 class="govuk-visually-hidden">Documents</h1>
     {{ template "DocumentList" . }}
 {{ end }}

--- a/web/template/donor.gohtml
+++ b/web/template/donor.gohtml
@@ -10,6 +10,7 @@
 
       {{ if .Success }}
         {{ if .IsNew }}
+          <h1 class="govuk-visually-hidden">Donor created</h1>
           <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
             <div class="govuk-notification-banner__header">
               <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
@@ -31,6 +32,7 @@
             </div>
           </div>
         {{ else }}
+          <h1 class="govuk-visually-hidden">Donor edited</h1>
           <meta data-app-reload="page" />
           {{ template "success-banner" "Donor was edited" }}
         {{ end }}

--- a/web/template/donor_details.gohtml
+++ b/web/template/donor_details.gohtml
@@ -2,7 +2,7 @@
 {{ define "main" }}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h2 class="govuk-heading-l app-!-embedded-hide">Donor details</h2>
+            <h1 class="govuk-heading-l app-!-embedded-hide">Donor details</h1>
 
             <table class="govuk-table app-donor-details-table">
                 <tbody class="govuk-table__body">

--- a/web/template/layout/mlpa-case-summary.gohtml
+++ b/web/template/layout/mlpa-case-summary.gohtml
@@ -13,7 +13,7 @@
 
         {{ $uid := .CaseSummary.DigitalLpa.UID }}
 
-        <div class="govuk-grid-row" data-id="case-summary" aria-expanded="true">
+        <div class="govuk-grid-row" data-id="case-summary">
             <div class="govuk-grid-column-one-third">
                 <div class="govuk-!-margin-bottom-4">
                     <div class="govuk-!-margin-bottom-2">

--- a/web/template/layout/search_filter.gohtml
+++ b/web/template/layout/search_filter.gohtml
@@ -1,5 +1,5 @@
 {{ define "search-filter" }}
-    <div class="moj-filter-layout__filter app-!-width-fit-content">
+    <div id="app-filters" class="moj-filter-layout__filter app-!-width-fit-content">
         <div class="moj-filter">
             <div class="moj-filter__header">
                 <div class="moj-filter__header-title">

--- a/web/template/layout/viewing-document.gohtml
+++ b/web/template/layout/viewing-document.gohtml
@@ -19,6 +19,7 @@
 
     <iframe
             class="document-viewer-container"
+            title="Document viewer"
             src="/lpa-api/v1/documents/{{ .Document.UUID }}/file"
     >
     </iframe>

--- a/web/template/lpa-history.gohtml
+++ b/web/template/lpa-history.gohtml
@@ -22,7 +22,7 @@
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-one-quarter">
-                    <div class="moj-filter moj-filter-layout__filter app-!-no-min-max-width" data-module="moj-filter">
+                    <div id="app-filters" class="moj-filter moj-filter-layout__filter app-!-no-min-max-width" data-module="moj-filter">
                         <div class="moj-filter__header govuk-!-padding-bottom-0 colour-sirius-dark-blue">
                             <div class="moj-filter__header-title">
                                 <h2 class="govuk-heading-m colour-govuk-white">Filter</h2>
@@ -215,8 +215,7 @@
                                                         {{ if .User.Deleted }}
                                                             deleted user
                                                         {{ else }}
-                                                            <a class="govuk-link"
-                                                               href="mailto:{{ .User.Email}}">{{ .User.DisplayName }}</a>
+                                                            {{ if .User.Email }}<a class="govuk-link" href="mailto:{{ .User.Email }}">{{ .User.DisplayName }}</a>{{ else }}{{ .User.DisplayName }}{{ end }}
                                                             {{ if gt (len .User.Teams) 0 }}({{ (index .User.Teams 0).DisplayName }}){{ end }}
                                                             {{ if .User.PhoneNumber }} &ndash; {{ .User.PhoneNumber }}{{ end }}
                                                         {{ end }}

--- a/web/template/mlpa-history.gohtml
+++ b/web/template/mlpa-history.gohtml
@@ -99,7 +99,7 @@
                             <div class="govuk-summary-list__row">
                                 <p class="govuk-hint govuk-!-margin-bottom-1 govuk-!-margin-top-1">
                                     {{ if .User }}
-                                        Created by <a class="govuk-link" href="mailto:{{ .User.Email}}">{{ .User.DisplayName }}</a>
+                                        Created by {{ if .User.Email }}<a class="govuk-link" href="mailto:{{ .User.Email }}">{{ .User.DisplayName }}</a>{{ else }}{{ .User.DisplayName }}{{ end }}
                                     {{ else }}
                                         Created by Unknown User
                                     {{ end }}

--- a/web/template/mlpa-manage-attorneys.gohtml
+++ b/web/template/mlpa-manage-attorneys.gohtml
@@ -36,7 +36,7 @@
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="f-attorneyActionManageDecisions" name="attorneyAction" type="radio" value="manage-decisions" {{ if eq "manage-decisions" .AttorneyAction }}checked{{ end }}>
-                <label class="govuk-label govuk-radios__label" for="f-manageDecisions">
+                <label class="govuk-label govuk-radios__label" for="f-attorneyActionManageDecisions">
                   Manage decisions - attorneys who cannot act jointly
                 </label>
               </div>

--- a/web/template/view-document.gohtml
+++ b/web/template/view-document.gohtml
@@ -9,7 +9,9 @@
                 {{ range .Document.CaseItems }}
                     {{ template "CaseLabel" . }}
                 {{ end }}
-                <strong>{{ (parseAndFormatDate .Document.CreatedDate "02/01/2006 15:04:05" "02/01/2006") }} {{ .Document.FriendlyDescription }}</strong>
+                <h1 class="govuk-heading-m">
+                    {{ (parseAndFormatDate .Document.CreatedDate "02/01/2006 15:04:05" "02/01/2006") }} {{ .Document.FriendlyDescription }}
+                </h1>
             </div>
 
             <div class="moj-button-group--inline">
@@ -41,6 +43,7 @@
 
                 <iframe
                         class="document-viewer-container"
+                        title="Document viewer"
                         src="/lpa-api/v1/documents/{{ .Document.UUID }}/file"
                 >
                 </iframe>


### PR DESCRIPTION
VEGA-3850

# Accessibility fixes ahead of axe being enabled

Template and mock data fixes identified during the axe spike (VEGA-3282). Clears all fixable violations so axe can be turned on cleanly in the follow-up ticket.

## Fixed

- **`aria-allowed-attr`** — removed `aria-expanded` from case summary `<div>` and the JS that was re-adding it on toggle. Attribute belongs on the button only.
- **`label`** — fixed `for`/`id` mismatches on `f-decisionReason` (add-fee-decision) and `f-attorneyActionManageDecisions` (manage-attorneys).
- **`frame-title`** — added `title="Document viewer"` to iframes in view-document, delete-document, and viewing-document templates.
- **`page-has-heading-one`** — added missing `<h1>` (visible or visually hidden as appropriate) to: compare-docs, create-additional-draft, create-draft, create-donor, delete-document, documents, donor, donor_details, edit-donor, view-document. Also fixed a `<h1>` inside a fieldset legend in create-draft that should be a `<span>`.
- **`empty-heading`** — added `application` data to anomaly Cypress mocks so donor name renders in the header `<h1>`.
- **`aria-valid-attr-value`** — added `id="app-filters"` to the filter containers in search-filter and lpa-history templates. The toggle button referenced this ID but the element didn't have it.
- **`link-name`** — conditionally render mailto links in mlpa-history and lpa-history only when `User.Email` is non-empty.

## Suppressed 

- `region` — search bar outside landmark is in `opg-sirius-search-ui` package, needs upstream fix.
- `aria-allowed-attr` on radio inputs — GOV.UK Frontend conditional reveal pattern, known GDS issue.

## Out of scope — follow-up tickets required

- `definition-list` — `govuk-summary-list` misuse in history timeline templates (structural fix needed).
- `landmark-*` — full page layout embedded inside a summary list value in digital-lpa-details (architectural decision needed).
