### PR TITLE
VEGA-4019 - Implement create/edit LPA form basic template

### DIFF
--- a/cypress/e2e/action-panel.cy.js
+++ b/cypress/e2e/action-panel.cy.js
@@ -194,13 +194,14 @@ describe("Action Panel", () => {
     cy.contains("Create document").should("not.be.visible");
     cy.contains("Create donor").should("not.be.visible");
     cy.contains("Create epa case").should("not.be.visible");
+    cy.contains("Create lpa case").should("not.be.visible");
     cy.contains("Create event").should("not.be.visible");
     cy.contains("Create relationship").should("not.be.visible");
     cy.contains("Create warning").should("not.be.visible");
     cy.contains("Delete relationship").should("not.be.visible");
     cy.contains("Edit dates").should("not.be.visible");
     cy.contains("Edit donor").should("not.be.visible");
-    cy.contains("Edit epa case").should("not.be.visible");
+    cy.contains("Edit case").should("not.be.visible");
     cy.contains("Fees").should("not.be.visible");
     cy.contains("Unlink record").should("not.be.visible");
     cy.contains("Link record").should("not.be.visible");
@@ -551,7 +552,30 @@ describe("Action Panel", () => {
     cy.get(".action-panel__form .govuk-link").contains("Cancel").click();
   });
 
-  it("displays the edit epa button on the action panel", () => {
+  it("displays the create lpa button on the action panel", () => {
+    cy.addMock(
+      "/lpa-api/v1/persons/1/documents?filter=draft:0,preview:0&limit=999",
+      "GET",
+      {
+        status: 200,
+        body: {
+          total: 0,
+          documents: [],
+        },
+      },
+    );
+
+    cy.visit("/donor/1/documents"); // create lpa button is only clickable when no cases are selected
+
+    cy.get("#actions-content").should("be.visible");
+    cy.get("#actions-content").contains("Create lpa case");
+
+    cy.get("a#action-panel-button-create-lpa-case").click();
+    cy.get(".action-panel__form").should("exist");
+    cy.get(".action-panel__form").contains("Create an LPA");
+  });
+
+  it("displays the edit case button on the action panel", () => {
     cy.addMock("/lpa-api/v1/cases/111", "GET", {
       status: 200,
       body: { id: 111 },
@@ -590,9 +614,9 @@ describe("Action Panel", () => {
     cy.visit("/donor/1/documents?uid[]=7000-9876-5432");
 
     cy.get("#actions-content").should("be.visible");
-    cy.get("#actions-content").contains("Edit epa case");
+    cy.get("#actions-content").contains("Edit case");
 
-    cy.get("a#action-panel-button-edit-epa-case").click();
+    cy.get("a#action-panel-button-edit-case").click();
     cy.get(".action-panel__form").should("exist");
     cy.get(".action-panel__form").contains("Edit EPA");
   });

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	golang.org/x/sys v0.45.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/server/action_panel.go
+++ b/internal/server/action_panel.go
@@ -163,7 +163,8 @@ func GetActionPanelButtons(selectedCases []sirius.Case, donorId int, caseUids st
 	deleteRelationshipUrl := fmt.Sprintf("/delete-relationship?id=%d%s", donorId, caseUids)
 	createRelationshipUrl := fmt.Sprintf("/create-relationship?id=%d&entity=person%s", donorId, caseUids)
 	createEpaUrl := fmt.Sprintf("/create-epa?id=%d", donorId)
-	editEpaUrl := ""
+	createLpaUrl := fmt.Sprintf("/create-lpa?id=%d", donorId)
+	editCaseUrl := ""
 	complaintUrl := ""
 	createDocumentUrl := ""
 	createInvestigationUrl := ""
@@ -191,7 +192,9 @@ func GetActionPanelButtons(selectedCases []sirius.Case, donorId int, caseUids st
 		createInvestigationUrl = fmt.Sprintf("/create-investigation?id=%d&case=%s%s", id, caseType, caseUids)
 
 		if strings.ToLower(selectedCase.CaseType) == "epa" {
-			editEpaUrl = fmt.Sprintf("/create-epa?id=%d&caseId=%d", donorId, selectedCases[0].ID)
+			editCaseUrl = fmt.Sprintf("/create-epa?id=%d&caseId=%d", donorId, selectedCases[0].ID)
+		} else if strings.ToLower(selectedCase.CaseType) == "lpa" {
+			editCaseUrl = fmt.Sprintf("/create-lpa?id=%d&caseId=%d", donorId, selectedCases[0].ID)
 		}
 
 		if hasDrafts {
@@ -358,10 +361,17 @@ func GetActionPanelButtons(selectedCases []sirius.Case, donorId int, caseUids st
 			Hidden:   !userPermissions.Includes("v1-donors-epas", "POST"),
 		},
 		{
-			Label:    "Edit epa case",
-			URL:      editEpaUrl,
+			Label:    "Create lpa case",
+			URL:      createLpaUrl,
+			IconName: "aw-create-case",
+			Disabled: caseUids != "",
+			Hidden:   !userPermissions.Includes("v1-donors-lpas", "POST"),
+		},
+		{
+			Label:    "Edit case",
+			URL:      editCaseUrl,
 			IconName: "aw-edit-case",
-			Disabled: len(selectedCases) != 1 || strings.ToLower(selectedCases[0].CaseType) != "epa",
+			Disabled: len(selectedCases) != 1,
 			Hidden:   !userPermissions.Includes("v1-lpas", "PUT"),
 		},
 		{

--- a/internal/server/action_panel_test.go
+++ b/internal/server/action_panel_test.go
@@ -204,7 +204,13 @@ func TestGetActionPanel(t *testing.T) {
 					Disabled: false,
 				},
 				{
-					Label:    "Edit epa case",
+					Label:    "Create lpa case",
+					URL:      "/create-lpa?id=123",
+					IconName: "aw-create-case",
+					Disabled: false,
+				},
+				{
+					Label:    "Edit case",
 					URL:      "",
 					IconName: "aw-edit-case",
 					Disabled: true,
@@ -376,10 +382,16 @@ func TestGetActionPanelWithUIDFilter(t *testing.T) {
 					Disabled: true,
 				},
 				{
-					Label:    "Edit epa case",
-					URL:      "",
-					IconName: "aw-edit-case",
+					Label:    "Create lpa case",
+					URL:      "/create-lpa?id=123",
+					IconName: "aw-create-case",
 					Disabled: true,
+				},
+				{
+					Label:    "Edit case",
+					URL:      "/create-lpa?id=123&caseId=1",
+					IconName: "aw-edit-case",
+					Disabled: false,
 				},
 				{
 					Label:    "Add investigation",
@@ -575,7 +587,13 @@ func TestGetActionPanelNoDonorID(t *testing.T) {
 					Disabled: false,
 				},
 				{
-					Label:    "Edit epa case",
+					Label:    "Create lpa case",
+					URL:      "/create-lpa?id=0",
+					IconName: "aw-create-case",
+					Disabled: false,
+				},
+				{
+					Label:    "Edit case",
 					URL:      "",
 					IconName: "aw-edit-case",
 					Disabled: true,
@@ -633,139 +651,69 @@ func TestGetActionPanelEditEpaOnlyEnabledWhenSingleEpaCaseSelected(t *testing.T)
 
 	template := &mockTemplate{}
 	template.
-		On("Func", mock.Anything, ActionPanelData{
-			ActionPanelButtons: []ActionPanelButton{
-				{
-					Label:    "Create warning",
-					URL:      "/create-warning?id=123&entity=epa&uid[]=7000-0000-0003",
-					IconName: "aw-create-warning",
-					Disabled: false,
-				},
-				{
-					Label:    "Create event",
-					URL:      "/create-event?id=123&entity=person&uid[]=7000-0000-0003",
-					IconName: "aw-new-event",
-					Disabled: false,
-				},
-				{
-					Label:    "Add complaint",
-					URL:      "/add-complaint?id=3&case=epa",
-					IconName: "aw-log-complaint",
-					Disabled: false,
-				},
-				{
-					Label:    "Create document",
-					URL:      "/create-document?id=3&case=epa",
-					IconName: "aw-new-template",
-					Disabled: false,
-				},
-				{
-					Label:    "Retrieve draft",
-					URL:      "/edit-document?id=3&case=epa",
-					IconName: "aw-new-template",
-					Disabled: false,
-				},
-				{
-					Label:    "Change status",
-					URL:      "/change-status?id=3&case=epa&donorId=123&uid[]=7000-0000-0003",
-					IconName: "aw-change-status",
-					Disabled: false,
-				},
-				{
-					Label:    "Fees",
-					URL:      "/payments/3",
-					IconName: "aw-fees",
-					Disabled: false,
-				},
-				{
-					Label:    "New task",
-					URL:      "/create-task?id=3&entity=epa&uid[]=7000-0000-0003",
-					IconName: "aw-new-task",
-					Disabled: false,
-				},
-				{
-					Label:    "Assign task",
-					URL:      "",
-					IconName: "aw-assign-task",
-					Disabled: true,
-				},
-				{
-					Label:    "Create donor",
-					URL:      "/create-donor?id=123&entity=person&uid[]=7000-0000-0003",
-					IconName: "aw-create-person",
-					Disabled: false,
-				},
-				{
-					Label:    "Edit donor",
-					URL:      "/edit-donor?id=123&entity=person&uid[]=7000-0000-0003",
-					IconName: "aw-edit-person",
-					Disabled: false,
-				},
-				{
-					Label:    "Edit dates",
-					URL:      "/edit-dates?id=3&case=epa",
-					IconName: "calendar-open",
-					Disabled: false,
-				},
-				{
-					Label:    "MI reporting",
-					URL:      "/mi-reporting?donorId=123&uid[]=7000-0000-0003",
-					IconName: "aw-mi",
-					Disabled: false,
-				},
-				{
-					Label:    "Allocate Case",
-					URL:      "/allocate-cases?id=3&entity=epa&uid[]=7000-0000-0003",
-					IconName: "aw-allocate-case",
-					Disabled: false,
-				},
-				{
-					Label:    "Link record",
-					URL:      "/link-person?id=123&uid[]=7000-0000-0003",
-					IconName: "aw-link",
-					Disabled: false,
-				},
-				{
-					Label:    "Unlink record",
-					URL:      "/unlink-person?id=123&uid[]=7000-0000-0003",
-					IconName: "aw-unlink",
-					Disabled: true,
-				},
-				{
-					Label:    "Delete relationship",
-					URL:      "/delete-relationship?id=123&uid[]=7000-0000-0003",
-					IconName: "icon-minus",
-					Disabled: false,
-				},
-				{
-					Label:    "Create relationship",
-					URL:      "/create-relationship?id=123&entity=person&uid[]=7000-0000-0003",
-					IconName: "aw-relationship",
-					Disabled: false,
-				},
-				{
-					Label:    "Create epa case",
-					URL:      "/create-epa?id=123",
-					IconName: "aw-create-case",
-					Disabled: true,
-				},
-				{
-					Label:    "Edit epa case",
-					URL:      "/create-epa?id=123&caseId=3",
-					IconName: "aw-edit-case",
-					Disabled: false,
-				},
-				{
-					Label:    "Add investigation",
-					URL:      "/create-investigation?id=3&case=epa&uid[]=7000-0000-0003",
-					IconName: "icon-investigation",
-					Disabled: false,
-				},
-			},
-		}).
+		On("Func", mock.Anything, mock.MatchedBy(func(data ActionPanelData) bool {
+			for _, btn := range data.ActionPanelButtons {
+				if btn.Label == "Edit case" {
+					return btn.URL == "/create-epa?id=123&caseId=3" && btn.Disabled == false
+				}
+			}
+			return false
+		})).
 		Return(nil)
 
 	r, _ := http.NewRequest(http.MethodGet, "/?donorId=123&entity=epa&uid[]=7000-0000-0003", nil)
+	w := httptest.NewRecorder()
+
+	err := ActionPanel(client, template.Func)(w, r)
+	resp := w.Result()
+
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mock.AssertExpectationsForObjects(t, client, template)
+	client.AssertNotCalled(t, "CasesByDonor")
+	client.AssertNotCalled(t, "Person")
+}
+
+func TestGetActionPanelEditLpaOnlyEnabledWhenSingleLpaCaseSelected(t *testing.T) {
+	cases := []sirius.Case{
+		{ID: 1, UID: "7000-0000-0001", CaseType: "LPA"},
+		{ID: 2, UID: "7000-0000-0002", CaseType: "LPA"},
+		{ID: 3, UID: "7000-0000-0003", CaseType: "EPA"},
+	}
+
+	client := &mockActionPanelClient{}
+	client.
+		On("CasesByDonor", mock.Anything, 123).
+		Return(cases, nil)
+	client.
+		On("GetDraftCount", mock.Anything, "lpa", 2).
+		Return(sirius.DocumentDraftCount{DraftCount: 1}, nil)
+	client.
+		On("Person", mock.Anything, 123).
+		Return(sirius.Person{}, nil)
+	client.
+		On("TasksForCase", mock.Anything, 2).
+		Return([]sirius.Task{}, nil)
+	client.
+		On("PersonReferences", mock.Anything, 123).
+		Return([]sirius.PersonReference{{ID: 987}}, nil)
+	client.
+		On("GetUserPermissions", mock.Anything).
+		Return(actionPanelPermissions, nil)
+
+	template := &mockTemplate{}
+	template.
+		On("Func", mock.Anything, mock.MatchedBy(func(data ActionPanelData) bool {
+			for _, btn := range data.ActionPanelButtons {
+				if btn.Label == "Edit case" {
+					return btn.URL == "/create-lpa?id=123&caseId=2" && btn.Disabled == false
+				}
+			}
+			return false
+		})).
+		Return(nil)
+
+	r, _ := http.NewRequest(http.MethodGet, "/?donorId=123&entity=lpa&uid[]=7000-0000-0002", nil)
 	w := httptest.NewRecorder()
 
 	err := ActionPanel(client, template.Func)(w, r)

--- a/internal/server/create_lpa.go
+++ b/internal/server/create_lpa.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/ministryofjustice/opg-go-common/template"
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+)
+
+type CreateLpaClient interface {
+	Person(sirius.Context, int) (sirius.Person, error)
+	Case(sirius.Context, int) (sirius.Case, error)
+}
+
+type createLpaData struct {
+	XSRFToken string
+	Success   bool
+	Error     sirius.ValidationError
+	DonorId   int
+	DonorName string
+	Title     string
+	CaseId    int
+	CaseItem  sirius.Case
+}
+
+func CreateLpa(client CreateLpaClient, tmpl template.Template, partialTmpl template.Template) Handler {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		ctx := getContext(r)
+
+		donorID, err := strToIntOrStatusError(r.FormValue("id"))
+		if err != nil {
+			return err
+		}
+
+		donor, err := client.Person(ctx, donorID)
+		if err != nil {
+			return err
+		}
+
+		data := createLpaData{
+			XSRFToken: ctx.XSRFToken,
+			DonorId:   donorID,
+			DonorName: donor.Firstname + " " + donor.Surname,
+			Title:     "Create an LPA",
+		}
+
+		caseIdStr := r.FormValue("caseId")
+		isEditing := caseIdStr != ""
+		if isEditing {
+			data.CaseId, err = strToIntOrStatusError(caseIdStr)
+			if err != nil {
+				return err
+			}
+
+			data.CaseItem, err = client.Case(ctx, data.CaseId)
+			if err != nil {
+				return err
+			}
+
+			data.Title = "Edit LPA"
+		}
+
+		if r.Header.Get("HX-Request") == "true" {
+			return partialTmpl(w, data)
+		}
+
+		return tmpl(w, data)
+	}
+}

--- a/internal/server/create_lpa_test.go
+++ b/internal/server/create_lpa_test.go
@@ -92,16 +92,22 @@ func TestGetCreateLpaEdit(t *testing.T) {
 
 func TestGetCreateLpaBadQuery(t *testing.T) {
 	testCases := map[string]string{
-		"no-id":  "/",
-		"bad-id": "/?id=test",
+		"no-id":       "/",
+		"bad-id":      "/?id=test",
+		"bad-case-id": "/?id=123&caseId=test",
 	}
 
 	for name, url := range testCases {
 		t.Run(name, func(t *testing.T) {
+			client := &mockCreateLpaClient{}
+			client.
+				On("Person", mock.Anything, 123).
+				Return(sirius.Person{}, nil)
+
 			r, _ := http.NewRequest(http.MethodGet, url, nil)
 			w := httptest.NewRecorder()
 
-			err := CreateLpa(nil, nil, nil)(w, r)
+			err := CreateLpa(client, nil, nil)(w, r)
 
 			assert.NotNil(t, err)
 		})

--- a/internal/server/create_lpa_test.go
+++ b/internal/server/create_lpa_test.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/ministryofjustice/opg-sirius-lpa-frontend/internal/sirius"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockCreateLpaClient struct {
+	mock.Mock
+}
+
+func (m *mockCreateLpaClient) Case(ctx sirius.Context, id int) (sirius.Case, error) {
+	args := m.Called(ctx, id)
+	return args.Get(0).(sirius.Case), args.Error(1)
+}
+
+func (m *mockCreateLpaClient) Person(ctx sirius.Context, id int) (sirius.Person, error) {
+	args := m.Called(ctx, id)
+	return args.Get(0).(sirius.Person), args.Error(1)
+}
+
+func TestGetCreateLpa(t *testing.T) {
+	for _, isHtmx := range []bool{false, true} {
+		t.Run("Is Htmx: "+strconv.FormatBool(isHtmx), func(t *testing.T) {
+			client := &mockCreateLpaClient{}
+			client.
+				On("Person", mock.Anything, 123).
+				Return(sirius.Person{Firstname: "Firstname", Surname: "Surname"}, nil)
+
+			template := &mockTemplate{}
+			template.
+				On("Func", mock.Anything, createLpaData{
+					DonorId:   123,
+					DonorName: "Firstname Surname",
+					Title:     "Create an LPA",
+				}).
+				Return(nil)
+
+			r, _ := http.NewRequest(http.MethodGet, "/?id=123", nil)
+			w := httptest.NewRecorder()
+
+			if isHtmx {
+				r.Header.Add("HX-Request", "true")
+			}
+
+			err := CreateLpa(client, template.Func, template.Func)(w, r)
+			resp := w.Result()
+
+			assert.Nil(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			mock.AssertExpectationsForObjects(t, client, template)
+		})
+	}
+}
+
+func TestGetCreateLpaEdit(t *testing.T) {
+	client := &mockCreateLpaClient{}
+	client.
+		On("Person", mock.Anything, 123).
+		Return(sirius.Person{Firstname: "Firstname", Surname: "Surname"}, nil)
+	client.
+		On("Case", mock.Anything, 456).
+		Return(sirius.Case{}, nil)
+
+	template := &mockTemplate{}
+	template.
+		On("Func", mock.Anything, createLpaData{
+			DonorId:   123,
+			DonorName: "Firstname Surname",
+			Title:     "Edit LPA",
+			CaseId:    456,
+			CaseItem:  sirius.Case{},
+		}).
+		Return(nil)
+
+	r, _ := http.NewRequest(http.MethodGet, "/?id=123&caseId=456", nil)
+	w := httptest.NewRecorder()
+
+	err := CreateLpa(client, template.Func, template.Func)(w, r)
+	resp := w.Result()
+
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	mock.AssertExpectationsForObjects(t, client, template)
+}
+
+func TestGetCreateLpaBadQuery(t *testing.T) {
+	testCases := map[string]string{
+		"no-id":  "/",
+		"bad-id": "/?id=test",
+	}
+
+	for name, url := range testCases {
+		t.Run(name, func(t *testing.T) {
+			r, _ := http.NewRequest(http.MethodGet, url, nil)
+			w := httptest.NewRecorder()
+
+			err := CreateLpa(nil, nil, nil)(w, r)
+
+			assert.NotNil(t, err)
+		})
+	}
+}
+
+func TestCreateLpaWhenPersonErrors(t *testing.T) {
+	client := &mockCreateLpaClient{}
+	client.
+		On("Person", mock.Anything, 123).
+		Return(sirius.Person{}, errExample)
+
+	r, _ := http.NewRequest(http.MethodGet, "/?id=123", nil)
+	w := httptest.NewRecorder()
+
+	err := CreateLpa(client, nil, nil)(w, r)
+
+	assert.Equal(t, err, errExample)
+	mock.AssertExpectationsForObjects(t, client)
+}
+
+func TestCreateLpaWhenCaseErrors(t *testing.T) {
+	client := &mockCreateLpaClient{}
+	client.
+		On("Person", mock.Anything, 123).
+		Return(sirius.Person{}, nil)
+	client.
+		On("Case", mock.Anything, 456).
+		Return(sirius.Case{}, errExample)
+
+	r, _ := http.NewRequest(http.MethodGet, "/?id=123&caseId=456", nil)
+	w := httptest.NewRecorder()
+
+	err := CreateLpa(client, nil, nil)(w, r)
+
+	assert.Equal(t, err, errExample)
+	mock.AssertExpectationsForObjects(t, client)
+}

--- a/internal/server/document_list_test.go
+++ b/internal/server/document_list_test.go
@@ -384,7 +384,14 @@ func TestGetDocumentList(t *testing.T) {
 					Hidden:   true,
 				},
 				{
-					Label:    "Edit epa case",
+					Label:    "Create lpa case",
+					URL:      "/create-lpa?id=82",
+					IconName: "aw-create-case",
+					Disabled: false,
+					Hidden:   true,
+				},
+				{
+					Label:    "Edit case",
 					URL:      "",
 					IconName: "aw-edit-case",
 					Disabled: true,
@@ -545,10 +552,17 @@ func TestGetDocumentList(t *testing.T) {
 					Hidden:   true,
 				},
 				{
-					Label:    "Edit epa case",
-					URL:      "",
+					Label:    "Create lpa case",
+					URL:      "/create-lpa?id=82",
+					IconName: "aw-create-case",
+					Disabled: false,
+					Hidden:   true,
+				},
+				{
+					Label:    "Edit case",
+					URL:      "/create-lpa?id=82&caseId=1",
 					IconName: "aw-edit-case",
-					Disabled: true,
+					Disabled: false,
 					Hidden:   true,
 				},
 				{
@@ -706,10 +720,17 @@ func TestGetDocumentList(t *testing.T) {
 					Hidden:   true,
 				},
 				{
-					Label:    "Edit epa case",
-					URL:      "",
-					IconName: "aw-edit-case",
+					Label:    "Create lpa case",
+					URL:      "/create-lpa?id=82",
+					IconName: "aw-create-case",
 					Disabled: true,
+					Hidden:   true,
+				},
+				{
+					Label:    "Edit case",
+					URL:      "/create-lpa?id=82&caseId=1",
+					IconName: "aw-edit-case",
+					Disabled: false,
 					Hidden:   true,
 				},
 				{
@@ -861,7 +882,6 @@ func TestGetDocumentList(t *testing.T) {
 					Hidden:   true,
 				},
 				{
-
 					Label:    "Create epa case",
 					URL:      "/create-epa?id=82",
 					IconName: "aw-create-case",
@@ -869,7 +889,14 @@ func TestGetDocumentList(t *testing.T) {
 					Hidden:   true,
 				},
 				{
-					Label:    "Edit epa case",
+					Label:    "Create lpa case",
+					URL:      "/create-lpa?id=82",
+					IconName: "aw-create-case",
+					Disabled: true,
+					Hidden:   true,
+				},
+				{
+					Label:    "Edit case",
 					URL:      "",
 					IconName: "aw-edit-case",
 					Disabled: true,
@@ -1270,7 +1297,14 @@ func TestDocumentListShowsValidationErrorWhenNoDocumentsSelected(t *testing.T) {
 						Hidden:   true,
 					},
 					{
-						Label:    "Edit epa case",
+						Label:    "Create lpa case",
+						URL:      "/create-lpa?id=82",
+						IconName: "aw-create-case",
+						Disabled: false,
+						Hidden:   true,
+					},
+					{
+						Label:    "Edit case",
 						URL:      "",
 						IconName: "aw-edit-case",
 						Disabled: true,
@@ -1520,7 +1554,14 @@ func TestDocumentListDismissValidation(t *testing.T) {
 						Hidden:   true,
 					},
 					{
-						Label:    "Edit epa case",
+						Label:    "Create lpa case",
+						URL:      "/create-lpa?id=82",
+						IconName: "aw-create-case",
+						Disabled: true,
+						Hidden:   true,
+					},
+					{
+						Label:    "Edit case",
 						URL:      "",
 						IconName: "aw-edit-case",
 						Disabled: true,
@@ -1900,10 +1941,17 @@ func TestGetDocumentListWhenTemplateErrors(t *testing.T) {
 						Hidden:   true,
 					},
 					{
-						Label:    "Edit epa case",
-						URL:      "",
+						Label:    "Create lpa case",
+						URL:      "/create-lpa?id=82",
+						IconName: "aw-create-case",
+						Disabled: false,
+						Hidden:   true,
+					},
+					{
+						Label:    "Edit case",
+						URL:      "/create-lpa?id=82&caseId=1",
 						IconName: "aw-edit-case",
-						Disabled: true,
+						Disabled: false,
 						Hidden:   true,
 					},
 					{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -175,6 +175,7 @@ func New(logger *slog.Logger, client Client, templates template.Templates, prefi
 	mux.Handle("/create-document", wrap(CreateDocument(client, templates.Get("create_document.gohtml"), templates.Get("create-document-htmx.gohtml"))))
 	mux.Handle("/create-epa", wrap(CreateEpa(client, templates.Get("create-epa-wrapper.gohtml"), templates.Get("create-epa-partial-wrapper.gohtml"))))
 	mux.Handle("/create-investigation", wrap(CreateInvestigation(client, templates.Get("create-investigation-wrapper.gohtml"), templates.Get("create-investigation-partial-wrapper.gohtml"))))
+	mux.Handle("/create-lpa", wrap(CreateLpa(client, templates.Get("create-lpa-wrapper.gohtml"), templates.Get("create-lpa-partial-wrapper.gohtml"))))
 	mux.Handle("/create-relationship", wrap(Relationship(client, templates.Get("create-relationship-wrapper.gohtml"), templates.Get("create-relationship-partial-wrapper.gohtml"))))
 	mux.Handle("/compare/{id}/{caseId}", wrap(CompareDocs(client, templates.Get("compare-docs.gohtml"))))
 	mux.Handle("/delete-fee-reduction", wrap(DeletePayment(client, templates.Get("delete-fee-reduction-wrapper.gohtml"), templates.Get("delete-fee-reduction-partial-wrapper.gohtml"))))

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -713,7 +713,8 @@ $app-action-panel-height: calc(100vh - $app-action-panel-top - 1rem);
     font-size: 0.875rem;
   }
   .govuk-accordion__section-button,
-  .govuk-accordion__section-heading-text {
+  .govuk-accordion__section-heading-text,
+  .govuk-summary-card__title {
     font-size: 1rem;
   }
   .govuk-select,
@@ -1112,4 +1113,21 @@ $app-action-panel-height: calc(100vh - $app-action-panel-top - 1rem);
 
 #documentTextEditor {
   display: none;
+}
+
+.app-lpa__donor-info {
+  margin-left: -15px;
+  margin-right: -15px;
+  padding-bottom: 5px;
+  text-align: center;
+  border-bottom: 1px solid #cecece;
+
+  .app-lpa__donor-info--pfa {
+    font-weight: bold;
+    color: $sirius-teal;
+  }
+  .app-lpa__donor-info--hw {
+    font-weight: bold;
+    color: $sirius-green;
+  }
 }

--- a/web/template/create-lpa-partial-wrapper.gohtml
+++ b/web/template/create-lpa-partial-wrapper.gohtml
@@ -29,7 +29,7 @@
         </button>
         <a class="govuk-link govuk-link--no-visited-state"
            href=""
-           hx-get="{{ prefix (printf "/action-panel?donorId=%d" .DonorId) }}"
+           hx-get="{{ if .CaseId }}{{ prefix (printf "/action-panel?donorId=%d&uid[]=%s" .DonorId .CaseItem.UID) }}{{ else }}{{ prefix (printf "/action-panel?donorId=%d" .DonorId) }}{{ end }}"
            hx-target=".action-panel__content"
            hx-swap="innerHTML scroll:.action-panel__content:top">Cancel</a>
       </div>

--- a/web/template/create-lpa-partial-wrapper.gohtml
+++ b/web/template/create-lpa-partial-wrapper.gohtml
@@ -1,0 +1,38 @@
+{{ define "page" }}
+  <div class="action-panel__form">
+    {{ template "error-summary" .Error }}
+
+    {{ if .Success }}
+      <meta http-equiv="Refresh" content="0" />
+      {{ if .CaseId }}
+          {{ template "success-banner" "You have successfully updated an LPA." }}
+      {{ else }}
+          {{ template "success-banner" "You have successfully created an LPA." }}
+      {{ end }}
+    {{ end }}
+
+    <p class="govuk-body app-lpa__donor-info">{{ .DonorName }}{{ if .CaseId }} – <span class="app-lpa__donor-info--{{ .CaseItem.SubType }}">{{ ToUpper .CaseItem.SubType }}</span> {{ .CaseItem.UID }}{{ end }}</p>
+
+    <h1 class="govuk-heading-m">{{ .Title }}</h1>
+
+    <form class="form"
+          method="POST"
+          hx-post="{{ if .CaseId }}{{ prefix (printf "/create-lpa?id=%d&caseId=%d" .DonorId .CaseId) }}{{ else }}{{ prefix (printf "/create-lpa?id=%d" .DonorId) }}{{ end }}"
+          hx-target=".action-panel__content"
+          hx-swap="innerHTML scroll:.action-panel__content:top"
+    >
+      {{ template "create-lpa" . }}
+
+      <div class="govuk-button-group">
+        <button class="govuk-button" data-module="govuk-button" type="submit"
+                data-disable-after-click="true">Save and exit
+        </button>
+        <a class="govuk-link govuk-link--no-visited-state"
+           href=""
+           hx-get="{{ prefix (printf "/action-panel?donorId=%d" .DonorId) }}"
+           hx-target=".action-panel__content"
+           hx-swap="innerHTML scroll:.action-panel__content:top">Cancel</a>
+      </div>
+    </form>
+  </div>
+{{ end }}

--- a/web/template/create-lpa-wrapper.gohtml
+++ b/web/template/create-lpa-wrapper.gohtml
@@ -1,0 +1,35 @@
+{{ template "page" . }}
+
+{{ define "title" }}{{ if .Error.Any }}Error: {{ end }}{{ .Title }}{{ end }}
+
+{{ define "main" }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ template "error-summary" .Error }}
+
+      {{ if .Success }}
+        <meta data-app-select-case="{{ .CaseId }}"/>
+        {{ if .CaseId }}
+            {{ template "success-banner" "You have successfully updated an LPA." }}
+        {{ else }}
+            {{ template "success-banner" "You have successfully created an LPA." }}
+        {{ end }}
+      {{ end }}
+
+      <p class="govuk-body app-lpa__donor-info">{{ .DonorName }}{{ if .CaseId }} – <span class="app-lpa__donor-info--{{ .CaseItem.SubType }}">{{ ToUpper .CaseItem.SubType }}</span> {{ .CaseItem.UID }}{{ end }}</p>
+
+      <h1 class="govuk-heading-l app-!-embedded-hide">{{ .Title }}</h1>
+
+      <form class="form" method="POST">
+        {{ template "create-lpa" . }}
+
+        <div class="govuk-button-group">
+          <button class="govuk-button" data-module="govuk-button" type="submit"
+                  data-disable-after-click="true">Save and exit
+          </button>
+          <a data-app-iframe-cancel class="govuk-link govuk-link--no-visited-state" href="#">Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+{{ end }}

--- a/web/template/layout/create-lpa.gohtml
+++ b/web/template/layout/create-lpa.gohtml
@@ -1,0 +1,171 @@
+{{ define "create-lpa" }}
+  <button class="govuk-visually-hidden" tabindex="-1" aria-hidden="true" data-module="govuk-button" type="submit"></button>
+  <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
+
+  <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-create-lpa">
+    <div class="govuk-accordion__section">
+      <div class="govuk-accordion__section-header">
+        <h2 class="govuk-accordion__section-heading">
+          <span class="govuk-accordion__section-button" id="accordion-create-lpa-heading-1">
+              Section 2–4: Attorney and appointment type
+          </span>
+        </h2>
+      </div>
+      <div id="accordion-create-lpa-content-1" class="govuk-accordion__section-content">
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">
+              LPA details
+            </h2>
+          </div>
+          <div class="govuk-summary-card__content">
+          </div>
+        </div>
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">
+              Attorneys
+            </h2>
+          </div>
+          <div class="govuk-summary-card__content">
+          </div>
+        </div>
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">
+              Appointment type
+            </h2>
+          </div>
+          <div class="govuk-summary-card__content">
+          </div>
+        </div>
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">
+              Replacement attorneys
+            </h2>
+          </div>
+          <div class="govuk-summary-card__content">
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-accordion__section">
+      <div class="govuk-accordion__section-header">
+        <h2 class="govuk-accordion__section-heading">
+          <span class="govuk-accordion__section-button" id="accordion-create-lpa-heading-1">
+              Section 5–8: LPA instructions and notified people
+          </span>
+        </h2>
+      </div>
+      <div id="accordion-create-lpa-content-1" class="govuk-accordion__section-content">
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">
+              When can the LPA be used?
+            </h2>
+          </div>
+          <div class="govuk-summary-card__content">
+          </div>
+        </div>
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">
+              Notified person
+            </h2>
+          </div>
+          <div class="govuk-summary-card__content">
+          </div>
+        </div>
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">
+              Preferences and instructions
+            </h2>
+          </div>
+          <div class="govuk-summary-card__content">
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-accordion__section">
+      <div class="govuk-accordion__section-header">
+        <h2 class="govuk-accordion__section-heading">
+          <span class="govuk-accordion__section-button" id="accordion-create-lpa-heading-1">
+              Section 9–11: Signatures and certified provider details
+          </span>
+        </h2>
+      </div>
+      <div id="accordion-create-lpa-content-1" class="govuk-accordion__section-content">
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">
+              Donor
+            </h2>
+          </div>
+          <div class="govuk-summary-card__content">
+          </div>
+        </div>
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">
+              Certified provider
+            </h2>
+          </div>
+          <div class="govuk-summary-card__content">
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-accordion__section">
+      <div class="govuk-accordion__section-header">
+        <h2 class="govuk-accordion__section-heading">
+          <span class="govuk-accordion__section-button" id="accordion-create-lpa-heading-1">
+              Section 12–15: Application form
+          </span>
+        </h2>
+      </div>
+      <div id="accordion-create-lpa-content-1" class="govuk-accordion__section-content">
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">
+              LPA applicant
+            </h2>
+          </div>
+          <div class="govuk-summary-card__content">
+          </div>
+        </div>
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">
+              Correspondent
+            </h2>
+          </div>
+          <div class="govuk-summary-card__content">
+          </div>
+        </div>
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">
+              Application fee
+            </h2>
+          </div>
+          <div class="govuk-summary-card__content">
+          </div>
+        </div>
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">
+              Any other information
+            </h2>
+          </div>
+          <div class="govuk-summary-card__content">
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{{ end }}


### PR DESCRIPTION
Fixes [VEGA-4019](https://opgtransform.atlassian.net/browse/VEGA-4019)

- Add the scaffolding for the create/edit LPA form
- Add the basic template for the create/edit LPA form (accordion, cards, and top donor/case info) for the current action panel
- Add the basic template for the create/edit LPA form for the new action panel using HTMX
- Add tests for create-lpa.go server file
- Update action panel tests


[VEGA-4019]: https://opgtransform.atlassian.net/browse/VEGA-4019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ