### PR TITLE
VEGA-3989 display activation key event new timeline

### DIFF
--- a/cypress/e2e/get-lpa-history-content.cy.js
+++ b/cypress/e2e/get-lpa-history-content.cy.js
@@ -833,6 +833,23 @@ describe("Show correct event content", () => {
       .should("contain.text", "Test note - This is a test note");
   });
 
+  it("can view activation key used event", () => {
+    mockEventHistory({
+      sourceType: "Note",
+      type: "Activation key used",
+      entity: {
+        type: "Activation key used",
+        description: "Date used: 2:30PM 15 March 2024\nJane Doe",
+      },
+    });
+    cy.visit("/donor/1/history");
+    cy.get(".moj-timeline__item")
+      .eq(0)
+      .should("contain.text", "Activation key used")
+      .should("contain.text", "Date used: 2:30PM 15 March 2024")
+      .should("contain.text", "Jane Doe");
+  });
+
   it("can view certificate provider added event", () => {
     mockEventHistory({
       sourceType: "CertificateProvider",

--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -675,6 +675,10 @@ $app-action-panel-height: calc(100vh - $app-action-panel-top - 1rem);
   }
 }
 
+.preserve-whitespace {
+  white-space: pre-wrap;
+}
+
 .action-panel__form {
   --action-panel-form-padding: 15px;
   padding: var(--action-panel-form-padding);

--- a/web/template/layout/partial-event-note.gohtml
+++ b/web/template/layout/partial-event-note.gohtml
@@ -1,5 +1,8 @@
 {{ define "partial-event-note" }}
     <p class="govuk-body"><strong>{{.Entity.type}}</strong></p>
+    {{ if eq .Entity.type "Activation key used" }}
+        <p class="preserve-whitespace">{{.Entity.description}}</p>
+    {{ else }}
     <p>{{.Entity.name}} - {{.Entity.description}}</p>
         {{ if .Entity.document }}
             <a class="govuk-link"
@@ -8,4 +11,5 @@
                 {{ .Entity.document.friendlyDescription }}
             </a>
         {{ end}}
+    {{ end }}
 {{ end }}


### PR DESCRIPTION
PR to update new timeline to display activation key event (The activation code for now is not included in the content):
<img width="750" height="137" alt="event" src="https://github.com/user-attachments/assets/cbb9ff8d-9155-4c46-b179-2b4678d95d93" />
Fixes VEGA-3989
#patch


## Checklist

- [x] I have updated the end-to-end tests to work with my changes
- [ ] I have added styling for Dark Mode
- [ ] I have checked that my UI changes meet accessibility standards
