### PR TITLE
VEGA-4007 - Stacked button group in action panel forms

### DIFF
--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -731,6 +731,22 @@ $app-action-panel-height: calc(100vh - $app-action-panel-top - 1rem);
   .govuk-form-group {
     margin-bottom: 20px;
   }
+  .govuk-button-group {
+    flex-direction: column;
+    align-items: center;
+    margin-right: 0;
+    margin-bottom: 5px;
+
+    .govuk-button {
+      margin-right: 0;
+      margin-bottom: 22px;
+      width: 100%;
+    }
+    .govuk-link {
+      margin-right: 0;
+      text-align: center;
+    }
+  }
 }
 
 .action-panel__form--wide {

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -731,7 +731,7 @@ $app-action-panel-height: calc(100vh - $app-action-panel-top - 1rem);
   .govuk-form-group {
     margin-bottom: 20px;
   }
-  .govuk-button-group {
+  .govuk-button-group:not(.govuk-button-group--row) {
     flex-direction: column;
     align-items: center;
     margin-right: 0;

--- a/web/template/create-document-htmx.gohtml
+++ b/web/template/create-document-htmx.gohtml
@@ -131,9 +131,7 @@
             </div>
           </fieldset>
         </div>
-        <div class="govuk-button-group govuk-!-padding-top-5">
-          <button class="govuk-button" data-module="govuk-button" type="submit" name="recipientControls" value="addNewRecipient">Continue</button>
-        </div>
+        <button class="govuk-button govuk-!-margin-top-5" data-module="govuk-button" type="submit" name="recipientControls" value="addNewRecipient">Continue</button>
         <div class="govuk-body">
           <a class="govuk-link govuk-link--no-visited-state"
              href=""
@@ -213,11 +211,9 @@
       </div>
     </div>
 
-    <div class="govuk-button-group govuk-!-padding-top-5">
-      <button class="govuk-button" data-module="create-document-button" type="submit" name="recipientControls" value="selectRecipients">
-        Create draft document
-      </button>
-    </div>
+    <button class="govuk-button govuk-!-margin-top-5" data-module="create-document-button" type="submit" name="recipientControls" value="selectRecipients">
+      Create draft document
+    </button>
     <div class="govuk-body">
       <a class="govuk-link govuk-link--no-visited-state"
          href=""
@@ -309,9 +305,7 @@
         {{ end }}
     </div>
 
-    <div class="govuk-button-group">
-      <button class="govuk-button" data-module="govuk-button" type="submit">Continue</button>
-    </div>
+    <button class="govuk-button govuk-!-margin-top-5" data-module="govuk-button" type="submit">Continue</button>
     <div class="govuk-body">
       <a class="govuk-link govuk-link--no-visited-state"
          href=""
@@ -380,9 +374,7 @@
       </template>
     </div>
 
-    <div class="govuk-button-group govuk-!-padding-top-5">
-      <button class="govuk-button" data-module="govuk-button" type="submit">Continue</button>
-    </div>
+    <button class="govuk-button govuk-!-margin-top-5" data-module="govuk-button" type="submit">Continue</button>
     <div class="govuk-body">
       <a class="govuk-link govuk-link--no-visited-state"
          href=""

--- a/web/template/edit-document-htmx.gohtml
+++ b/web/template/edit-document-htmx.gohtml
@@ -104,7 +104,7 @@
                 </div>
               {{ end }}
 
-            <div class="govuk-button-group">
+            <div class="govuk-button-group govuk-button-group--row">
               <button class="govuk-button govuk-button--secondary" data-module="govuk-button" name="documentControls" type="submit" value="save">Save draft</button>
               <button class="govuk-button govuk-button--secondary" data-module="govuk-button" name="documentControls" type="submit" value="saveAndExit" id="saveAndExit">Save and exit</button>
               <button class="govuk-button govuk-button--secondary" data-module="govuk-button" name="documentControls" type="submit" value="delete">Delete draft</button>

--- a/web/template/payments-partial-wrapper.gohtml
+++ b/web/template/payments-partial-wrapper.gohtml
@@ -2,28 +2,30 @@
 <div class="action-panel__form">
     {{ template "payments" . }}
 
-    <a class="govuk-button govuk-button--secondary"
-        href=""
-        hx-get="{{ prefix (printf "/add-payment?id=%d" .Case.ID) }}"
-        hx-target=".action-panel__content"
-        hx-swap="innerHTML">
-        Add payment
-    </a>
-    {{ if and (.IsReducedFeesUser) (not .FeeReductions) }}
-        <a class="govuk-button govuk-button--secondary" id="f-apply-fee-reduction-button"
-            href=""
-            hx-get="{{ prefix (printf "/apply-fee-reduction?id=%d" .Case.ID) }}"
-            hx-target=".action-panel__content"
-            hx-swap="innerHTML">
-            Apply fee reduction
+    <div class="govuk-button-group">
+        <a class="govuk-button govuk-button--secondary"
+           href=""
+           hx-get="{{ prefix (printf "/add-payment?id=%d" .Case.ID) }}"
+           hx-target=".action-panel__content"
+           hx-swap="innerHTML">
+            Add payment
         </a>
-    {{ end }}
-    <div class="govuk-body">
-        <a class="govuk-link govuk-link--no-visited-state"
-            href=""
-            hx-get="{{ prefix (printf "/action-panel?donorId=%d&entity=%s&uid[]=%s" .Case.Donor.ID (ToLower .Case.CaseType) .Case.UID) }}"
-            hx-target=".action-panel__content"
-        >Cancel</a>
+        {{ if and (.IsReducedFeesUser) (not .FeeReductions) }}
+            <a class="govuk-button govuk-button--secondary" id="f-apply-fee-reduction-button"
+               href=""
+               hx-get="{{ prefix (printf "/apply-fee-reduction?id=%d" .Case.ID) }}"
+               hx-target=".action-panel__content"
+               hx-swap="innerHTML">
+                Apply fee reduction
+            </a>
+        {{ end }}
+        <div class="govuk-body">
+            <a class="govuk-link govuk-link--no-visited-state"
+               href=""
+               hx-get="{{ prefix (printf "/action-panel?donorId=%d&entity=%s&uid[]=%s" .Case.Donor.ID (ToLower .Case.CaseType) .Case.UID) }}"
+               hx-target=".action-panel__content"
+            >Cancel</a>
+        </div>
     </div>
 </div>
 {{ end }}


### PR DESCRIPTION
Fixes [VEGA-4007](https://opgtransform.atlassian.net/browse/VEGA-4007)

- Add the form buttons in payments partial template to a button group to ensure they are stacked.
- Remove the button groups from the create document partial template to retain previous appearance.
- Update action panel form css to ensure buttons inside button groups are stacked and full width.


[VEGA-4007]: https://opgtransform.atlassian.net/browse/VEGA-4007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ