### PR TITLE
VEGA-3967 : add county to PostcodeLookupAddress so it overwrites on update

### DIFF
--- a/internal/sirius/postcode_lookup.go
+++ b/internal/sirius/postcode_lookup.go
@@ -10,6 +10,7 @@ type PostcodeLookupAddress struct {
 	Line2       string `json:"addressLine2"`
 	Line3       string `json:"addressLine3"`
 	Town        string `json:"town"`
+	County      string `json:"county"`
 	Postcode    string `json:"postcode"`
 	Country     string `json:"country"`
 	Description string `json:"description"`


### PR DESCRIPTION
fixes: [vega-3967](https://opgtransform.atlassian.net/browse/VEGA-3967)

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards
