### PR TITLE
VEGA-4036 - Add isPartial check to page template

### DIFF
--- a/internal/templatefn/fn.go
+++ b/internal/templatefn/fn.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/url"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -368,6 +369,16 @@ func All(siriusPublicURL, prefix, staticHash string) map[string]interface{} {
 		"actionPanelButton": actionPanelButton,
 		"headerBarButton":   headerBarButton,
 		"personInfoRow":     personInfoRow,
+		"hasField": func(v interface{}, name string) bool {
+			rv := reflect.ValueOf(v)
+			if rv.Kind() == reflect.Pointer {
+				rv = rv.Elem()
+			}
+			if rv.Kind() != reflect.Struct {
+				return false
+			}
+			return rv.FieldByName(name).IsValid()
+		},
 	}
 }
 

--- a/internal/templatefn/fn_test.go
+++ b/internal/templatefn/fn_test.go
@@ -882,3 +882,21 @@ func TestPersonInfoRow(t *testing.T) {
 	val := fn("Name", sirius.Person{}, 123, 456, 1, true, true)
 	assert.Equal(t, expected, val)
 }
+
+func TestHasField(t *testing.T) {
+	fns := All("", "", "")
+	fn := fns["hasField"].(func(interface{}, string) bool)
+
+	tests := map[interface{}]bool{
+		"not-struct": false,
+		struct{ ExistingField string }{ExistingField: "123"}:        true,
+		struct{ NonExistingField string }{NonExistingField: "123"}:  false,
+		&struct{ ExistingField string }{ExistingField: "123"}:       true,
+		&struct{ NonExistingField string }{NonExistingField: "123"}: false,
+	}
+
+	for input, expected := range tests {
+		result := fn(input, "ExistingField")
+		assert.Equal(t, expected, result)
+	}
+}

--- a/web/template/layout/page.gohtml
+++ b/web/template/layout/page.gohtml
@@ -1,43 +1,47 @@
 {{ define "page" }}
-  <!DOCTYPE html>
-  <html lang="en" class="govuk-template app-html-class">
-    <head>
-      <meta charset="utf-8">
-      <title>{{ block "title" . }}{{ end }} - Sirius</title>
-      <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-      <meta name="theme-color" content="#1d70b8">
+  {{ if and (hasField . "IsPartial") .IsPartial }}
+    {{ block "partial-content" . }}{{ end }}
+  {{ else }}
+    <!DOCTYPE html>
+    <html lang="en" class="govuk-template app-html-class">
+      <head>
+        <meta charset="utf-8">
+        <title>{{ block "title" . }}{{ end }} - Sirius</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+        <meta name="theme-color" content="#1d70b8">
 
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-      <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ prefix "/assets/images/favicon.ico" }}" type="image/x-icon">
-      <link rel="icon" sizes="any" href="{{ prefix "/assets/images/favicon.svg" }}" type="image/svg+xml">
-      <link rel="mask-icon" href="{{ prefix "/assets/images/govuk-icon-mask.svg" }}" color="blue">
-      <link rel="apple-touch-icon" href="{{ prefix "/assets/images/govuk-icon-180.png" }}">
+        <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ prefix "/assets/images/favicon.ico" }}" type="image/x-icon">
+        <link rel="icon" sizes="any" href="{{ prefix "/assets/images/favicon.svg" }}" type="image/svg+xml">
+        <link rel="mask-icon" href="{{ prefix "/assets/images/govuk-icon-mask.svg" }}" color="blue">
+        <link rel="apple-touch-icon" href="{{ prefix "/assets/images/govuk-icon-180.png" }}">
 
-      <link href="{{ prefixAsset "/stylesheets/all.css" }}" rel="stylesheet">
-    </head>
+        <link href="{{ prefixAsset "/stylesheets/all.css" }}" rel="stylesheet">
+      </head>
 
-    <body class="govuk-template__body app-body-class" data-prefix="{{ prefix "" }}">
-      <script src="{{ prefixAsset "/javascript/load-classes.js" }}"></script>
-      <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+      <body class="govuk-template__body app-body-class" data-prefix="{{ prefix "" }}">
+        <script src="{{ prefixAsset "/javascript/load-classes.js" }}"></script>
+        <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
-      {{ template "header" . }}
+        {{ template "header" . }}
 
-      {{ block "sirius-header" . }}{{ end }}
+        {{ block "sirius-header" . }}{{ end }}
 
-      <div class="govuk-width-container{{ block "container-classes" . }}{{ end }}">
-        {{ block "backlink" . }}{{ end }}
+        <div class="govuk-width-container{{ block "container-classes" . }}{{ end }}">
+          {{ block "backlink" . }}{{ end }}
 
-        <main class="govuk-main-wrapper" id="main-content" role="main">
-          {{ block "main" . }}{{ end }}
-        </main>
+          <main class="govuk-main-wrapper" id="main-content" role="main">
+            {{ block "main" . }}{{ end }}
+          </main>
 
-        {{ block "action-panel-wrapper" . }}{{ end }}
-      </div>
+          {{ block "action-panel-wrapper" . }}{{ end }}
+        </div>
 
-      <footer class="govuk-footer app-!-embedded-hide" role="contentinfo"></footer>
+        <footer class="govuk-footer app-!-embedded-hide" role="contentinfo"></footer>
 
-      <script src="{{ prefixAsset "/javascript/main.js" }}" type="module"></script>
-    </body>
-  </html>
+        <script src="{{ prefixAsset "/javascript/main.js" }}" type="module"></script>
+      </body>
+    </html>
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
Fixes [VEGA-4036](https://opgtransform.atlassian.net/browse/VEGA-4036)

First part of the htmx refactor. Adds an `IsPartial` check to the page template to render an empty partial-content block if the template is a partial. Future tickets will override the empty partial-content block in templates to display partial content.


[VEGA-4036]: https://opgtransform.atlassian.net/browse/VEGA-4036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ