### PR TITLE
VEGA-4011: large font action panel

### DIFF
--- a/cypress/e2e/action-panel.cy.js
+++ b/cypress/e2e/action-panel.cy.js
@@ -619,4 +619,15 @@ describe("Action Panel", () => {
     cy.get(".action-panel__form").should("exist");
     cy.get(".action-panel__form").contains("Assign Task");
   });
+
+  it("applies large font styling to the action panel when an accessible theme is set", () => {
+    cy.setCookie("siriusTheme", "accessible-light");
+    cy.visit("/donor/1/documents?uid[]=7000-1234-1234");
+
+    cy.get("html").should("have.class", "app-!-html-class--large-font");
+    cy.get(".action-panel__button").should("not.be.visible");
+    cy.get("a#action-panel-button-create-warning")
+      .should("be.visible")
+      .and("contain", "Create warning");
+  });
 });

--- a/web/assets/accessible.scss
+++ b/web/assets/accessible.scss
@@ -1,0 +1,20 @@
+.app-\!-html-class--large-font {
+  .action-panel__inner {
+    display: block;
+
+    a {
+      display: block;
+      width: 95%;
+      min-height: 2em;
+      margin-bottom: 1em;
+      text-align: left;
+      text-transform: none;
+      font-weight: 900;
+      font-size: 1.3em;
+
+      .action-panel__button {
+        display: none;
+      }
+    }
+  }
+}

--- a/web/assets/load-classes.js
+++ b/web/assets/load-classes.js
@@ -15,3 +15,7 @@ if (
 ) {
   document.documentElement.className += " app-!-html-class--dark";
 }
+
+if (document.cookie.indexOf("siriusTheme=accessible-") > -1) {
+  document.documentElement.className += " app-!-html-class--large-font";
+}

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -19,6 +19,7 @@ $govuk-assets-path: "../assets/";
 @import "node_modules/accessible-autocomplete/src/autocomplete";
 @import "node_modules/opg-sirius-search-ui/src/search";
 @import "./dark.scss";
+@import "./accessible.scss";
 @import "./wysiwyg.scss";
 @import "./pdf-viewer.scss";
 @import "./calendar.scss";


### PR DESCRIPTION
VEGA-4011

Implements the large-font accessible theme for the new HTMX action panel, matching the existing behaviour on the legacy Angular action widget.

The old Angular app swaps the entire #themeCSS stylesheet bundle when an accessible theme is selected. The new Go/HTMX frontend is a separate top-level page (not an iframe), with a single compiled stylesheet, so that mechanism doesn't apply directly. 
Instead, this follows the existing pattern already used for dark mode: load-classes.js reads the siriusTheme cookie on page load (before paint) and adds a class to <html>, which SCSS then targets.

Note
This covers the action panel only, per the ticket. It doesn't implement the site-wide large-font styling (base font-size bump, timeline, search dropdown, etc.) that the old Angular app applies via accessible-base.less