### PR TITLE
VEGA-3974 Back Button

### DIFF
--- a/cypress/e2e/create-attorney.cy.js
+++ b/cypress/e2e/create-attorney.cy.js
@@ -58,6 +58,16 @@ describe("Create or Update Attorney", () => {
     cy.url().should("include", "create-attorney");
   });
 
+  it("has a back link to the EPA form", () => {
+    cy.get(".govuk-back-link")
+      .should("exist")
+      .and("have.attr", "href")
+      .and(
+        "include",
+        "/create-epa?id=1&caseId=2#accordion-create-epa-heading-3",
+      );
+  });
+
   it("updates an existing attorney on an EPA", () => {
     cy.addMock("/lpa-api/v1/epas/2", "PUT", {
       status: 200,

--- a/cypress/e2e/create-correspondent.cy.js
+++ b/cypress/e2e/create-correspondent.cy.js
@@ -42,6 +42,22 @@ describe("Create or update correspondent", () => {
     cy.url().should("include", "/create-epa");
   });
 
+  it("has a back link to the EPA form", () => {
+    cy.addMock("/lpa-api/v1/cases/2", "GET", {
+      status: 200,
+      body: { id: 2 },
+    });
+
+    cy.visit("/create-correspondent?id=1&caseId=2");
+    cy.get(".govuk-back-link")
+      .should("exist")
+      .and("have.attr", "href")
+      .and(
+        "include",
+        "/create-epa?id=1&caseId=2#accordion-create-epa-heading-3",
+      );
+  });
+
   it("updates a correspondent on an EPA", () => {
     cy.addMock("/lpa-api/v1/epas/2", "PUT", {
       status: 200,

--- a/web/template/create-attorney.gohtml
+++ b/web/template/create-attorney.gohtml
@@ -7,6 +7,8 @@
     <div class="govuk-grid-column-two-thirds">
       {{ template "error-summary" .Error }}
 
+      <a href="{{ prefix (printf "/create-epa?id=%d&caseId=%d#accordion-create-epa-heading-3" .DonorId .CaseId) }}" class="govuk-back-link">Back</a>
+
       <h1 class="govuk-heading-l">{{ .Title }}</h1>
 
       <form class="form" method="POST">

--- a/web/template/create-correspondent.gohtml
+++ b/web/template/create-correspondent.gohtml
@@ -5,7 +5,9 @@
 {{ define "main" }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        {{ template "error-summary" .Error }}
+      {{ template "error-summary" .Error }}
+
+      <a href="{{ prefix (printf "/create-epa?id=%d&caseId=%d#accordion-create-epa-heading-3" .DonorId .CaseId) }}" class="govuk-back-link">Back</a>
 
       <h1 class="govuk-heading-l">{{ .Title }}</h1>
 


### PR DESCRIPTION
VEGA-3974

Adds a GOV.UK styled back link to the top of the add/update attorney and correspondent forms, allowing users to return to the EPA create/edit page without saving changes.

- Added `govuk-back-link` anchor above the `<h1>` in `create-attorney.gohtml` and `create-correspondent.gohtml`
- Link navigates the iframe directly to the EPA form URL, preserving the widget state
- Includes anchor to scroll to the Step 3: Actors accordion section on return
- Added Cypress assertions to both test files to verify the back link exists with the correct href