### PR TITLE
Only theme-switch if event was explicitly "dark" or "light"

### DIFF
--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -144,7 +144,7 @@ if (window.self !== window.parent) {
     }
     if (event.data === "dark") {
       document.documentElement.classList.add("app-!-html-class--dark");
-    } else {
+    } else if (event.data === "light") {
       document.documentElement.classList.remove("app-!-html-class--dark");
     }
   });


### PR DESCRIPTION
The previous behaviour meant that any messages from the parent that weren't "dark" would cause the frame to switch to light mode

Fixes VEGA-4091 #patch
