### PR TITLE
VEGA-4074 -  Update LPA form sections on case subtype selection

### DIFF
--- a/web/assets/lpa-form-subtype.js
+++ b/web/assets/lpa-form-subtype.js
@@ -27,8 +27,6 @@ export default function lpaFormSubtype(scope) {
 
     hwSection.hidden = value !== "hw";
     pfaSection.hidden = value !== "pfa";
-
-    console.log(pfaSection.hidden);
   }
 
   handleFormSubtype();

--- a/web/assets/lpa-form-subtype.js
+++ b/web/assets/lpa-form-subtype.js
@@ -1,0 +1,33 @@
+export default function lpaFormSubtype(scope) {
+  scope = scope || document;
+
+  const radios = scope.querySelectorAll(
+    '[data-module="app-lpa-form-subtype-input"]',
+  );
+  const hwSection = scope.querySelector(
+    '[data-module="app-lpa-form-subtype-hw"]',
+  );
+  const pfaSection = scope.querySelector(
+    '[data-module="app-lpa-form-subtype-pfa"]',
+  );
+
+  if (!radios.length || !hwSection || !pfaSection) return;
+
+  hwSection.hidden = true;
+  pfaSection.hidden = true;
+
+  radios.forEach((radio) =>
+    radio.addEventListener("change", handleFormSubtype),
+  );
+
+  function handleFormSubtype() {
+    const checkedRadios = Array.from(radios).filter((radio) => radio.checked);
+    if (checkedRadios.length === 0) return;
+    const value = checkedRadios[0].value;
+
+    hwSection.hidden = value !== "hw";
+    pfaSection.hidden = value !== "pfa";
+  }
+
+  handleFormSubtype();
+}

--- a/web/assets/lpa-form-subtype.js
+++ b/web/assets/lpa-form-subtype.js
@@ -27,6 +27,8 @@ export default function lpaFormSubtype(scope) {
 
     hwSection.hidden = value !== "hw";
     pfaSection.hidden = value !== "pfa";
+
+    console.log(pfaSection.hidden);
   }
 
   handleFormSubtype();

--- a/web/assets/lpa-form-subtype.test.js
+++ b/web/assets/lpa-form-subtype.test.js
@@ -39,21 +39,47 @@ describe("LPA form subtype", () => {
   });
 
   test("should hide both sections when no radios are checked", async () => {
-    expect(hwSection.hidden).toBe(true);
-    expect(pfaSection.hidden).toBe(true);
+    expect(hwSection.hidden).true;
+    expect(pfaSection.hidden).true;
+  });
+
+  test("should show the pfa section if the pfa radio is already checked", async () => {
+    document.body.innerHTML = `
+      <input type="radio" data-module="app-lpa-form-subtype-input" name="caseSubtype" value="hw" />
+      <input type="radio" data-module="app-lpa-form-subtype-input" name="caseSubtype" value="pfa" checked="checked" />
+      <div data-module="app-lpa-form-subtype-hw"></div>
+      <div data-module="app-lpa-form-subtype-pfa"></div>
+    `;
+    lpaFormSubtype();
+
+    expect(hwSection.hidden).true;
+    expect(pfaSection.hidden).false;
+  });
+
+  test("should show the hw section if the hw radio is already checked", async () => {
+    document.body.innerHTML = `
+      <input type="radio" data-module="app-lpa-form-subtype-input" name="caseSubtype" value="hw" checked />
+      <input type="radio" data-module="app-lpa-form-subtype-input" name="caseSubtype" value="pfa" />
+      <div data-module="app-lpa-form-subtype-hw"></div>
+      <div data-module="app-lpa-form-subtype-pfa"></div>
+    `;
+    lpaFormSubtype();
+
+    expect(hwSection.hidden).false;
+    expect(pfaSection.hidden).true;
   });
 
   test("should show the pfa section when the pfa radio is checked", async () => {
     pfaRadio.checked = true;
     pfaRadio.dispatchEvent(new Event("change"));
-    expect(hwSection.hidden).toBe(true);
-    expect(pfaSection.hidden).toBe(false);
+    expect(hwSection.hidden).true;
+    expect(pfaSection.hidden).false;
   });
 
   test("should show the hw section when the hw radio is checked", async () => {
     hwRadio.checked = true;
     hwRadio.dispatchEvent(new Event("change"));
-    expect(hwSection.hidden).toBe(false);
-    expect(pfaSection.hidden).toBe(true);
+    expect(hwSection.hidden).false;
+    expect(pfaSection.hidden).true;
   });
 });

--- a/web/assets/lpa-form-subtype.test.js
+++ b/web/assets/lpa-form-subtype.test.js
@@ -1,0 +1,59 @@
+import lpaFormSubtype from "./lpa-form-subtype.js";
+
+describe("LPA form subtype", () => {
+  let hwRadio;
+  let pfaRadio;
+  let hwSection;
+  let pfaSection;
+
+  beforeEach(async () => {
+    document.body.innerHTML = `
+    <input type="radio" data-module="app-lpa-form-subtype-input" name="caseSubtype" value="hw" />
+    <input type="radio" data-module="app-lpa-form-subtype-input" name="caseSubtype" value="pfa" />
+    <div data-module="app-lpa-form-subtype-hw"></div>
+    <div data-module="app-lpa-form-subtype-pfa"></div>
+  `;
+
+    hwRadio = document.querySelector(
+      'input[data-module="app-lpa-form-subtype-input"][value="hw"]',
+    );
+    pfaRadio = document.querySelector(
+      'input[data-module="app-lpa-form-subtype-input"][value="pfa"]',
+    );
+    hwSection = document.querySelector(
+      '[data-module="app-lpa-form-subtype-hw"]',
+    );
+    pfaSection = document.querySelector(
+      '[data-module="app-lpa-form-subtype-pfa"]',
+    );
+
+    lpaFormSubtype();
+  });
+
+  afterEach(() => {
+    hwRadio = null;
+    pfaRadio = null;
+    hwSection = null;
+    pfaSection = null;
+    document.body.innerHTML = "";
+  });
+
+  test("should hide both sections when no radios are checked", async () => {
+    expect(hwSection.hidden).toBe(true);
+    expect(pfaSection.hidden).toBe(true);
+  });
+
+  test("should show the pfa section when the pfa radio is checked", async () => {
+    pfaRadio.checked = true;
+    pfaRadio.dispatchEvent(new Event("change"));
+    expect(hwSection.hidden).toBe(true);
+    expect(pfaSection.hidden).toBe(false);
+  });
+
+  test("should show the hw section when the hw radio is checked", async () => {
+    hwRadio.checked = true;
+    hwRadio.dispatchEvent(new Event("change"));
+    expect(hwSection.hidden).toBe(false);
+    expect(pfaSection.hidden).toBe(true);
+  });
+});

--- a/web/assets/lpa-form-subtype.test.js
+++ b/web/assets/lpa-form-subtype.test.js
@@ -39,8 +39,8 @@ describe("LPA form subtype", () => {
   });
 
   test("should hide both sections when no radios are checked", async () => {
-    expect(hwSection.hidden).true;
-    expect(pfaSection.hidden).true;
+    expect(hwSection.hidden).toBe(true);
+    expect(pfaSection.hidden).toBe(true);
   });
 
   test("should show the pfa section if the pfa radio is already checked", async () => {
@@ -50,10 +50,18 @@ describe("LPA form subtype", () => {
       <div data-module="app-lpa-form-subtype-hw"></div>
       <div data-module="app-lpa-form-subtype-pfa"></div>
     `;
+
+    hwSection = document.querySelector(
+      '[data-module="app-lpa-form-subtype-hw"]',
+    );
+    pfaSection = document.querySelector(
+      '[data-module="app-lpa-form-subtype-pfa"]',
+    );
+
     lpaFormSubtype();
 
-    expect(hwSection.hidden).true;
-    expect(pfaSection.hidden).false;
+    expect(hwSection.hidden).toBe(true);
+    expect(pfaSection.hidden).toBe(false);
   });
 
   test("should show the hw section if the hw radio is already checked", async () => {
@@ -63,23 +71,31 @@ describe("LPA form subtype", () => {
       <div data-module="app-lpa-form-subtype-hw"></div>
       <div data-module="app-lpa-form-subtype-pfa"></div>
     `;
+
+    hwSection = document.querySelector(
+      '[data-module="app-lpa-form-subtype-hw"]',
+    );
+    pfaSection = document.querySelector(
+      '[data-module="app-lpa-form-subtype-pfa"]',
+    );
+
     lpaFormSubtype();
 
-    expect(hwSection.hidden).false;
-    expect(pfaSection.hidden).true;
+    expect(hwSection.hidden).toBe(false);
+    expect(pfaSection.hidden).toBe(true);
   });
 
   test("should show the pfa section when the pfa radio is checked", async () => {
     pfaRadio.checked = true;
     pfaRadio.dispatchEvent(new Event("change"));
-    expect(hwSection.hidden).true;
-    expect(pfaSection.hidden).false;
+    expect(hwSection.hidden).toBe(true);
+    expect(pfaSection.hidden).toBe(false);
   });
 
   test("should show the hw section when the hw radio is checked", async () => {
     hwRadio.checked = true;
     hwRadio.dispatchEvent(new Event("change"));
-    expect(hwSection.hidden).false;
-    expect(pfaSection.hidden).true;
+    expect(hwSection.hidden).toBe(false);
+    expect(pfaSection.hidden).toBe(true);
   });
 });

--- a/web/assets/main.js
+++ b/web/assets/main.js
@@ -23,6 +23,7 @@ import htmx from "htmx.org/dist/htmx.esm";
 import documentListSort from "./document-list-sort";
 import initPdfViewer from "./pdf-viewer";
 import initSiriusHeader from "./sirius-header.js";
+import lpaFormSubtype from "./lpa-form-subtype.js";
 
 const prefix = document.body.getAttribute("data-prefix");
 
@@ -48,6 +49,7 @@ disableAfterClick();
 documentListSort();
 initPdfViewer();
 initSiriusHeader();
+lpaFormSubtype();
 
 globalThis.htmx = htmx;
 // Don't include indicator styles as CSP blocks inline styles
@@ -71,6 +73,7 @@ htmx.on("htmx:afterSettle", (event) => {
     autoClick(swapDetails.target);
     textEditor();
     addressFinder(prefix, swapDetails.target);
+    lpaFormSubtype(swapDetails.target);
 
     // Update the action panel width if swapping in create-document or edit-document content
     if (swapDetails.target.id === "actions-content") {

--- a/web/template/layout/create-lpa.gohtml
+++ b/web/template/layout/create-lpa.gohtml
@@ -26,12 +26,12 @@
                 <div class="govuk-radios app-!-radios--inline {{ if .Error.Field.caseSubtype }}govuk-radios--error{{ end }}" data-module="govuk-radios">
                   <div class="govuk-radios__item">
                     <input class="govuk-radios__input" id="f-caseSubtype" name="caseSubtype" type="radio"
-                           value="pfa" {{ if eq .Lpa.SubType "pfa" }}checked{{ end }}>
+                           value="pfa" {{ if eq .Lpa.SubType "pfa" }}checked{{ end }} data-module="app-lpa-form-subtype-input">
                     <label class="govuk-label govuk-radios__label" for="f-caseSubtype">PFA</label>
                   </div>
                   <div class="govuk-radios__item">
                     <input class="govuk-radios__input" id="f-caseSubtype-2" name="caseSubtype" type="radio"
-                           value="hw" {{ if eq .Lpa.SubType "hw" }}checked{{ end }}>
+                           value="hw" {{ if eq .Lpa.SubType "hw" }}checked{{ end }} data-module="app-lpa-form-subtype-input">
                     <label class="govuk-label govuk-radios__label" for="f-caseSubtype-2">HW</label>
                   </div>
                 </div>
@@ -199,13 +199,13 @@
       </div>
       <div id="accordion-create-lpa-content-1" class="govuk-accordion__section-content">
         <div class="govuk-summary-card">
-          <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">
-              {{ if eq .Lpa.SubType "hw" }}Life sustaining treatment (LST){{ else }}When can the LPA be used?{{ end }}
-            </h2>
-          </div>
-          <div class="govuk-summary-card__content">
-            {{ if eq .Lpa.SubType "hw" }}
+          <div data-module="app-lpa-form-subtype-hw">
+            <div class="govuk-summary-card__title-wrapper">
+              <h2 class="govuk-summary-card__title">
+                Life sustaining treatment (LST)
+              </h2>
+            </div>
+            <div class="govuk-summary-card__content">
               <div class="govuk-form-group {{ if .Error.Field.lifeSustainingTreatment }}govuk-form-group--error{{ end }}">
                 <fieldset class="govuk-fieldset">
                   <legend class="govuk-fieldset__legend govuk-visually-hidden">Life sustaining treatment</legend>
@@ -248,7 +248,15 @@
                   </div>
                 </fieldset>
               </div>
-            {{ else }}
+            </div>
+          </div>
+          <div data-module="app-lpa-form-subtype-pfa">
+            <div class="govuk-summary-card__title-wrapper">
+              <h2 class="govuk-summary-card__title">
+                When can the LPA be used?
+              </h2>
+            </div>
+            <div class="govuk-summary-card__content">
               <div class="govuk-form-group {{ if .Error.Field.attorneyActDecisions }}govuk-form-group--error{{ end }}">
                 <fieldset class="govuk-fieldset">
                   <legend class="govuk-fieldset__legend govuk-visually-hidden">When can the LPA be used?</legend>
@@ -267,7 +275,7 @@
                   </div>
                 </fieldset>
               </div>
-            {{ end }}
+            </div>
           </div>
         </div>
         <div class="govuk-summary-card">


### PR DESCRIPTION
Fixes [VEGA-4074](https://opgtransform.atlassian.net/browse/VEGA-4074)

- Add Javascript module to toggle the LPA form sections depending on the users choice of case subtype (HW/PFA)
- Add unit test


[VEGA-4074]: https://opgtransform.atlassian.net/browse/VEGA-4074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ