### PR TITLE
Update theme-color to #1d70b8

### DIFF
--- a/internal/server/event.go
+++ b/internal/server/event.go
@@ -101,7 +101,7 @@ func Event(client EventClient, tmpl template.Template, partialTmpl template.Temp
 		}
 
 		if r.Method == http.MethodPost {
-			if err := r.ParseMultipartForm(64 * Megabyte); err != nil {
+			if err := r.ParseMultipartForm(64 * Megabyte); err != nil { //#nosec G120 -- This value is high to allow large file uploads
 				return err
 			}
 

--- a/internal/sirius/get_user_permissions.go
+++ b/internal/sirius/get_user_permissions.go
@@ -4,7 +4,6 @@ import "slices"
 
 type PermissionType struct {
 	Permissions  []string `json:"permissions"`
-	Restrictions []string `json:"restrictions"`
 }
 
 type Permissions map[string]PermissionType

--- a/internal/sirius/get_user_permissions_test.go
+++ b/internal/sirius/get_user_permissions_test.go
@@ -38,7 +38,6 @@ func TestGetUserPermissions(t *testing.T) {
 						Body: matchers.Like(map[string]interface{}{
 							"keep-alive": matchers.Like(map[string]interface{}{
 								"permissions":  matchers.EachLike("GET", 1),
-								"restrictions": matchers.EachLike("GET", 0),
 							}),
 						}),
 						Headers: matchers.MapMatcher{"Content-Type": matchers.String("application/json")},

--- a/web/template/layout/page.gohtml
+++ b/web/template/layout/page.gohtml
@@ -5,7 +5,7 @@
       <meta charset="utf-8">
       <title>{{ block "title" . }}{{ end }} - Sirius</title>
       <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-      <meta name="theme-color" content="blue">
+      <meta name="theme-color" content="#1d70b8">
 
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
 


### PR DESCRIPTION
To match the GOV.UK template, and provide a less-jarring colour to browsers that make use of it.

#patch
