### PR TITLE
Vega 3958 working days calculator

### DIFF
--- a/cypress/e2e/sirius-header-calendars.cy.js
+++ b/cypress/e2e/sirius-header-calendars.cy.js
@@ -86,19 +86,19 @@ describe("Calendars on the header bar", () => {
     cy.get("#calc-startdate").should("not.have.attr", "readonly");
     cy.get("#calc-numworkingdays").should("not.have.attr", "readonly");
 
-    cy.get("#mode-startdate").check({ force: true });
+    cy.get("#mode-startdate").click();
     cy.get("#mode-startdate").should("be.checked");
     cy.get("#calc-startdate").should("have.attr", "readonly");
     cy.get("#calc-enddate").should("not.have.attr", "readonly");
     cy.get("#calc-numworkingdays").should("not.have.attr", "readonly");
 
-    cy.get("#mode-numworkingdays").check({ force: true });
+    cy.get("#mode-numworkingdays").click();
     cy.get("#mode-numworkingdays").should("be.checked");
     cy.get("#calc-numworkingdays").should("have.attr", "readonly");
     cy.get("#calc-startdate").should("not.have.attr", "readonly");
     cy.get("#calc-enddate").should("not.have.attr", "readonly");
 
-    cy.get("#mode-enddate").check({ force: true });
+    cy.get("#mode-enddate").click();
     cy.get("#mode-enddate").should("be.checked");
     cy.get("#calc-enddate").should("have.attr", "readonly");
     cy.get("#calc-startdate").should("not.have.attr", "readonly");

--- a/cypress/e2e/sirius-header-calendars.cy.js
+++ b/cypress/e2e/sirius-header-calendars.cy.js
@@ -74,7 +74,7 @@ describe("Calendars on the header bar", () => {
     );
   });
 
-  it("shows the working-days calculator and updates disabled fields by mode", () => {
+  it("shows the working-days calculator and updates readonly fields by mode", () => {
     cy.visit("/donor/1/documents");
     cy.get("#header-button-calendars").click();
 
@@ -82,26 +82,26 @@ describe("Calendars on the header bar", () => {
     cy.contains("h3", "Difference Calculator").should("be.visible");
 
     cy.get("#mode-enddate").should("be.checked");
-    cy.get("#calc-enddate").should("be.disabled");
-    cy.get("#calc-startdate").should("not.be.disabled");
-    cy.get("#calc-numworkingdays").should("not.be.disabled");
+    cy.get("#calc-enddate").should("have.attr", "readonly");
+    cy.get("#calc-startdate").should("not.have.attr", "readonly");
+    cy.get("#calc-numworkingdays").should("not.have.attr", "readonly");
 
     cy.get("#mode-startdate").check({ force: true });
     cy.get("#mode-startdate").should("be.checked");
-    cy.get("#calc-startdate").should("be.disabled");
-    cy.get("#calc-enddate").should("not.be.disabled");
-    cy.get("#calc-numworkingdays").should("not.be.disabled");
+    cy.get("#calc-startdate").should("have.attr", "readonly");
+    cy.get("#calc-enddate").should("not.have.attr", "readonly");
+    cy.get("#calc-numworkingdays").should("not.have.attr", "readonly");
 
     cy.get("#mode-numworkingdays").check({ force: true });
     cy.get("#mode-numworkingdays").should("be.checked");
-    cy.get("#calc-numworkingdays").should("be.disabled");
-    cy.get("#calc-startdate").should("not.be.disabled");
-    cy.get("#calc-enddate").should("not.be.disabled");
+    cy.get("#calc-numworkingdays").should("have.attr", "readonly");
+    cy.get("#calc-startdate").should("not.have.attr", "readonly");
+    cy.get("#calc-enddate").should("not.have.attr", "readonly");
 
     cy.get("#mode-enddate").check({ force: true });
     cy.get("#mode-enddate").should("be.checked");
-    cy.get("#calc-enddate").should("be.disabled");
-    cy.get("#calc-startdate").should("not.be.disabled");
-    cy.get("#calc-numworkingdays").should("not.be.disabled");
+    cy.get("#calc-enddate").should("have.attr", "readonly");
+    cy.get("#calc-startdate").should("not.have.attr", "readonly");
+    cy.get("#calc-numworkingdays").should("not.have.attr", "readonly");
   });
 });

--- a/cypress/e2e/sirius-header-calendars.cy.js
+++ b/cypress/e2e/sirius-header-calendars.cy.js
@@ -73,4 +73,35 @@ describe("Calendars on the header bar", () => {
       "February 2025",
     );
   });
+
+  it("shows the working-days calculator and updates disabled fields by mode", () => {
+    cy.visit("/donor/1/documents");
+    cy.get("#header-button-calendars").click();
+
+    cy.get(".panel-calendar").should("be.visible");
+    cy.contains("h3", "Difference Calculator").should("be.visible");
+
+    cy.get("#mode-enddate").should("be.checked");
+    cy.get("#calc-enddate").should("be.disabled");
+    cy.get("#calc-startdate").should("not.be.disabled");
+    cy.get("#calc-numworkingdays").should("not.be.disabled");
+
+    cy.get("#mode-startdate").check({ force: true });
+    cy.get("#mode-startdate").should("be.checked");
+    cy.get("#calc-startdate").should("be.disabled");
+    cy.get("#calc-enddate").should("not.be.disabled");
+    cy.get("#calc-numworkingdays").should("not.be.disabled");
+
+    cy.get("#mode-numworkingdays").check({ force: true });
+    cy.get("#mode-numworkingdays").should("be.checked");
+    cy.get("#calc-numworkingdays").should("be.disabled");
+    cy.get("#calc-startdate").should("not.be.disabled");
+    cy.get("#calc-enddate").should("not.be.disabled");
+
+    cy.get("#mode-enddate").check({ force: true });
+    cy.get("#mode-enddate").should("be.checked");
+    cy.get("#calc-enddate").should("be.disabled");
+    cy.get("#calc-startdate").should("not.be.disabled");
+    cy.get("#calc-numworkingdays").should("not.be.disabled");
+  });
 });

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -202,6 +202,7 @@ func New(logger *slog.Logger, client Client, templates template.Templates, prefi
 	mux.Handle("/sirius-header-people-info", wrap(SiriusHeaderPeopleInfo(client, templates.Get("sirius-header-partial-people-info.gohtml"))))
 	mux.Handle("/unlink-person", wrap(UnlinkPerson(client, templates.Get("unlink_person.gohtml"))))
 	mux.Handle("/view-document/{uuid}", wrap(ViewDocument(client, templates.Get("view-document.gohtml"))))
+	mux.Handle("/working-days", wrap(WorkingDays(client, templates.Get("working-days-partial.gohtml"))))
 
 	static := http.FileServer(http.Dir("web/static"))
 	mux.Handle("/assets/{path...}", static)

--- a/internal/server/sirius_header_calendars.go
+++ b/internal/server/sirius_header_calendars.go
@@ -3,6 +3,9 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/ministryofjustice/opg-go-common/template"
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
@@ -12,11 +15,54 @@ type SiriusHeaderCalendarClient interface {
 	BankHolidays(ctx sirius.Context) (sirius.BankHolidays, error)
 }
 
+type WorkingDaysMode string
+
+const (
+	WorkingDaysModeNumWorkingDays WorkingDaysMode = "numworkingdays"
+	WorkingDaysModeStartDate      WorkingDaysMode = "startdate"
+	WorkingDaysModeEndDate        WorkingDaysMode = "enddate"
+)
+
+func parseWorkingDaysMode(value string) WorkingDaysMode {
+	switch WorkingDaysMode(strings.ToLower(value)) {
+	case WorkingDaysModeNumWorkingDays, WorkingDaysModeStartDate, WorkingDaysModeEndDate:
+		return WorkingDaysMode(strings.ToLower(value))
+	default:
+		return WorkingDaysModeNumWorkingDays
+	}
+}
+
+func (WorkingDaysData) ModeStartDate() WorkingDaysMode {
+	return WorkingDaysModeStartDate
+}
+
+func (WorkingDaysData) ModeEndDate() WorkingDaysMode {
+	return WorkingDaysModeEndDate
+}
+
+func (WorkingDaysData) ModeNumWorkingDays() WorkingDaysMode {
+	return WorkingDaysModeNumWorkingDays
+}
+
+type WorkingDaysData struct {
+	XSRFToken      string
+	StartDate      string
+	EndDate        string
+	NumWorkingDays int
+	Mode           WorkingDaysMode
+}
+
 type siriusHeaderCalendarData struct {
+	XSRFToken        string
 	BankHolidaysJSON string
+	Calculator       WorkingDaysData
 }
 
 func SiriusHeaderCalendars(client SiriusHeaderCalendarClient, tmpl template.Template) Handler {
+	return siriusHeaderCalendarsWithNow(client, tmpl, time.Now)
+}
+
+func siriusHeaderCalendarsWithNow(client SiriusHeaderCalendarClient, tmpl template.Template, now func() time.Time) Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		ctx := getContext(r)
 
@@ -30,10 +76,123 @@ func SiriusHeaderCalendars(client SiriusHeaderCalendarClient, tmpl template.Temp
 			bankHolidaysJSON = []byte("{}")
 		}
 
+		today := now().UTC().Truncate(24 * time.Hour)
+
+		calculator := calculateWorkingDays(today, time.Time{}, 20, WorkingDaysModeEndDate, bankHolidays)
+		calculator.XSRFToken = ctx.XSRFToken
+
 		data := siriusHeaderCalendarData{
+			XSRFToken:        ctx.XSRFToken,
 			BankHolidaysJSON: string(bankHolidaysJSON),
+			Calculator:       calculator,
 		}
 
 		return tmpl(w, data)
 	}
+}
+
+func WorkingDays(client SiriusHeaderCalendarClient, tmpl template.Template) Handler {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		if err := r.ParseForm(); err != nil {
+			return err
+		}
+
+		ctx := getContext(r)
+
+		numWorkingDays, _ := strconv.Atoi(r.FormValue("numworkingdays"))
+		startDate, _ := time.Parse(time.DateOnly, r.FormValue("startdate"))
+		endDate, _ := time.Parse(time.DateOnly, r.FormValue("enddate"))
+		mode := parseWorkingDaysMode(r.FormValue("mode"))
+
+		bankHolidays, err := client.BankHolidays(ctx)
+		if err != nil {
+			bankHolidays = sirius.BankHolidays{}
+		}
+
+		data := calculateWorkingDays(startDate, endDate, numWorkingDays, mode, bankHolidays)
+
+		data.XSRFToken = ctx.XSRFToken
+
+		return tmpl(w, data)
+	}
+}
+
+func isWorkingDay(day time.Time, bankHolidaySet map[time.Time]bool) bool {
+	weekendDays := map[time.Weekday]bool{
+		time.Saturday: true,
+		time.Sunday:   true,
+	}
+	if weekendDays[day.Weekday()] {
+		return false
+	}
+	return !bankHolidaySet[day]
+}
+
+func calculateWorkingDays(startDate time.Time, endDate time.Time, numWorkingDays int, mode WorkingDaysMode, bankHolidays sirius.BankHolidays) WorkingDaysData {
+	bankHolidaySet := make(map[time.Time]bool)
+	for _, years := range bankHolidays {
+		for _, date := range years {
+			parsedDate, err := time.Parse(time.RFC3339, date)
+			if err == nil {
+				y, m, d := parsedDate.In(time.UTC).Date()
+				bankHolidaySet[time.Date(y, m, d, 0, 0, 0, 0, time.UTC)] = true
+			}
+		}
+	}
+
+	output := WorkingDaysData{
+		StartDate:      startDate.Format(time.DateOnly),
+		EndDate:        endDate.Format(time.DateOnly),
+		NumWorkingDays: numWorkingDays,
+		Mode:           mode,
+	}
+
+	switch mode {
+	case WorkingDaysModeNumWorkingDays:
+		if !startDate.Before(endDate) {
+			output.StartDate = endDate.AddDate(0, 0, -1).Format(time.DateOnly)
+			output.NumWorkingDays = 1
+			break
+		}
+		workingDaysCount, d := 0, startDate
+		for d.Before(endDate) {
+			if isWorkingDay(d, bankHolidaySet) {
+				workingDaysCount++
+			}
+			d = d.AddDate(0, 0, 1)
+		}
+		output.NumWorkingDays = workingDaysCount
+
+	case WorkingDaysModeStartDate:
+		if numWorkingDays < 0 {
+			output.StartDate = endDate.Format(time.DateOnly)
+			output.NumWorkingDays = 0
+			break
+		}
+		remaining, d := numWorkingDays, endDate
+		for remaining > 0 {
+			d = d.AddDate(0, 0, -1)
+			if isWorkingDay(d, bankHolidaySet) {
+				remaining--
+			}
+		}
+		output.StartDate = d.Format(time.DateOnly)
+
+	case WorkingDaysModeEndDate:
+		if numWorkingDays < 0 {
+			output.EndDate = startDate.Format(time.DateOnly)
+			output.NumWorkingDays = 0
+			break
+		}
+		remaining, d := numWorkingDays, startDate
+		for remaining > 0 {
+			d = d.AddDate(0, 0, 1)
+			if isWorkingDay(d, bankHolidaySet) {
+				remaining--
+			}
+		}
+		output.EndDate = d.Format(time.DateOnly)
+	}
+
+	return output
 }

--- a/internal/server/sirius_header_calendars.go
+++ b/internal/server/sirius_header_calendars.go
@@ -194,6 +194,9 @@ func calculateWorkingDays(startDate time.Time, endDate time.Time, numWorkingDays
 			}
 		}
 		output.EndDate = d.Format(time.DateOnly)
+
+	default:
+
 	}
 
 	return output

--- a/internal/server/sirius_header_calendars.go
+++ b/internal/server/sirius_header_calendars.go
@@ -50,6 +50,7 @@ type WorkingDaysData struct {
 	EndDate        string
 	NumWorkingDays int
 	Mode           WorkingDaysMode
+	PreviousMode   WorkingDaysMode
 }
 
 type siriusHeaderCalendarData struct {
@@ -103,6 +104,7 @@ func WorkingDays(client SiriusHeaderCalendarClient, tmpl template.Template) Hand
 		startDate, _ := time.Parse(time.DateOnly, r.FormValue("startdate"))
 		endDate, _ := time.Parse(time.DateOnly, r.FormValue("enddate"))
 		mode := parseWorkingDaysMode(r.FormValue("mode"))
+		previousMode := parseWorkingDaysMode(r.FormValue("previousmode"))
 
 		bankHolidays, err := client.BankHolidays(ctx)
 		if err != nil {
@@ -110,7 +112,7 @@ func WorkingDays(client SiriusHeaderCalendarClient, tmpl template.Template) Hand
 		}
 
 		data := calculateWorkingDays(startDate, endDate, numWorkingDays, mode, bankHolidays)
-
+		data.PreviousMode = previousMode
 		data.XSRFToken = ctx.XSRFToken
 
 		return tmpl(w, data)

--- a/internal/server/sirius_header_calendars_test.go
+++ b/internal/server/sirius_header_calendars_test.go
@@ -150,6 +150,7 @@ func TestWorkingDays(t *testing.T) {
 		WorkingDaysModeEndDate,
 		bankHolidays,
 	)
+	expectedCalculator.PreviousMode = WorkingDaysModeStartDate
 
 	client := &mockSiriusCalendarsClient{}
 	client.
@@ -161,6 +162,7 @@ func TestWorkingDays(t *testing.T) {
 		"enddate":        {""},
 		"numworkingdays": {"20"},
 		"mode":           {"enddate"},
+		"previousmode":   {"startdate"},
 	}
 
 	template := &mockTemplate{}

--- a/internal/server/sirius_header_calendars_test.go
+++ b/internal/server/sirius_header_calendars_test.go
@@ -3,7 +3,10 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
 	"github.com/stretchr/testify/assert"
@@ -20,11 +23,22 @@ func (m *mockSiriusCalendarsClient) BankHolidays(ctx sirius.Context) (sirius.Ban
 }
 
 func TestGetSiriusCalendars(t *testing.T) {
+	fixedNow := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	now := func() time.Time { return fixedNow }
+
 	bankHolidays := sirius.BankHolidays{
 		"2025": {
 			"New Year": "2025-01-01T00:00:00+00:00",
 		},
 	}
+
+	expectedCalculator := calculateWorkingDays(
+		fixedNow.UTC().Truncate(24*time.Hour),
+		time.Time{},
+		20,
+		WorkingDaysModeEndDate,
+		bankHolidays,
+	)
 
 	client := &mockSiriusCalendarsClient{}
 	client.
@@ -35,13 +49,14 @@ func TestGetSiriusCalendars(t *testing.T) {
 	template.
 		On("Func", mock.Anything, siriusHeaderCalendarData{
 			BankHolidaysJSON: `{"2025":{"New Year":"2025-01-01T00:00:00+00:00"}}`,
+			Calculator:       expectedCalculator,
 		}).
 		Return(nil)
 
 	r, _ := http.NewRequest(http.MethodGet, "/lpa-api/v1/dates/bank-holidays", nil)
 	w := httptest.NewRecorder()
 
-	err := SiriusHeaderCalendars(client, template.Func)(w, r)
+	err := siriusHeaderCalendarsWithNow(client, template.Func, now)(w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
@@ -50,6 +65,17 @@ func TestGetSiriusCalendars(t *testing.T) {
 }
 
 func TestGetSiriusCalendarsWhenBankHolidaysErrors(t *testing.T) {
+	fixedNow := time.Date(2026, 6, 26, 0, 0, 0, 0, time.UTC)
+	now := func() time.Time { return fixedNow }
+
+	expectedCalculator := calculateWorkingDays(
+		fixedNow.UTC().Truncate(24*time.Hour),
+		time.Time{},
+		20,
+		WorkingDaysModeEndDate,
+		sirius.BankHolidays{},
+	)
+
 	client := &mockSiriusCalendarsClient{}
 	client.
 		On("BankHolidays", mock.Anything).
@@ -59,20 +85,32 @@ func TestGetSiriusCalendarsWhenBankHolidaysErrors(t *testing.T) {
 	template.
 		On("Func", mock.Anything, siriusHeaderCalendarData{
 			BankHolidaysJSON: `{}`,
+			Calculator:       expectedCalculator,
 		}).
 		Return(nil)
 
 	r, _ := http.NewRequest(http.MethodGet, "/lpa-api/v1/dates/bank-holidays", nil)
 	w := httptest.NewRecorder()
 
-	err := SiriusHeaderCalendars(client, template.Func)(w, r)
+	err := siriusHeaderCalendarsWithNow(client, template.Func, now)(w, r)
 
 	assert.Nil(t, err)
 	mock.AssertExpectationsForObjects(t, client, template)
 }
 
 func TestGetSiriusCalendarsWithEmptyBankHolidaysJSON(t *testing.T) {
+	fixedNow := time.Date(2026, 6, 26, 0, 0, 0, 0, time.UTC)
+	now := func() time.Time { return fixedNow }
+
 	bankHolidays := sirius.BankHolidays{}
+
+	expectedCalculator := calculateWorkingDays(
+		fixedNow.UTC().Truncate(24*time.Hour),
+		time.Time{},
+		20,
+		WorkingDaysModeEndDate,
+		bankHolidays,
+	)
 
 	client := &mockSiriusCalendarsClient{}
 	client.
@@ -83,16 +121,205 @@ func TestGetSiriusCalendarsWithEmptyBankHolidaysJSON(t *testing.T) {
 	template.
 		On("Func", mock.Anything, siriusHeaderCalendarData{
 			BankHolidaysJSON: `{}`,
+			Calculator:       expectedCalculator,
 		}).
 		Return(nil)
 
 	r, _ := http.NewRequest(http.MethodGet, "/lpa-api/v1/dates/bank-holidays", nil)
 	w := httptest.NewRecorder()
 
-	err := SiriusHeaderCalendars(client, template.Func)(w, r)
+	err := siriusHeaderCalendarsWithNow(client, template.Func, now)(w, r)
 	resp := w.Result()
 
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	mock.AssertExpectationsForObjects(t, client, template)
+}
+
+func TestWorkingDays(t *testing.T) {
+	bankHolidays := sirius.BankHolidays{
+		"2025": {
+			"New Year": "2025-01-01T00:00:00+00:00",
+		},
+	}
+
+	expectedCalculator := calculateWorkingDays(
+		time.Date(2026, 6, 26, 0, 0, 0, 0, time.UTC),
+		time.Time{},
+		20,
+		WorkingDaysModeEndDate,
+		bankHolidays,
+	)
+
+	client := &mockSiriusCalendarsClient{}
+	client.
+		On("BankHolidays", mock.Anything).
+		Return(bankHolidays, nil)
+
+	form := url.Values{
+		"startdate":      {"2026-06-26"},
+		"enddate":        {""},
+		"numworkingdays": {"20"},
+		"mode":           {"enddate"},
+	}
+
+	template := &mockTemplate{}
+	template.
+		On("Func", mock.Anything, expectedCalculator).
+		Return(nil)
+
+	r, _ := http.NewRequest(http.MethodPost, "/lpa-api/v1/dates/bank-holidays", strings.NewReader(form.Encode()))
+	r.Header.Add("Content-Type", formUrlEncoded)
+	w := httptest.NewRecorder()
+
+	err := WorkingDays(client, template.Func)(w, r)
+	resp := w.Result()
+
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mock.AssertExpectationsForObjects(t, client, template)
+}
+
+func TestCalculateWorkingDays(t *testing.T) {
+	testCases := []struct {
+		name           string
+		startDate      time.Time
+		endDate        time.Time
+		numWorkingDays int
+		mode           WorkingDaysMode
+		expected       WorkingDaysData
+	}{
+		{
+			name:      "numworkingdays: between two dates with no weekends or bank holidays",
+			startDate: time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC),
+			endDate:   time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC),
+			mode:      WorkingDaysModeNumWorkingDays,
+			expected: WorkingDaysData{
+				StartDate:      "2026-04-07",
+				EndDate:        "2026-04-10",
+				Mode:           WorkingDaysModeNumWorkingDays,
+				NumWorkingDays: 3,
+			},
+		},
+		{
+			name:      "numworkingdays: between two dates with weekend",
+			startDate: time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC),
+			endDate:   time.Date(2026, 4, 13, 0, 0, 0, 0, time.UTC),
+			mode:      WorkingDaysModeNumWorkingDays,
+			expected: WorkingDaysData{
+				StartDate:      "2026-04-07",
+				EndDate:        "2026-04-13",
+				Mode:           WorkingDaysModeNumWorkingDays,
+				NumWorkingDays: 4,
+			},
+		},
+		{
+			name:      "numworkingdays: between two dates with bank holidays",
+			startDate: time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC),
+			endDate:   time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC),
+			mode:      WorkingDaysModeNumWorkingDays,
+			expected: WorkingDaysData{
+				StartDate:      "2026-04-02",
+				EndDate:        "2026-04-07",
+				Mode:           WorkingDaysModeNumWorkingDays,
+				NumWorkingDays: 1,
+			},
+		},
+		{
+			name:      "numberworkingdays: enddate before startdate, expect startdate to reset to day before enddate",
+			startDate: time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC),
+			endDate:   time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC),
+			mode:      WorkingDaysModeNumWorkingDays,
+			expected: WorkingDaysData{
+				StartDate:      "2026-04-06",
+				EndDate:        "2026-04-07",
+				Mode:           WorkingDaysModeNumWorkingDays,
+				NumWorkingDays: 1,
+			},
+		},
+		{
+			name:           "startdate: no weekends or bank holidays",
+			endDate:        time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC),
+			mode:           WorkingDaysModeStartDate,
+			numWorkingDays: 3,
+			expected: WorkingDaysData{
+				StartDate:      "2026-04-07",
+				EndDate:        "2026-04-10",
+				Mode:           WorkingDaysModeStartDate,
+				NumWorkingDays: 3,
+			},
+		},
+		{
+			name:           "startdate: weekends and bank holidays",
+			endDate:        time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC),
+			mode:           WorkingDaysModeStartDate,
+			numWorkingDays: 1,
+			expected: WorkingDaysData{
+				StartDate:      "2026-04-02",
+				EndDate:        "2026-04-07",
+				Mode:           WorkingDaysModeStartDate,
+				NumWorkingDays: 1,
+			},
+		},
+		{
+			name:           "startdate: numworkingdays is negative, expect startdate to reset to enddate",
+			endDate:        time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC),
+			mode:           WorkingDaysModeStartDate,
+			numWorkingDays: -1,
+			expected: WorkingDaysData{
+				StartDate:      "2026-04-07",
+				EndDate:        "2026-04-07",
+				Mode:           WorkingDaysModeStartDate,
+				NumWorkingDays: 0,
+			},
+		},
+		{
+			name:           "enddate: no weekends or bank holidays",
+			startDate:      time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC),
+			mode:           WorkingDaysModeEndDate,
+			numWorkingDays: 3,
+			expected: WorkingDaysData{
+				StartDate:      "2026-04-07",
+				EndDate:        "2026-04-10",
+				Mode:           WorkingDaysModeEndDate,
+				NumWorkingDays: 3,
+			},
+		},
+		{
+			name:           "enddate: weekends and bank holidays",
+			startDate:      time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC),
+			mode:           WorkingDaysModeEndDate,
+			numWorkingDays: 1,
+			expected: WorkingDaysData{
+				StartDate:      "2026-04-02",
+				EndDate:        "2026-04-07",
+				Mode:           WorkingDaysModeEndDate,
+				NumWorkingDays: 1,
+			},
+		},
+		{
+			name:           "enddate: numworkingdays is negative, expect enddate to reset to startdate",
+			startDate:      time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC),
+			mode:           WorkingDaysModeEndDate,
+			numWorkingDays: -1,
+			expected: WorkingDaysData{
+				StartDate:      "2026-04-07",
+				EndDate:        "2026-04-07",
+				Mode:           WorkingDaysModeEndDate,
+				NumWorkingDays: 0,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bankHolidays := sirius.BankHolidays{
+				"2026": {
+					"Good Friday":   "2026-04-03T00:00:00+00:00",
+					"Easter Monday": "2026-04-06T00:00:00+00:00",
+				},
+			}
+			result := calculateWorkingDays(tc.startDate, tc.endDate, tc.numWorkingDays, tc.mode, bankHolidays)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
 }

--- a/web/assets/calendar.js
+++ b/web/assets/calendar.js
@@ -48,13 +48,20 @@ const renderCalendars = (container, startMonth, startYear, bankHolidays) => {
     calendars.push(renderMonth(month, year, bankHolidays, index));
   });
 
-  container.innerHTML = "";
+  let calendarGrid = container.querySelector(".panel-calendar");
 
-  const calendarGrid = document.createElement("div");
-  calendarGrid.className = "panel-calendar";
-  calendarGrid.innerHTML = calendars.join("");
+  if (!calendarGrid) {
+    calendarGrid = document.createElement("div");
+    calendarGrid.className = "panel-calendar";
+    container.appendChild(calendarGrid);
+  }
 
-  container.appendChild(calendarGrid);
+  // Keep existing content (i.e. working days calculator) and only refresh calendar components.
+  calendarGrid.querySelectorAll("opg-calendar").forEach((calendar) => {
+    calendar.remove();
+  });
+
+  calendarGrid.insertAdjacentHTML("afterbegin", calendars.join(""));
 
   calendarMonths.forEach(({ month, year, index }) => {
     const prevButton = container.querySelector(`.prev-month-${index}`);

--- a/web/assets/calendar.scss
+++ b/web/assets/calendar.scss
@@ -1,12 +1,16 @@
 .panel-calendar {
   padding: 15px;
-  height: 50%;
-  overflow: hidden;
+  height: auto;
+  overflow: visible;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-start;
 
   opg-calendar {
-    width: 24%;
-    margin-right: 1%;
-    float: left;
+    flex: 1 1 0;
+    min-width: 14rem;
+    margin-right: 0;
 
     * {
       user-select: none;
@@ -74,8 +78,9 @@
   }
 
   .date-difference {
-    float: right;
-    width: 24%;
+    flex: 0 0 20rem;
+    width: auto;
+    min-width: 20rem;
     color: #ffffff;
 
     .govuk-heading-s,
@@ -86,25 +91,30 @@
     }
 
     .govuk-fieldset {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
+      display: flex !important;
+      align-items: flex-start;
       gap: 0.5em;
       margin-bottom: 1em;
     }
 
     .govuk-fieldset__legend {
-      margin-bottom: 0;
+      margin-bottom: 0 !important;
       width: auto;
       font-size: 0.9rem;
       white-space: nowrap;
+      display: inline-block !important;
+      float: none;
+      flex: 0 0 auto;
+      padding-top: 8px;
+      margin-right: 0.5em;
     }
 
     .govuk-radios {
-      display: flex;
-      justify-content: flex-end;
+      display: flex !important;
+      align-items: flex-start;
       flex-wrap: wrap;
-      gap: 0.25em 0.5em;
+      flex: 1 1 auto;
+      gap: 0.25em 0.25em;
     }
 
     .govuk-radios__item {
@@ -113,23 +123,36 @@
       float: none;
     }
 
+    .govuk-radios.govuk-radios--inline .govuk-radios__item {
+      margin-right: 0 !important;
+    }
+
     .govuk-radios__label {
       float: none;
       width: auto;
       line-height: 1.2;
       font-size: 0.9rem;
+      padding-right: 0;
+    }
+
+    .govuk-form-group {
+      display: grid;
+      grid-template-columns: minmax(8rem, 40%) 1fr;
+      column-gap: 0.75rem;
+      row-gap: 0.5rem;
+      align-items: center;
     }
 
     .govuk-form-group > .govuk-label {
-      float: left;
-      width: 40%;
-      line-height: 2em;
+      float: none;
+      width: auto;
+      line-height: 1.3;
       margin-bottom: 0;
     }
 
     .govuk-input[type="date"],
     .govuk-input[type="number"] {
-      width: 40% !important;
+      width: 90% !important;
       max-width: none;
     }
 
@@ -143,8 +166,33 @@
 
     .govuk-form-group::after {
       content: "";
-      display: table;
-      clear: both;
+      display: none;
+    }
+
+  }
+
+  @media (max-width: 1100px) {
+    opg-calendar {
+      min-width: 12rem;
+    }
+  }
+
+  @media (max-width: 800px) {
+    opg-calendar {
+      min-width: 10rem;
+    }
+  }
+
+  @media (max-width: 560px) {
+    opg-calendar {
+      min-width: 8.5rem;
+    }
+
+    .date-difference {
+
+      .govuk-form-group {
+        grid-template-columns: 1fr;
+      }
     }
   }
 }

--- a/web/assets/calendar.scss
+++ b/web/assets/calendar.scss
@@ -89,7 +89,7 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 0.5em; 
+      gap: 0.5em;
       margin-bottom: 1em;
     }
 

--- a/web/assets/calendar.scss
+++ b/web/assets/calendar.scss
@@ -156,7 +156,7 @@
       max-width: none;
     }
 
-    .govuk-input[disabled] {
+    .govuk-input[readonly] {
       background-color: transparent;
       color: #ffffff;
       font-weight: 700;

--- a/web/assets/calendar.scss
+++ b/web/assets/calendar.scss
@@ -76,36 +76,64 @@
   .date-difference {
     float: right;
     width: 24%;
+    color: #ffffff;
 
-    .selector {
-      label:first-child {
-        height: 4em;
-      }
-      label:not(:first-child) {
-        width: 30%;
-      }
-      label:last-child {
-        width: 60%;
-      }
+    .govuk-heading-s,
+    .govuk-fieldset__legend,
+    .govuk-label,
+    .govuk-radios__label {
+      color: #ffffff;
     }
 
-    div {
-      clear: both;
-      margin-bottom: 0.5em;
+    .govuk-fieldset {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5em; 
+      margin-bottom: 1em;
     }
 
-    label {
+    .govuk-fieldset__legend {
+      margin-bottom: 0;
+      width: auto;
+      font-size: 0.9rem;
+      white-space: nowrap;
+    }
+
+    .govuk-radios {
+      display: flex;
+      justify-content: flex-end;
+      flex-wrap: wrap;
+      gap: 0.25em 0.5em;
+    }
+
+    .govuk-radios__item {
+      margin-bottom: 0;
+      margin-right: 0;
+      float: none;
+    }
+
+    .govuk-radios__label {
+      float: none;
+      width: auto;
+      line-height: 1.2;
+      font-size: 0.9rem;
+    }
+
+    .govuk-form-group > .govuk-label {
       float: left;
       width: 40%;
       line-height: 2em;
+      margin-bottom: 0;
     }
 
-    input[type="text"],
-    input[type="number"] {
+    .govuk-input[type="date"],
+    .govuk-input[type="number"] {
       width: 40% !important;
+      max-width: none;
     }
 
-    input[disabled] {
+    .govuk-input[disabled] {
       background-color: transparent;
       color: #ffffff;
       font-weight: 700;
@@ -113,12 +141,10 @@
       border: none;
     }
 
-    button {
-      color: #ffffff;
-
-      &[disabled] {
-        display: none;
-      }
+    .govuk-form-group::after {
+      content: "";
+      display: table;
+      clear: both;
     }
   }
 }

--- a/web/assets/calendar.scss
+++ b/web/assets/calendar.scss
@@ -168,7 +168,6 @@
       content: "";
       display: none;
     }
-
   }
 
   @media (max-width: 1100px) {
@@ -189,7 +188,6 @@
     }
 
     .date-difference {
-
       .govuk-form-group {
         grid-template-columns: 1fr;
       }

--- a/web/template/layout/working-days-calculator.gohtml
+++ b/web/template/layout/working-days-calculator.gohtml
@@ -1,6 +1,6 @@
 {{ define "workingDaysCalculator" }}
-    <div class="date-difference">
-        <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Difference Calculator</h3>
+    <div class="date-difference" role="region" aria-labelledby="working-days-calculator-title" tabindex="0">
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-2" id="working-days-calculator-title">Difference Calculator</h3>
 
         <form hx-post="{{ prefix "/working-days" }}"
               hx-target=".date-difference"
@@ -41,40 +41,22 @@
                 <input class="govuk-input govuk-input--width-10"
                        type="date" id="calc-startdate" name="startdate" value="{{ .StartDate }}"
                        placeholder="DD/MM/YYYY"
-                       {{ if eq .Mode .ModeStartDate }}aria-label="Start date (calculated)" disabled{{ end }}
+                       {{ if eq .Mode .ModeStartDate }}aria-label="Start date (calculated)" readonly aria-readonly="true"{{ end }}
                        {{ if and (eq .Mode .PreviousMode) (ne .Mode .ModeStartDate) }}hx-preserve{{ end }}>
-                {{ if eq .Mode .ModeStartDate }}
-                    <input type="hidden" name="startdate" value="{{ .StartDate }}">
-                    <p class="govuk-visually-hidden" aria-live="polite" aria-atomic="true" role="status">
-                        Start date calculated: {{ .StartDate }}
-                    </p>
-                {{ end }}
 
                 <label class="govuk-label" for="calc-enddate">End date:</label>
                 <input class="govuk-input govuk-input--width-10"
                        type="date" id="calc-enddate" name="enddate" value="{{ .EndDate }}"
                        placeholder="DD/MM/YYYY"
-                       {{ if eq .Mode .ModeEndDate }}aria-label="End date (calculated)" disabled{{ end }}
+                       {{ if eq .Mode .ModeEndDate }}aria-label="End date (calculated)" readonly aria-readonly="true"{{ end }}
                        {{ if and (eq .Mode .PreviousMode) (ne .Mode .ModeEndDate) }}hx-preserve{{ end }}>
-                {{ if eq .Mode .ModeEndDate }}
-                    <input type="hidden" name="enddate" value="{{ .EndDate }}">
-                    <p class="govuk-visually-hidden" aria-live="polite" aria-atomic="true" role="status">
-                        End date calculated: {{ .EndDate }}
-                    </p>
-                {{ end }}
 
                 <label class="govuk-label" for="calc-numworkingdays">Working days:</label>
                 <input class="govuk-input govuk-input--width-10"
                        type="number" id="calc-numworkingdays" name="numworkingdays" value="{{ .NumWorkingDays }}"
                        min="0"
-                       {{ if eq .Mode .ModeNumWorkingDays }}aria-label="Working days (calculated)" disabled{{ end }}
+                       {{ if eq .Mode .ModeNumWorkingDays }}aria-label="Working days (calculated)" readonly aria-readonly="true"{{ end }}
                        {{ if and (eq .Mode .PreviousMode) (ne .Mode .ModeNumWorkingDays) }}hx-preserve{{ end }}>
-                {{ if eq .Mode .ModeNumWorkingDays }}
-                    <input type="hidden" name="numworkingdays" value="{{ .NumWorkingDays }}">
-                    <p class="govuk-visually-hidden" aria-live="polite" aria-atomic="true" role="status">
-                        Working days calculated: {{ .NumWorkingDays }}
-                    </p>
-                {{ end }}
             </div>
         </form>
     </div>

--- a/web/template/layout/working-days-calculator.gohtml
+++ b/web/template/layout/working-days-calculator.gohtml
@@ -10,10 +10,10 @@
             <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
             <input type="hidden" name="previousmode" value="{{ .Mode }}"/>
 
-            <fieldset class="govuk-fieldset">
-                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+            <div class="govuk-fieldset" role="group" aria-labelledby="calc-mode-label">
+                <span id="calc-mode-label" class="govuk-fieldset__legend govuk-fieldset__legend--s">
                     Calculate:
-                </legend>
+                </span>
                 <div class="govuk-radios govuk-radios--small govuk-radios--inline" data-module="govuk-radios">
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" type="radio"
@@ -34,7 +34,7 @@
                         <label class="govuk-label govuk-radios__label" for="mode-{{ .ModeNumWorkingDays }}">Working days</label>
                     </div>
                 </div>
-            </fieldset>
+            </div>
 
             <div class="govuk-form-group">
                 <label class="govuk-label" for="calc-startdate">Start date:</label>

--- a/web/template/layout/working-days-calculator.gohtml
+++ b/web/template/layout/working-days-calculator.gohtml
@@ -5,9 +5,10 @@
         <form hx-post="{{ prefix "/working-days" }}"
               hx-target=".date-difference"
               hx-swap="outerHTML"
-              hx-trigger="keyup changed delay:500ms from:input[type=date], change from:input[type=radio], keyup changed delay:500ms from:input[type=number]">
+              hx-trigger="change from:input, keyup changed from:input[type=number]">
 
             <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
+            <input type="hidden" name="previousmode" value="{{ .Mode }}"/>
 
             <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
@@ -40,7 +41,8 @@
                 <input class="govuk-input govuk-input--width-10"
                        type="date" id="calc-startdate" name="startdate" value="{{ .StartDate }}"
                        placeholder="DD/MM/YYYY"
-                       {{ if eq .Mode .ModeStartDate }}aria-label="Start date (calculated)" disabled{{ end }}>
+                       {{ if eq .Mode .ModeStartDate }}aria-label="Start date (calculated)" disabled{{ end }}
+                       {{ if and (eq .Mode .PreviousMode) (ne .Mode .ModeStartDate) }}hx-preserve{{ end }}>
                 {{ if eq .Mode .ModeStartDate }}
                     <input type="hidden" name="startdate" value="{{ .StartDate }}">
                     <p class="govuk-visually-hidden" aria-live="polite" aria-atomic="true" role="status">
@@ -52,7 +54,8 @@
                 <input class="govuk-input govuk-input--width-10"
                        type="date" id="calc-enddate" name="enddate" value="{{ .EndDate }}"
                        placeholder="DD/MM/YYYY"
-                       {{ if eq .Mode .ModeEndDate }}aria-label="End date (calculated)" disabled{{ end }}>
+                       {{ if eq .Mode .ModeEndDate }}aria-label="End date (calculated)" disabled{{ end }}
+                       {{ if and (eq .Mode .PreviousMode) (ne .Mode .ModeEndDate) }}hx-preserve{{ end }}>
                 {{ if eq .Mode .ModeEndDate }}
                     <input type="hidden" name="enddate" value="{{ .EndDate }}">
                     <p class="govuk-visually-hidden" aria-live="polite" aria-atomic="true" role="status">
@@ -64,7 +67,8 @@
                 <input class="govuk-input govuk-input--width-10"
                        type="number" id="calc-numworkingdays" name="numworkingdays" value="{{ .NumWorkingDays }}"
                        min="0"
-                       {{ if eq .Mode .ModeNumWorkingDays }}aria-label="Working days (calculated)" disabled{{ end }}>
+                       {{ if eq .Mode .ModeNumWorkingDays }}aria-label="Working days (calculated)" disabled{{ end }}
+                       {{ if and (eq .Mode .PreviousMode) (ne .Mode .ModeNumWorkingDays) }}hx-preserve{{ end }}>
                 {{ if eq .Mode .ModeNumWorkingDays }}
                     <input type="hidden" name="numworkingdays" value="{{ .NumWorkingDays }}">
                     <p class="govuk-visually-hidden" aria-live="polite" aria-atomic="true" role="status">

--- a/web/template/layout/working-days-calculator.gohtml
+++ b/web/template/layout/working-days-calculator.gohtml
@@ -1,0 +1,77 @@
+{{ define "workingDaysCalculator" }}
+    <div class="date-difference">
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Difference Calculator</h3>
+
+        <form hx-post="{{ prefix "/working-days" }}"
+              hx-target=".date-difference"
+              hx-swap="outerHTML"
+              hx-trigger="keyup changed delay:500ms from:input[type=date], change from:input[type=radio], keyup changed delay:500ms from:input[type=number]">
+
+            <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
+
+            <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                    Calculate:
+                </legend>
+                <div class="govuk-radios govuk-radios--small govuk-radios--inline" data-module="govuk-radios">
+                    <div class="govuk-radios__item">
+                        <input class="govuk-radios__input" type="radio"
+                               id="mode-{{ .ModeStartDate }}" name="mode" value={{ .ModeStartDate }}
+                               {{ if eq .Mode .ModeStartDate }}checked{{ end }}>
+                        <label class="govuk-label govuk-radios__label" for="mode-{{ .ModeStartDate }}">Start date</label>
+                    </div>
+                    <div class="govuk-radios__item">
+                        <input class="govuk-radios__input" type="radio"
+                               id="mode-{{ .ModeEndDate }}" name="mode" value={{ .ModeEndDate }}
+                               {{ if eq .Mode .ModeEndDate }}checked{{ end }}>
+                        <label class="govuk-label govuk-radios__label" for="mode-{{ .ModeEndDate }}">End date</label>
+                    </div>
+                    <div class="govuk-radios__item">
+                        <input class="govuk-radios__input" type="radio"
+                               id="mode-{{ .ModeNumWorkingDays }}" name="mode" value={{ .ModeNumWorkingDays }}
+                               {{ if eq .Mode .ModeNumWorkingDays }}checked{{ end }}>
+                        <label class="govuk-label govuk-radios__label" for="mode-{{ .ModeNumWorkingDays }}">Working days</label>
+                    </div>
+                </div>
+            </fieldset>
+
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="calc-startdate">Start date:</label>
+                <input class="govuk-input govuk-input--width-10"
+                       type="date" id="calc-startdate" name="startdate" value="{{ .StartDate }}"
+                       placeholder="DD/MM/YYYY"
+                       {{ if eq .Mode .ModeStartDate }}aria-label="Start date (calculated)" disabled{{ end }}>
+                {{ if eq .Mode .ModeStartDate }}
+                    <input type="hidden" name="startdate" value="{{ .StartDate }}">
+                    <p class="govuk-visually-hidden" aria-live="polite" aria-atomic="true" role="status">
+                        Start date calculated: {{ .StartDate }}
+                    </p>
+                {{ end }}
+
+                <label class="govuk-label" for="calc-enddate">End date:</label>
+                <input class="govuk-input govuk-input--width-10"
+                       type="date" id="calc-enddate" name="enddate" value="{{ .EndDate }}"
+                       placeholder="DD/MM/YYYY"
+                       {{ if eq .Mode .ModeEndDate }}aria-label="End date (calculated)" disabled{{ end }}>
+                {{ if eq .Mode .ModeEndDate }}
+                    <input type="hidden" name="enddate" value="{{ .EndDate }}">
+                    <p class="govuk-visually-hidden" aria-live="polite" aria-atomic="true" role="status">
+                        End date calculated: {{ .EndDate }}
+                    </p>
+                {{ end }}
+
+                <label class="govuk-label" for="calc-numworkingdays">Working days:</label>
+                <input class="govuk-input govuk-input--width-10"
+                       type="number" id="calc-numworkingdays" name="numworkingdays" value="{{ .NumWorkingDays }}"
+                       min="0"
+                       {{ if eq .Mode .ModeNumWorkingDays }}aria-label="Working days (calculated)" disabled{{ end }}>
+                {{ if eq .Mode .ModeNumWorkingDays }}
+                    <input type="hidden" name="numworkingdays" value="{{ .NumWorkingDays }}">
+                    <p class="govuk-visually-hidden" aria-live="polite" aria-atomic="true" role="status">
+                        Working days calculated: {{ .NumWorkingDays }}
+                    </p>
+                {{ end }}
+            </div>
+        </form>
+    </div>
+{{ end }}

--- a/web/template/sirius-header-partial-calendars.gohtml
+++ b/web/template/sirius-header-partial-calendars.gohtml
@@ -1,4 +1,7 @@
 {{ define "page" }}
 <div class="sirius-header__dropdown" data-module="calendar" data-bank-holidays='{{ .BankHolidaysJSON }}'>
+    <div class="panel-calendar">
+        {{ template "workingDaysCalculator" .Calculator }}
+    </div>
 </div>
 {{ end }}

--- a/web/template/working-days-partial.gohtml
+++ b/web/template/working-days-partial.gohtml
@@ -1,0 +1,3 @@
+{{ define "page" }}
+    {{ template "workingDaysCalculator" . }}
+{{ end }}


### PR DESCRIPTION
Fixes: [VEGA-3958](https://opgtransform.atlassian.net/browse/VEGA-3958)

- Adds working-days-calculator to calendar panel

## Checklist

- [ ] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards


[VEGA-3958]: https://opgtransform.atlassian.net/browse/VEGA-3958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ