### PR TITLE
Use new reporting config structure

### DIFF
--- a/cypress/e2e/mi-reporting.cy.js
+++ b/cypress/e2e/mi-reporting.cy.js
@@ -1,5 +1,10 @@
 describe("MI Reporting", () => {
   beforeEach(() => {
+    cy.addMock("/lpa-api/reporting/config", "GET", {
+      status: 200,
+      body:{"reports":{"epasReceived":{"description":"Number of EPAs received"}}}
+    });
+
     cy.visit("/mi-reporting");
   });
 

--- a/cypress/mocks/migrated-from-pact.json
+++ b/cypress/mocks/migrated-from-pact.json
@@ -830,15 +830,6 @@
       }
     },
     {
-      "name": "A request for the MI config",
-      "request": { "method": "GET", "url": "/api/reporting/config" },
-      "response": {
-        "status": 200,
-        "headers": { "Content-Type": "application/json" },
-        "body": "{\"data\":{\"items\":[{\"properties\":{\"reportType\":{\"description\":\"radio\",\"enum\":[{\"description\":\"Number of EPAs received\",\"name\":\"epasReceived\"}],\"type\":\"reportType\"}}}]}}"
-      }
-    },
-    {
       "name": "A request for an MI report",
       "request": {
         "method": "GET",

--- a/internal/server/mi_reporting.go
+++ b/internal/server/mi_reporting.go
@@ -10,12 +10,12 @@ import (
 )
 
 type MiReportingClient interface {
-	MiConfig(sirius.Context) (map[string]sirius.MiConfigProperty, error)
+	MiConfig(sirius.Context) (sirius.MiConfig, error)
 	MiReport(sirius.Context, url.Values) (*sirius.MiReportResponse, error)
 }
 
 type miReportingData struct {
-	ReportTypes []sirius.MiConfigEnum
+	ReportTypes map[string]sirius.MiReportConfig
 	ReportType  string
 	ReportName  string
 	Controls    []namedControl
@@ -25,9 +25,11 @@ type miReportingData struct {
 }
 
 type namedControl struct {
-	Name       string
-	Label      string
-	Properties sirius.MiConfigProperty
+	Name    string
+	Label   string
+	Type    string
+	MaxDate string
+	Options []sirius.MiConfigEnum
 }
 
 var miLabels = map[string]string{
@@ -58,23 +60,30 @@ func MiReporting(client MiReportingClient, tmpl template.Template) Handler {
 				return err
 			}
 
-			data.ReportTypes = config["reportType"].Enum
+			data.ReportTypes = config.Reports
 			data.ReportType = r.FormValue("reportType")
 
 			if data.ReportType != "" {
-				for _, report := range data.ReportTypes {
-					if report.Name == data.ReportType {
+				for reportType, report := range data.ReportTypes {
+					if reportType == data.ReportType {
 						data.ReportName = report.Description
 						break
 					}
 				}
 
-				for name, properties := range config {
-					for _, reportType := range properties.DependsOn.ReportType {
-						if reportType.Name == data.ReportType {
-							data.Controls = append(data.Controls, namedControl{Name: name, Label: miLabels[name], Properties: properties})
-						}
+				for _, field := range config.Reports[data.ReportType].Fields {
+					properties, ok := config.Fields[field.Name]
+					if !ok {
+						continue
 					}
+
+					data.Controls = append(data.Controls, namedControl{
+						Name:    field.Name,
+						Label:   miLabels[field.Name],
+						Type:    properties.Type,
+						MaxDate: properties.MaxDate,
+						Options: properties.Options,
+					})
 				}
 
 				orderMap := map[string]int{}

--- a/internal/server/mi_reporting_test.go
+++ b/internal/server/mi_reporting_test.go
@@ -16,13 +16,13 @@ type mockMiReportingClient struct {
 	mock.Mock
 }
 
-func (m *mockMiReportingClient) MiConfig(ctx sirius.Context) (map[string]sirius.MiConfigProperty, error) {
+func (m *mockMiReportingClient) MiConfig(ctx sirius.Context) (sirius.MiConfig, error) {
 	args := m.Called(ctx)
 
-	if v, ok := args.Get(0).(map[string]sirius.MiConfigProperty); ok {
+	if v, ok := args.Get(0).(sirius.MiConfig); ok {
 		return v, args.Error(1)
 	}
-	return nil, args.Error(1)
+	return sirius.MiConfig{}, args.Error(1)
 }
 
 func (m *mockMiReportingClient) MiReport(ctx sirius.Context, form url.Values) (*sirius.MiReportResponse, error) {
@@ -34,18 +34,20 @@ func (m *mockMiReportingClient) MiReport(ctx sirius.Context, form url.Values) (*
 }
 
 func TestGetMiReporting(t *testing.T) {
-	reportTypes := []sirius.MiConfigEnum{
-		{Name: "epaReport", Description: "EPA Report"},
-		{Name: "lpaReport", Description: "LPA Report"},
+	reportTypes := map[string]sirius.MiReportConfig{
+		"epaReport": {
+			Description: "EPA Report",
+		},
+		"lpaReport": {
+			Description: "LPA Report",
+		},
 	}
 
 	client := &mockMiReportingClient{}
 	client.
 		On("MiConfig", mock.Anything).
-		Return(map[string]sirius.MiConfigProperty{
-			"reportType": {
-				Enum: reportTypes,
-			},
+		Return(sirius.MiConfig{
+			Reports: reportTypes,
 		}, nil)
 
 	template := &mockTemplate{}
@@ -67,29 +69,42 @@ func TestGetMiReporting(t *testing.T) {
 }
 
 func TestGetMiReportingWhenReportTypeSelected(t *testing.T) {
-	reportTypes := []sirius.MiConfigEnum{
-		{Name: "epaReport", Description: "EPA Report"},
-		{Name: "lpaReport", Description: "LPA Report"},
+	reportTypes := map[string]sirius.MiReportConfig{
+		"epaReport": {
+			Description: "EPA Report",
+		},
+		"lpaReport": {
+			Description: "LPA Report",
+			Fields: []struct {
+				Name     string `json:"name"`
+				Optional bool   `json:"optional"`
+			}{
+				{Name: "startDate"},
+				{Name: "endDate"},
+			},
+		},
 	}
 
-	dateControl := sirius.MiConfigProperty{
-		Description: "date",
-		DependsOn: sirius.MiConfigDependsOn{
-			ReportType: []sirius.MiConfigReportType{{Name: "lpaReport"}},
-		},
+	dateControl := sirius.MiConfigField{
+		Type:    "date",
+		MaxDate: "today",
 	}
 
 	client := &mockMiReportingClient{}
 	client.
 		On("MiConfig", mock.Anything).
-		Return(map[string]sirius.MiConfigProperty{
-			"reportType": {
-				Enum: reportTypes,
-			},
-			"endDate":   dateControl,
-			"startDate": dateControl,
-			"otherThing": {
-				Description: "date",
+		Return(sirius.MiConfig{
+			Reports: reportTypes,
+			Fields: map[string]sirius.MiConfigField{
+				"startDate": dateControl,
+				"endDate":   dateControl,
+				"applicationType": {
+					Type: "checkbox",
+					Options: []sirius.MiConfigEnum{
+						{Value: "HW", Label: "HW"},
+						{Value: "PFA", Label: "PFA"},
+					},
+				},
 			},
 		}, nil)
 
@@ -101,14 +116,18 @@ func TestGetMiReportingWhenReportTypeSelected(t *testing.T) {
 			ReportName:  "LPA Report",
 			Controls: []namedControl{
 				{
-					Name:       "startDate",
-					Label:      "From",
-					Properties: dateControl,
+					Name:    "startDate",
+					Label:   "From",
+					Type:    "date",
+					MaxDate: "today",
+					Options: nil,
 				},
 				{
-					Name:       "endDate",
-					Label:      "To",
-					Properties: dateControl,
+					Name:    "endDate",
+					Label:   "To",
+					Type:    "date",
+					MaxDate: "today",
+					Options: nil,
 				},
 			},
 		}).
@@ -141,18 +160,20 @@ func TestGetMiReportingWhenConfigErrors(t *testing.T) {
 }
 
 func TestGetMiReportingWhenTemplateErrors(t *testing.T) {
-	reportTypes := []sirius.MiConfigEnum{
-		{Name: "epaReport", Description: "EPA Report"},
-		{Name: "lpaReport", Description: "LPA Report"},
+	reportTypes := map[string]sirius.MiReportConfig{
+		"epaReport": {
+			Description: "EPA Report",
+		},
+		"lpaReport": {
+			Description: "LPA Report",
+		},
 	}
 
 	client := &mockMiReportingClient{}
 	client.
 		On("MiConfig", mock.Anything).
-		Return(map[string]sirius.MiConfigProperty{
-			"reportType": {
-				Enum: reportTypes,
-			},
+		Return(sirius.MiConfig{
+			Reports: reportTypes,
 		}, nil)
 
 	template := &mockTemplate{}

--- a/internal/sirius/mi_config.go
+++ b/internal/sirius/mi_config.go
@@ -1,79 +1,36 @@
 package sirius
 
-import (
-	"encoding/json"
-	"fmt"
-)
-
-type miConfig struct {
-	Data struct {
-		Items []struct {
-			Properties map[string]MiConfigProperty `json:"properties"`
-		} `json:"items"`
-	} `json:"data"`
+type MiReportConfig struct {
+	Class       string `json:"class"`
+	Description string `json:"description"`
+	Fields      []struct {
+		Name     string `json:"name"`
+		Optional bool   `json:"optional"`
+	} `json:"fields"`
 }
 
-type MiConfigProperty struct {
-	Description   string            `json:"description"`
-	Type          string            `json:"type"`
-	Required      bool              `json:"required"`
-	Enum          []MiConfigEnum    `json:"enum"`
-	DependsOn     MiConfigDependsOn `json:"dependsOn"`
-	Format        string            `json:"format"`
-	FormatMaximum string            `json:"formatMaximum"`
-}
-
-type MiConfigDependsOn struct {
-	ReportType []MiConfigReportType `json:"reportType"`
-}
-
-type MiConfigReportType struct {
-	Name string `json:"name"`
+type MiConfigField struct {
+	Type    string         `json:"type"`
+	MaxDate string         `json:"maxDate"`
+	Options []MiConfigEnum `json:"options"`
 }
 
 type MiConfigEnum struct {
-	Name        string
-	Description string
+	Value string `json:"value"`
+	Label string `json:"label"`
 }
 
-type rawMiConfigEnum struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Value       string `json:"value"`
-	Label       string `json:"label"`
+type MiConfig struct {
+	Reports map[string]MiReportConfig `json:"reports"`
+
+	Fields map[string]MiConfigField `json:"fields"`
 }
 
-func (e *MiConfigEnum) UnmarshalJSON(text []byte) error {
-	var v rawMiConfigEnum
-	if err := json.Unmarshal(text, &v); err == nil {
-		if v.Name != "" {
-			e.Name = v.Name
-			e.Description = v.Description
-		}
-		if v.Value != "" {
-			e.Name = v.Value
-			e.Description = v.Label
-		}
-	}
-
-	var s string
-	if err := json.Unmarshal(text, &s); err == nil {
-		e.Name = s
-		e.Description = s
-	}
-
-	if e.Name == "" {
-		return fmt.Errorf("could not unmarshal '%s' to MiConfigEnum", text)
-	}
-
-	return nil
-}
-
-func (c *Client) MiConfig(ctx Context) (map[string]MiConfigProperty, error) {
-	var v miConfig
+func (c *Client) MiConfig(ctx Context) (MiConfig, error) {
+	var v MiConfig
 	if err := c.get(ctx, "/api/reporting/config", &v); err != nil {
-		return nil, err
+		return MiConfig{}, err
 	}
 
-	return v.Data.Items[0].Properties, nil
+	return v, nil
 }

--- a/internal/sirius/mi_config_test.go
+++ b/internal/sirius/mi_config_test.go
@@ -3,10 +3,11 @@ package sirius
 import (
 	"context"
 	"fmt"
-	"github.com/pact-foundation/pact-go/v2/consumer"
-	"github.com/pact-foundation/pact-go/v2/matchers"
 	"net/http"
 	"testing"
+
+	"github.com/pact-foundation/pact-go/v2/consumer"
+	"github.com/pact-foundation/pact-go/v2/matchers"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -20,7 +21,7 @@ func TestMiConfig(t *testing.T) {
 	testCases := []struct {
 		name           string
 		setup          func()
-		expectedResult map[string]MiConfigProperty
+		expectedResult MiConfig
 		expectedError  func(int) error
 	}{
 		{
@@ -38,30 +39,49 @@ func TestMiConfig(t *testing.T) {
 						Status:  http.StatusOK,
 						Headers: matchers.MapMatcher{"Content-Type": matchers.String("application/json")},
 						Body: matchers.Like(map[string]interface{}{
-							"data": matchers.Like(map[string]interface{}{
-								"items": matchers.EachLike(map[string]interface{}{
-									"properties": matchers.Like(map[string]interface{}{
-										"reportType": matchers.Like(map[string]interface{}{
-											"description": matchers.String("radio"),
-											"type":        matchers.String("reportType"),
-											"enum": matchers.EachLike(map[string]interface{}{
-												"name":        matchers.String("epasReceived"),
-												"description": matchers.String("Number of EPAs received"),
-											}, 1),
-										}),
-									}),
-								}, 1),
+							"reports": matchers.Like(map[string]interface{}{
+								"epasReceived": matchers.Like(map[string]interface{}{
+									"class":       matchers.String("EPAReceived"),
+									"description": matchers.String("Number of EPAs received"),
+									"fields": matchers.EachLike(map[string]interface{}{
+										"name": matchers.String("startDate"),
+									}, 1),
+								}),
+							}),
+							"fields": matchers.Like(map[string]interface{}{
+								"startDate": matchers.Like(map[string]interface{}{
+									"type":    matchers.String("date"),
+									"maxDate": matchers.String("today"),
+								}),
+								"applicationType": matchers.Like(map[string]interface{}{
+									"type": matchers.String("checkbox"),
+									"options": matchers.EachLike(map[string]interface{}{
+										"value": matchers.String("HW"),
+										"label": matchers.String("HW"),
+									}, 1),
+								}),
 							}),
 						}),
 					})
 			},
-			expectedResult: map[string]MiConfigProperty{
-				"reportType": {
-					Description: "radio",
-					Type:        "reportType",
-					Enum: []MiConfigEnum{
-						{Name: "epasReceived", Description: "Number of EPAs received"},
+			expectedResult: MiConfig{
+				Reports: map[string]MiReportConfig{
+					"epasReceived": {
+						Class:       "EPAReceived",
+						Description: "Number of EPAs received",
+						Fields: []struct {
+							Name     string `json:"name"`
+							Optional bool   `json:"optional"`
+						}{
+							{Name: "startDate", Optional: false},
+						},
 					},
+				},
+				Fields: map[string]MiConfigField{
+					"startDate": {Type: "date", MaxDate: "today"},
+					"applicationType": {Type: "checkbox", Options: []MiConfigEnum{
+						{Value: "HW", Label: "HW"},
+					}},
 				},
 			},
 		},

--- a/internal/templatefn/fn.go
+++ b/internal/templatefn/fn.go
@@ -565,10 +565,18 @@ func options(list interface{}, attrs ...interface{}) []optionData {
 			datas[i] = optionData{Value: item, Label: item}
 		}
 
+	case map[string]sirius.MiReportConfig:
+		datas = make([]optionData, len(v))
+		i := 0
+		for reportId, item := range v {
+			datas[i] = optionData{Value: reportId, Label: item.Description}
+			i++
+		}
+
 	case []sirius.MiConfigEnum:
 		datas = make([]optionData, len(v))
 		for i, item := range v {
-			datas[i] = optionData{Value: item.Name, Label: item.Description}
+			datas[i] = optionData{Value: item.Value, Label: item.Label}
 		}
 
 	case []sirius.RefDataItem:

--- a/internal/templatefn/fn_test.go
+++ b/internal/templatefn/fn_test.go
@@ -396,8 +396,8 @@ func TestOptionsStringSlice(t *testing.T) {
 
 func TestOptionsMiConfigEnumSlice(t *testing.T) {
 	input := []sirius.MiConfigEnum{
-		{Name: "opt1", Description: "Option 1"},
-		{Name: "opt2", Description: "Option 2"},
+		{Value: "opt1", Label: "Option 1"},
+		{Value: "opt2", Label: "Option 2"},
 	}
 	expected := []optionData{
 		{Value: "opt1", Label: "Option 1"},

--- a/web/template/mi_reporting.gohtml
+++ b/web/template/mi_reporting.gohtml
@@ -35,24 +35,24 @@
           <input type="hidden" name="reportType" value="{{ .ReportType }}" />
 
           {{ range .Controls }}
-            {{ if eq .Properties.Format "date" }}
+            {{ if eq .Type "date" }}
               <div class="govuk-form-group">
                 <label class="govuk-label" for="f-{{ .Name }}">{{ .Label }}</label>
-                <input class="govuk-input govuk-!-width-one-third" type="date" id="f-{{ .Name }}" name="{{ .Name }}" {{ if eq .Properties.FormatMaximum "today" }}max="{{ today }}"{{ end }} />
+                <input class="govuk-input govuk-!-width-one-third" type="date" id="f-{{ .Name }}" name="{{ .Name }}" {{ if eq .MaxDate "today" }}max="{{ today }}"{{ end }} />
               </div>
             {{ end }}
 
-            {{ if eq .Properties.Description "checkbox" }}
+            {{ if eq .Type "checkbox" }}
               <div class="govuk-form-group">
                 <fieldset class="govuk-fieldset">
                   <legend class="govuk-fieldset__legend">{{ .Label }}</legend>
                   <div class="govuk-checkboxes" data-module="govuk-checkboxes">
                     {{ $name := .Name }}
-                    {{ range $i, $e := .Properties.Enum }}
+                    {{ range $i, $e := .Options }}
                       <div class="govuk-checkboxes__item">
-                        <input class="govuk-checkboxes__input" id="{{ $name }}-{{ $i }}" name="{{ $name }}" type="checkbox" value="{{ $e.Name }}">
+                        <input class="govuk-checkboxes__input" id="{{ $name }}-{{ $i }}" name="{{ $name }}" type="checkbox" value="{{ $e.Value }}">
                         <label class="govuk-label govuk-checkboxes__label" for="{{ $name }}-{{ $i }}">
-                          {{ $e.Description }}
+                          {{ $e.Label }}
                         </label>
                       </div>
                     {{ end }}


### PR DESCRIPTION
The config endpoint returns a simpler interface now: update the sirius wrapper to destructure it, and update the mi_reporting handler/template to use the new structure

For CTC-301 #patch
