### PR TITLE
VEGA-4094 - Fix duplication of create document template dropdown

### DIFF
--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -63,7 +63,7 @@ htmx.on("htmx:afterSwap", (event) => {
   if (swapDetails.successful) {
     GOVUKFrontend.initAll(swapDetails.target);
     MOJFrontend.initAll(swapDetails.target);
-    select(prefix);
+    select(prefix, swapDetails.target);
     todaysDate(swapDetails.target);
     handleCreateDocumentButton();
     insertSelector(swapDetails.target);

--- a/web/assets/select.js
+++ b/web/assets/select.js
@@ -1,16 +1,17 @@
 import accessibleAutocomplete from "accessible-autocomplete";
 
-export default function select(prefix) {
+export default function select(prefix, scope) {
+  scope = scope || document;
   enhanceUserPersonSearchElement(
-    document.querySelector("[data-select-user]"),
+    scope.querySelector("[data-select-user]"),
     fetchUser(prefix),
   );
   enhanceUserPersonSearchElement(
-    document.querySelector("[data-select-person]"),
+    scope.querySelector("[data-select-person]"),
     fetchPerson(prefix),
   );
   enhanceTemplateSearchElement(
-    document.querySelector("[data-select-template]"),
+    scope.querySelector("[data-select-template]"),
   );
 }
 

--- a/web/assets/select.js
+++ b/web/assets/select.js
@@ -10,9 +10,7 @@ export default function select(prefix, scope) {
     scope.querySelector("[data-select-person]"),
     fetchPerson(prefix),
   );
-  enhanceTemplateSearchElement(
-    scope.querySelector("[data-select-template]"),
-  );
+  enhanceTemplateSearchElement(scope.querySelector("[data-select-template]"));
 }
 
 function enhanceTemplateSearchElement(element) {

--- a/web/template/layout/working-days-calculator.gohtml
+++ b/web/template/layout/working-days-calculator.gohtml
@@ -5,7 +5,7 @@
         <form hx-post="{{ prefix "/working-days" }}"
               hx-target=".date-difference"
               hx-swap="outerHTML"
-              hx-trigger="change from:input, keyup changed from:input[type=number]">
+              hx-trigger="change from:(.date-difference input), keyup changed from:(.date-difference input[type=number])">
 
             <input type="hidden" name="xsrfToken" value="{{ .XSRFToken }}"/>
             <input type="hidden" name="previousmode" value="{{ .Mode }}"/>


### PR DESCRIPTION
Fixes [VEGA-4094](https://opgtransform.atlassian.net/browse/VEGA-4094)

The template dropdown in the partial version of the create document form is being duplicated with every htmx request that is completed on the page. Fix this by passing a scope into the module so it is only reinitialised on the swapped in partial.

Also, restrict the css selector in the trigger of the working days calculator htmx request to ensure only changes to the inputs on the calculator itself trigger requests.

[VEGA-4094]: https://opgtransform.atlassian.net/browse/VEGA-4094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ