### PR TITLE
VEGA-3959 : service to get bank-holidays

### DIFF
--- a/internal/sirius/bank_holidays.go
+++ b/internal/sirius/bank_holidays.go
@@ -1,0 +1,17 @@
+package sirius
+
+type BankHolidays map[string]map[string]string
+
+func (c *Client) BankHolidays(ctx Context) (BankHolidays, error) {
+	var b BankHolidays
+
+	if cached, ok := getCached("bank-holidays"); ok {
+		return cached.(BankHolidays), nil
+	}
+
+	err := c.get(ctx, "/lpa-api/v1/dates/bank-holidays", &b)
+
+	setCached("bank-holidays", b)
+
+	return b, err
+}

--- a/internal/sirius/bank_holidays_test.go
+++ b/internal/sirius/bank_holidays_test.go
@@ -1,0 +1,58 @@
+package sirius
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/pact-foundation/pact-go/v2/consumer"
+	"github.com/pact-foundation/pact-go/v2/matchers"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBankHolidays(t *testing.T) {
+	t.Parallel()
+
+	pact, err := newPact()
+	assert.NoError(t, err)
+
+	pact.
+		AddInteraction().
+		Given("").
+		UponReceiving("A request to get bank holidays").
+		WithCompleteRequest(consumer.Request{
+			Method: http.MethodGet,
+			Path:   matchers.String("/lpa-api/v1/dates/bank-holidays"),
+		}).
+		WithCompleteResponse(consumer.Response{
+			Status:  http.StatusOK,
+			Headers: matchers.MapMatcher{"Content-Type": matchers.String("application/json")},
+			Body: matchers.Like(map[string]interface{}{
+				"2025": map[string]interface{}{
+					"New Year": matchers.String("2025-01-01T00:00:00+00:00"),
+				},
+			}),
+		})
+
+	expectedResponse := BankHolidays{
+		"2025": {
+			"New Year": "2025-01-01T00:00:00+00:00",
+		},
+	}
+
+	t.Run("Get bank holidays", func(t *testing.T) {
+		assert.Nil(t, pact.ExecuteTest(t, func(config consumer.MockServerConfig) error {
+			client := NewClient(http.DefaultClient, fmt.Sprintf("http://127.0.0.1:%d", config.Port))
+
+			bankHolidays, err := client.BankHolidays(Context{Context: context.Background()})
+
+			assert.Equal(t, expectedResponse, bankHolidays)
+			assert.Nil(t, err)
+
+			return nil
+		}))
+	})
+
+}

--- a/internal/sirius/cache.go
+++ b/internal/sirius/cache.go
@@ -7,22 +7,22 @@ import (
 
 type cacheItem struct {
 	time  time.Time
-	value []RefDataItem
+	value interface{}
 }
 
 var mutex = &sync.RWMutex{}
 
 var cache map[string]cacheItem
 
-func getCached(category string) ([]RefDataItem, bool) {
-	var v []RefDataItem
+func getCached(category string) (interface{}, bool) {
+	var v interface{}
 	found := false
 
 	oneHourAgo := time.Now().Add(-1 * time.Hour)
 
 	mutex.RLock()
 
-	if cache[category].time.After(oneHourAgo) && len(cache[category].value) > 0 {
+	if cache[category].time.After(oneHourAgo) && cache[category].value != nil {
 		v = cache[category].value
 		found = true
 	}
@@ -32,7 +32,7 @@ func getCached(category string) ([]RefDataItem, bool) {
 	return v, found
 }
 
-func setCached(category string, value []RefDataItem) {
+func setCached(category string, value interface{}) {
 	if cache == nil {
 		cache = map[string]cacheItem{}
 	}

--- a/internal/sirius/cache_test.go
+++ b/internal/sirius/cache_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func getCountries() []RefDataItem {
-	return []RefDataItem{
-		{
-			Handle: "UK",
-			Label:  "United Kingdom",
+func getCountries() interface{} {
+	return []interface{}{
+		map[string]string{
+			"Handle": "UK",
+			"Label":  "United Kingdom",
 		},
 	}
 }
@@ -18,7 +18,7 @@ func getCountries() []RefDataItem {
 func TestCacheWhenEmpty(t *testing.T) {
 	val, ok := getCached("not set")
 
-	assert.Len(t, val, 0)
+	assert.Nil(t, val)
 	assert.Equal(t, ok, false)
 }
 
@@ -34,6 +34,6 @@ func TestCacheWhenMiss(t *testing.T) {
 	setCached("countries", getCountries())
 	val, ok := getCached("cities")
 
-	assert.Len(t, val, 0)
+	assert.Nil(t, val)
 	assert.Equal(t, ok, false)
 }

--- a/internal/sirius/ref_data.go
+++ b/internal/sirius/ref_data.go
@@ -34,7 +34,7 @@ func (c *Client) RefDataByCategory(ctx Context, category string) ([]RefDataItem,
 	var v []RefDataItem
 
 	if cached, ok := getCached(category); ok {
-		return cached, nil
+		return cached.([]RefDataItem), nil
 	}
 
 	err := c.get(ctx, fmt.Sprintf("/lpa-api/v1/reference-data/%s", category), &v)


### PR DESCRIPTION
fixes: [VEGA-3959](https://opgtransform.atlassian.net/browse/VEGA-3959)

updated the existing cache implementation to be more general so can be used for bank-holidays as well as ref-data.

[VEGA-3959]: https://opgtransform.atlassian.net/browse/VEGA-3959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ